### PR TITLE
Fixed wrong filepath to the signed collaborator certificate in docs

### DIFF
--- a/docs/running_the_federation.certificates.rst
+++ b/docs/running_the_federation.certificates.rst
@@ -159,5 +159,5 @@ Before you run the federation make sure you have activated a Python virtual envi
 
     .. code-block:: console
         
-       $ fx collaborator certify --import /PATH/TO/col_COL.LABEL_to_agg_cert_request.zip
+       $ fx collaborator certify --import /PATH/TO/agg_to_col_COL.LABEL_signed_cert.zip
 


### PR DESCRIPTION
### Fixed wrong filepath to the signed collaborator certificate in docs:


![image](https://user-images.githubusercontent.com/32339262/111044449-e2629780-8459-11eb-8716-862e4a77737e.png)

