### PR TITLE
Use kroki to create svg

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,7 @@ extensions = [
     "sphinx-prompt",
     'sphinx_substitution_extensions',
     "sphinx.ext.ifconfig",
-    "sphinxcontrib.mermaid"
+    "sphinxcontrib.kroki"
 ]
 
 # -- Project information -----------------------------------------------------

--- a/docs/mermaid/CSR_signing.mmd
+++ b/docs/mermaid/CSR_signing.mmd
@@ -1,4 +1,3 @@
-```mermaid
 sequenceDiagram
 Title: Collaborator Certificate Signing Flow 
   participant A as Alice
@@ -16,5 +15,3 @@ Title: Collaborator Certificate Signing Flow
   B->>BG: Bob runs script to sign .csr,<br/> confirming the hash as input,<br/> creating the .crt file
   B->>A: Bob sends the .crt file back to Alice
   A->>AC: Alice copies the signed certificate (.crt)<br/>to her collaborator node.<br/>She now has a signed certificate.
-  
-```

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -3,4 +3,4 @@
 sphinx-rtd-theme
 sphinx-prompt 
 sphinx_substitution_extensions 
-sphinxcontrib-mermaid
+sphinxcontrib-kroki

--- a/docs/running_the_federation.certificates.rst
+++ b/docs/running_the_federation.certificates.rst
@@ -19,10 +19,12 @@ so these configuration steps just need to be done once on that machine.
 
 .. _install_certs:
 
-.. mermaid:: mermaid/CSR_signing.md
-    :alt: Certificate generationa and signing.
-    :align: center
+.. kroki:: mermaid/CSR_signing.mmd
     :caption: Certificate generation and signing
+    :align: center
+    :type: mermaid
+
+
     
 .. _install_certs_agg:
 
@@ -79,9 +81,9 @@ Before you run the federation make sure you have activated a Python virtual envi
     +===========================+==================================================+
     | Certificate chain         | WORKSPACE.PATH/cert/cert_chain.crt               |
     +---------------------------+--------------------------------------------------+
-    | Aggregator certificate    | WORKSPACE.PATH/cert/server/agg_AFQDN.crt    |
+    | Aggregator certificate    | WORKSPACE.PATH/cert/server/agg_AFQDN.crt         |
     +---------------------------+--------------------------------------------------+
-    | Aggregator key            | WORKSPACE.PATH/cert/server/agg_AFQDN.key    |
+    | Aggregator key            | WORKSPACE.PATH/cert/server/agg_AFQDN.key         |
     +---------------------------+--------------------------------------------------+
     
     where **AFQDN** is the fully-qualified domain name of the aggregator node.


### PR DESCRIPTION
Using only mermaid will cause large white boxes around the diagram. Using Korki to pre-create a mermaid image helps to avoid this.