### PR TITLE
Fix torchvision MNIST download

### DIFF
--- a/openfl-workspace/torch_cnn_mnist/code/mnist_utils.py
+++ b/openfl-workspace/torch_cnn_mnist/code/mnist_utils.py
@@ -9,13 +9,13 @@ from logging import getLogger
 from torchvision.datasets import MNIST
 from torchvision.transforms import ToTensor
 
-logger = getLogger(__name__)
-
 # Remove this after upgrade to torchvision==0.9. See https://github.com/pytorch/vision/issues/3497
 from six.moves import urllib
 opener = urllib.request.build_opener()
 opener.addheaders = [('User-agent', 'Mozilla/5.0')]
 urllib.request.install_opener(opener)
+
+logger = getLogger(__name__)
 
 
 def one_hot(labels, classes):

--- a/openfl-workspace/torch_cnn_mnist/code/mnist_utils.py
+++ b/openfl-workspace/torch_cnn_mnist/code/mnist_utils.py
@@ -11,6 +11,12 @@ from torchvision.transforms import ToTensor
 
 logger = getLogger(__name__)
 
+# Remove this after upgrade to torchvision==0.9. See https://github.com/pytorch/vision/issues/3497
+from six.moves import urllib
+opener = urllib.request.build_opener()
+opener.addheaders = [('User-agent', 'Mozilla/5.0')]
+urllib.request.install_opener(opener)
+
 
 def one_hot(labels, classes):
     """

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,8 @@ setup(
         'ipykernel',
         'flatten_json',
         'cryptography==3.4.6',
-        'six' # # Remove this after upgrade to torchvision==0.9. See https://github.com/pytorch/vision/issues/3497
+        'six'  # Remove this after upgrade to torchvision==0.9
+        # See https://github.com/pytorch/vision/issues/3497
     ],
     python_requires='>=3.6, <3.9',
     project_urls={

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         'ipykernel',
         'flatten_json',
         'cryptography==3.4.6',
+        'six' # # Remove this after upgrade to torchvision==0.9. See https://github.com/pytorch/vision/issues/3497
     ],
     python_requires='>=3.6, <3.9',
     project_urls={

--- a/tests/github/python_native.py
+++ b/tests/github/python_native.py
@@ -8,6 +8,12 @@ import json
 
 import openfl.native as fx
 
+# Remove this after upgrade to torchvision==0.9. See https://github.com/pytorch/vision/issues/3497
+from six.moves import urllib
+opener = urllib.request.build_opener()
+opener.addheaders = [('User-agent', 'Mozilla/5.0')]
+urllib.request.install_opener(opener)
+
 
 def one_hot(labels, classes):
     """One-hot encode `labels` using `classes` classes."""


### PR DESCRIPTION
This PR contains:
- Adding the User-Agent header for `torchvision` MNIST dataset requests.

See pytorch/vision#3497 for more details.