### PR TITLE
Enable compression options

### DIFF
--- a/docs/advanced_topics.rst
+++ b/docs/advanced_topics.rst
@@ -11,5 +11,6 @@ Advanced Topics
    :maxdepth: 4
 
    multiple_plans
+   compression_settings
 
 

--- a/docs/compression_settings.rst
+++ b/docs/compression_settings.rst
@@ -1,0 +1,27 @@
+.. # Copyright (C) 2021 Intel Corporation
+.. # Licensed subject to the terms of the separately executed evaluation license agreement between Intel Corporation and you.
+
+.. _compression_settings:
+
+***************
+Compression Settings
+***************
+
+Federated Learning can enable tens to thousands of participants to work together on the same model, but with this scaling comes increased communication cost. Furthermore, large models exacerbate this problem. For this reason we make compression is a core capability of |productName|, and our framework supports several lossless and lossy compression pipelines out of the box. In general, the weights of a model are typically not robust to information loss, so no compression is applied by default to the model weights sent bidirectionally; however, the deltas between the model weights for each round are inherently more sparse and better suited for lossy compression. The following is the list of compression pipelines that |productName| currently supports:
+
+* ``NoCompressionPipeline``: This is the default option applied to model weights
+* ``RandomShiftPipeline``: A **lossless** pipeline that randomly shifts the weights during transport
+* ``STCPipeline``: A **lossy** pipeline consisting of three transformations: *Sparsity Transform* (p_sparsity=0.1), which by default retains only the (p*100)% absolute values of greatest magnitude. *Ternary Transform*, which discretizes the sparse array into three buckets, and finally a *GZIP Transform*. 
+* ``SKCPipeline``: A **lossy** pipeline consisting of three transformations: *Sparsity Transform* (p=0.1), which by default retains only the(p*100)% absolute values of greatest magnitude. *KMeans Transform* (k=6), which applies the KMeans algorithm to the sparse array with *k* centroids, and finally a *GZIP Transform*. 
+* ``KCPipeline``: A **lossy** pipeline consisting of two transformations: *KMeans Transform* (k=6), which applies the KMeans algorithm to the original weight array with *k* centroids, and finally a *GZIP Transform*. 
+
+We provide an example template, **keras_cnn_with_compression**, that utilizes the *KCPipeline* with 6 centroids for KMeans. To gain a better understanding of how experiments perform with greater or fewer centroids, you can modify the *n_clusters* parameter in the template's plan.yaml:
+
+    .. code-block:: console
+    
+       compression_pipeline :
+         defaults : plan/defaults/compression_pipeline.yaml
+         template : openfl.pipelines.KCPipeline
+         settings :
+           n_clusters : 6
+

--- a/openfl-workspace/default/plan/plan.yaml
+++ b/openfl-workspace/default/plan/plan.yaml
@@ -31,3 +31,6 @@ assigner :
 
 tasks :
   defaults : plan/defaults/tasks_fast_estimator.yaml
+
+compression_pipeline :
+  defaults : plan/defaults/compression_pipeline.yaml

--- a/openfl-workspace/fe_torch_adversarial_cifar/plan/plan.yaml
+++ b/openfl-workspace/fe_torch_adversarial_cifar/plan/plan.yaml
@@ -37,3 +37,6 @@ assigner :
 
 tasks :
   defaults : plan/defaults/tasks_fast_estimator.yaml
+
+compression_pipeline :
+  defaults : plan/defaults/compression_pipeline.yaml

--- a/openfl-workspace/keras_cnn_mnist/plan/plan.yaml
+++ b/openfl-workspace/keras_cnn_mnist/plan/plan.yaml
@@ -37,3 +37,6 @@ assigner :
 
 tasks :
   defaults : plan/defaults/tasks_keras.yaml
+
+compression_pipeline :
+  defaults : plan/defaults/compression_pipeline.yaml

--- a/openfl-workspace/keras_cnn_with_compression/.workspace
+++ b/openfl-workspace/keras_cnn_with_compression/.workspace
@@ -1,0 +1,2 @@
+current_plan_name: default
+

--- a/openfl-workspace/keras_cnn_with_compression/code/__init__.py
+++ b/openfl-workspace/keras_cnn_with_compression/code/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""You may copy this file as the starting point of your own model."""

--- a/openfl-workspace/keras_cnn_with_compression/code/keras_cnn.py
+++ b/openfl-workspace/keras_cnn_with_compression/code/keras_cnn.py
@@ -1,0 +1,85 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""You may copy this file as the starting point of your own model."""
+
+import tensorflow.keras as ke
+
+from tensorflow.keras import Sequential
+from tensorflow.keras.layers import Conv2D, Flatten, Dense
+
+from openfl.federated import KerasTaskRunner
+
+
+class KerasCNN(KerasTaskRunner):
+    """A basic convolutional neural network model."""
+
+    def __init__(self, **kwargs):
+        """
+        Initialize.
+
+        Args:
+            **kwargs: Additional parameters to pass to the function
+        """
+        super().__init__(**kwargs)
+
+        self.model = self.build_model(self.feature_shape, self.data_loader.num_classes, **kwargs)
+
+        self.initialize_tensorkeys_for_functions()
+
+        self.model.summary(print_fn=self.logger.info)
+
+        if self.data_loader is not None:
+            self.logger.info(f'Train Set Size : {self.get_train_data_size()}')
+            self.logger.info(f'Valid Set Size : {self.get_valid_data_size()}')
+
+    def build_model(self,
+                    input_shape,
+                    num_classes,
+                    conv_kernel_size=(4, 4),
+                    conv_strides=(2, 2),
+                    conv1_channels_out=16,
+                    conv2_channels_out=32,
+                    final_dense_inputsize=100,
+                    **kwargs):
+        """
+        Define the model architecture.
+
+        Args:
+            input_shape (numpy.ndarray): The shape of the data
+            num_classes (int): The number of classes of the dataset
+
+        Returns:
+            tensorflow.python.keras.engine.sequential.Sequential: The model defined in Keras
+
+        """
+        model = Sequential()
+
+        model.add(Conv2D(conv1_channels_out,
+                         kernel_size=conv_kernel_size,
+                         strides=conv_strides,
+                         activation='relu',
+                         input_shape=input_shape))
+
+        model.add(Conv2D(conv2_channels_out,
+                         kernel_size=conv_kernel_size,
+                         strides=conv_strides,
+                         activation='relu'))
+
+        model.add(Flatten())
+
+        model.add(Dense(final_dense_inputsize, activation='relu'))
+
+        model.add(Dense(num_classes, activation='softmax'))
+
+        model.compile(loss=ke.losses.categorical_crossentropy,
+                      optimizer=ke.optimizers.Adam(),
+                      metrics=['accuracy'])
+
+        # initialize the optimizer variables
+        opt_vars = model.optimizer.variables()
+
+        for v in opt_vars:
+            v.initializer.run(session=self.sess)
+
+        return model

--- a/openfl-workspace/keras_cnn_with_compression/code/mnist_utils.py
+++ b/openfl-workspace/keras_cnn_with_compression/code/mnist_utils.py
@@ -1,0 +1,118 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""You may copy this file as the starting point of your own model."""
+
+import numpy as np
+
+from logging import getLogger
+from tensorflow.python.keras.utils.data_utils import get_file
+
+logger = getLogger(__name__)
+
+
+def one_hot(labels, classes):
+    """
+    One Hot encode a vector.
+
+    Args:
+        labels (list):  List of labels to onehot encode
+        classes (int): Total number of categorical classes
+
+    Returns:
+        np.array: Matrix of one-hot encoded labels
+    """
+    return np.eye(classes)[labels]
+
+
+def _load_raw_datashards(shard_num, collaborator_count):
+    """
+    Load the raw data by shard.
+
+    Returns tuples of the dataset shard divided into training and validation.
+
+    Args:
+        shard_num (int): The shard number to use
+        collaborator_count (int): The number of collaborators in the federation
+
+    Returns:
+        2 tuples: (image, label) of the training, validation dataset
+    """
+    origin_folder = 'https://storage.googleapis.com/tensorflow/tf-keras-datasets/'
+    path = get_file('mnist.npz',
+                    origin=origin_folder + 'mnist.npz',
+                    file_hash='731c5ac602752760c8e48fbffcf8c3b850d9dc2a2aedcf2cc48468fc17b673d1')
+
+    with np.load(path) as f:
+        # get all of mnist
+        X_train_tot = f['x_train']
+        y_train_tot = f['y_train']
+
+        X_valid_tot = f['x_test']
+        y_valid_tot = f['y_test']
+
+    # create the shards
+    shard_num = int(shard_num)
+    X_train = X_train_tot[shard_num::collaborator_count]
+    y_train = y_train_tot[shard_num::collaborator_count]
+
+    X_valid = X_valid_tot[shard_num::collaborator_count]
+    y_valid = y_valid_tot[shard_num::collaborator_count]
+
+    return (X_train, y_train), (X_valid, y_valid)
+
+
+def load_mnist_shard(shard_num, collaborator_count, categorical=True,
+                     channels_last=True, **kwargs):
+    """
+    Load the MNIST dataset.
+
+    Args:
+        shard_num (int): The shard to use from the dataset
+        collaborator_count (int): The number of collaborators in the federation
+        categorical (bool): True = convert the labels to one-hot encoded
+         vectors (Default = True)
+        channels_last (bool): True = The input images have the channels
+         last (Default = True)
+        **kwargs: Additional parameters to pass to the function
+
+    Returns:
+        list: The input shape
+        int: The number of classes
+        numpy.ndarray: The training data
+        numpy.ndarray: The training labels
+        numpy.ndarray: The validation data
+        numpy.ndarray: The validation labels
+    """
+    img_rows, img_cols = 28, 28
+    num_classes = 10
+
+    (X_train, y_train), (X_valid, y_valid) = _load_raw_datashards(
+        shard_num, collaborator_count
+    )
+
+    if channels_last:
+        X_train = X_train.reshape(X_train.shape[0], img_rows, img_cols, 1)
+        X_valid = X_valid.reshape(X_valid.shape[0], img_rows, img_cols, 1)
+        input_shape = (img_rows, img_cols, 1)
+    else:
+        X_train = X_train.reshape(X_train.shape[0], 1, img_rows, img_cols)
+        X_valid = X_valid.reshape(X_valid.shape[0], 1, img_rows, img_cols)
+        input_shape = (1, img_rows, img_cols)
+
+    X_train = X_train.astype('float32')
+    X_valid = X_valid.astype('float32')
+    X_train /= 255
+    X_valid /= 255
+
+    logger.info(f'MNIST > X_train Shape : {X_train.shape}')
+    logger.info(f'MNIST > y_train Shape : {y_train.shape}')
+    logger.info(f'MNIST > Train Samples : {X_train.shape[0]}')
+    logger.info(f'MNIST > Valid Samples : {X_valid.shape[0]}')
+
+    if categorical:
+        # convert class vectors to binary class matrices
+        y_train = one_hot(y_train, num_classes)
+        y_valid = one_hot(y_valid, num_classes)
+
+    return input_shape, num_classes, X_train, y_train, X_valid, y_valid

--- a/openfl-workspace/keras_cnn_with_compression/code/tfmnist_inmemory.py
+++ b/openfl-workspace/keras_cnn_with_compression/code/tfmnist_inmemory.py
@@ -1,0 +1,40 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""You may copy this file as the starting point of your own model."""
+
+from openfl.federated import TensorFlowDataLoader
+
+from .mnist_utils import load_mnist_shard
+
+
+class TensorFlowMNISTInMemory(TensorFlowDataLoader):
+    """TensorFlow Data Loader for MNIST Dataset."""
+
+    def __init__(self, data_path, batch_size, **kwargs):
+        """
+        Initialize.
+
+        Args:
+            data_path: File path for the dataset
+            batch_size (int): The batch size for the data loader
+            **kwargs: Additional arguments, passed to super init and load_mnist_shard
+        """
+        super().__init__(batch_size, **kwargs)
+
+        # TODO: We should be downloading the dataset shard into a directory
+        # TODO: There needs to be a method to ask how many collaborators and
+        #  what index/rank is this collaborator.
+        # Then we have a way to automatically shard based on rank and size of
+        # collaborator list.
+
+        _, num_classes, X_train, y_train, X_valid, y_valid = load_mnist_shard(
+            shard_num=int(data_path), **kwargs
+        )
+
+        self.X_train = X_train
+        self.y_train = y_train
+        self.X_valid = X_valid
+        self.y_valid = y_valid
+
+        self.num_classes = num_classes

--- a/openfl-workspace/keras_cnn_with_compression/plan/cols.yaml
+++ b/openfl-workspace/keras_cnn_with_compression/plan/cols.yaml
@@ -1,0 +1,5 @@
+# Copyright (C) 2020 Intel Corporation
+# Licensed subject to the terms of the separately executed evaluation license agreement between Intel Corporation and you.
+
+collaborators:
+  

--- a/openfl-workspace/keras_cnn_with_compression/plan/data.yaml
+++ b/openfl-workspace/keras_cnn_with_compression/plan/data.yaml
@@ -1,0 +1,7 @@
+# Copyright (C) 2020 Intel Corporation
+# Licensed subject to the terms of the separately executed evaluation license agreement between Intel Corporation and you.
+
+# collaborator_name,data_directory_path
+one,1
+
+  

--- a/openfl-workspace/keras_cnn_with_compression/plan/defaults
+++ b/openfl-workspace/keras_cnn_with_compression/plan/defaults
@@ -1,0 +1,2 @@
+../../workspace/plan/defaults
+

--- a/openfl-workspace/keras_cnn_with_compression/plan/plan.yaml
+++ b/openfl-workspace/keras_cnn_with_compression/plan/plan.yaml
@@ -8,12 +8,14 @@ aggregator :
     init_state_path : save/keras_cnn_mnist_init.pbuf
     best_state_path : save/keras_cnn_mnist_best.pbuf
     last_state_path : save/keras_cnn_mnist_last.pbuf
+    db_store_rounds: 2
     rounds_to_train : 10
 
 collaborator :
   defaults : plan/defaults/collaborator.yaml
   template : openfl.component.Collaborator
   settings :
+    db_store_rounds: 2
     delta_updates    : true
     opt_treatment    : RESET
 
@@ -40,7 +42,6 @@ tasks :
 
 compression_pipeline :
   defaults : plan/defaults/compression_pipeline.yaml
-  template : openfl.pipelines.SKCPipeline
+  template : openfl.pipelines.KCPipeline
   settings :
-    p_sparsity : 0.01 
     n_clusters : 6

--- a/openfl-workspace/keras_cnn_with_compression/plan/plan.yaml
+++ b/openfl-workspace/keras_cnn_with_compression/plan/plan.yaml
@@ -5,29 +5,29 @@ aggregator :
   defaults : plan/defaults/aggregator.yaml
   template : openfl.component.Aggregator
   settings :
-    init_state_path : save/keras_lenet_init.pbuf
-    best_state_path : save/keras_lenet_best.pbuf
-    last_state_path : save/keras_lenet_last.pbuf
+    init_state_path : save/keras_cnn_mnist_init.pbuf
+    best_state_path : save/keras_cnn_mnist_best.pbuf
+    last_state_path : save/keras_cnn_mnist_last.pbuf
     rounds_to_train : 10
 
 collaborator :
   defaults : plan/defaults/collaborator.yaml
   template : openfl.component.Collaborator
   settings :
-    delta_updates    : false
+    delta_updates    : true
     opt_treatment    : RESET
 
 data_loader :
   defaults : plan/defaults/data_loader.yaml
-  template : code.fecifar_inmemory.FastEstimatorCifarInMemory
+  template : code.tfmnist_inmemory.TensorFlowMNISTInMemory
   settings :
     collaborator_count : 2
-    data_group_name    : cifar
-    batch_size         : 32
+    data_group_name    : mnist
+    batch_size         : 256
 
 task_runner :
   defaults : plan/defaults/task_runner.yaml
-  template : code.fe_fgsm.FastEstimatorFGSM
+  template : code.keras_cnn.KerasCNN
 
 network :
   defaults : plan/defaults/network.yaml
@@ -36,7 +36,11 @@ assigner :
   defaults : plan/defaults/assigner.yaml
 
 tasks :
-  defaults : plan/defaults/tasks_fast_estimator.yaml
+  defaults : plan/defaults/tasks_keras.yaml
 
 compression_pipeline :
   defaults : plan/defaults/compression_pipeline.yaml
+  template : openfl.pipelines.SKCPipeline
+  settings :
+    p_sparsity : 0.01 
+    n_clusters : 6

--- a/openfl-workspace/keras_cnn_with_compression/requirements.txt
+++ b/openfl-workspace/keras_cnn_with_compression/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.3.1

--- a/openfl-workspace/keras_nlp/plan/plan.yaml
+++ b/openfl-workspace/keras_nlp/plan/plan.yaml
@@ -42,3 +42,6 @@ assigner :
 
 tasks :
   defaults : plan/defaults/tasks_keras.yaml
+
+compression_pipeline :
+  defaults : plan/defaults/compression_pipeline.yaml

--- a/openfl-workspace/tf_2dunet/plan/plan.yaml
+++ b/openfl-workspace/tf_2dunet/plan/plan.yaml
@@ -38,3 +38,6 @@ assigner :
 
 tasks :
   defaults : plan/defaults/tasks_tensorflow.yaml
+
+compression_pipeline :
+  defaults : plan/defaults/compression_pipeline.yaml

--- a/openfl-workspace/tf_cnn_histology/plan/plan.yaml
+++ b/openfl-workspace/tf_cnn_histology/plan/plan.yaml
@@ -8,6 +8,7 @@ aggregator :
     init_state_path  : save/tf_cnn_histology_init.pbuf
     last_state_path  : save/tf_cnn_histology_latest.pbuf
     best_state_path  : save/tf_cnn_histology_best.pbuf
+    db_store_rounds: 2
     rounds_to_train : 10
 
 collaborator :
@@ -15,6 +16,7 @@ collaborator :
   template : openfl.component.Collaborator
   settings :
     delta_updates    : true
+    db_store_rounds: 2
     opt_treatment    : RESET
 
 data_loader :

--- a/openfl-workspace/torch_cnn_histology/plan/plan.yaml
+++ b/openfl-workspace/torch_cnn_histology/plan/plan.yaml
@@ -36,3 +36,6 @@ tasks:
 
 assigner:
   defaults: plan/defaults/assigner.yaml
+
+compression_pipeline :
+  defaults : plan/defaults/compression_pipeline.yaml

--- a/openfl-workspace/torch_cnn_mnist/plan/plan.yaml
+++ b/openfl-workspace/torch_cnn_mnist/plan/plan.yaml
@@ -38,3 +38,5 @@ assigner :
 tasks :
   defaults : plan/defaults/tasks_torch.yaml
 
+compression_pipeline :
+  defaults : plan/defaults/compression_pipeline.yaml

--- a/openfl-workspace/torch_unet_kvasir/plan/plan.yaml
+++ b/openfl-workspace/torch_unet_kvasir/plan/plan.yaml
@@ -55,3 +55,6 @@ tasks :
       apply   : local
       metrics :
       - dice_coef
+
+compression_pipeline :
+  defaults : plan/defaults/compression_pipeline.yaml

--- a/openfl-workspace/workspace/plan/defaults/compression_pipeline.yaml
+++ b/openfl-workspace/workspace/plan/defaults/compression_pipeline.yaml
@@ -1,0 +1,1 @@
+template: openfl.pipelines.NoCompressionPipeline

--- a/openfl/component/aggregator/aggregator.py
+++ b/openfl/component/aggregator/aggregator.py
@@ -320,9 +320,6 @@ class Aggregator:
         )
         tensor_name, origin, round_number, report, tags = tensor_key
 
-        # send_model_deltas = False
-        #compress_lossless = not self.tensor_codec.compression_pipeline.is_lossy()
-
         if 'aggregated' in tags and 'delta' in tags and round_number != 0:
             # send_model_deltas = True
             agg_tensor_key = TensorKey(

--- a/openfl/component/aggregator/aggregator.py
+++ b/openfl/component/aggregator/aggregator.py
@@ -11,7 +11,6 @@ from openfl.databases import TensorDB
 
 from openfl.protocols import utils
 from openfl.protocols import ModelProto
-from hashlib import sha384
 
 
 class Aggregator:
@@ -121,8 +120,6 @@ class Aggregator:
             TensorKey(k, self.uuid, self.round_number, False, ('model',)):
                 v for k, v in tensor_dict.items()
         }
-        # REMOVE
-        #self.logger.info(f'Initial weights : {tensor_key_dict.values()}')
         # all initial model tensors are loaded here
         self.tensor_db.cache_tensor(tensor_key_dict)
         self.logger.debug('This is the initial tensor_db:'
@@ -302,7 +299,6 @@ class Aggregator:
             named_tensor : protobuf NamedTensor
                 the tensor requested by the collaborator
         """
-        # REMOVE (or change to debug)
         self.logger.debug(f'Retrieving aggregated tensor {tensor_name},{round_number},{tags} \
                     for collaborator {collaborator_name}')
 
@@ -310,8 +306,6 @@ class Aggregator:
             compress_lossless = True
         else:
             compress_lossless = False
-        # REMOVE
-        #self.logger.info(f'Requesting lossless tensor = {compress_lossless}')
 
         # TODO the TensorDB doesn't support compressed data yet.
         #  The returned tensor will
@@ -380,14 +374,9 @@ class Aggregator:
                 "aggregated model is present")
             delta_tensor_key, delta_nparray = self.tensor_codec.generate_delta(
                 tensor_key, nparray, model_nparray)
-            # REMOVE
-            #self.logger.info(f'Delta tensor key : {delta_tensor_key}')
-            #self.logger.info(f'Checking math : {nparray - model_nparray}')
-            #self.logger.info(f'Delta nparray : {delta_nparray}')
             delta_comp_tensor_key, delta_comp_nparray, metadata = \
                 self.tensor_codec.compress(delta_tensor_key, delta_nparray,
                                            lossless=compress_lossless)
-            #self.logger.info(f'Constructed delta tensorkey = {delta_comp_tensor_key}')
             named_tensor = utils.construct_named_tensor(delta_comp_tensor_key,
                                                         delta_comp_nparray, metadata,
                                                         lossless=compress_lossless)
@@ -572,16 +561,10 @@ class Aggregator:
             if base_model_nparray is None:
                 raise ValueError('Base model {} not present in'
                                  ' TensorDB'.format(base_model_tensor_key))
-            # REMOVE
-            self.logger.info(f'Applying delta for tensorkey {decompressed_tensor_key}')
-            self.logger.info(f'Delta tensorkey: {decompressed_nparray}')
             final_tensor_key, final_nparray = self.tensor_codec.apply_delta(
                 decompressed_tensor_key,
                 decompressed_nparray, base_model_nparray
             )
-            #self.logger.info(f'After applying delta : {final_nparray}')
-            #REMOVE
-            #self.logger.info(f'Final tensorkey = {final_tensor_key}')
         else:
             final_tensor_key = decompressed_tensor_key
             final_nparray = decompressed_nparray
@@ -635,9 +618,6 @@ class Aggregator:
             report,
             ('aggregated',)
         )
-        # REMOVE
-        #self.logger.info(f'Entered prepare train sequence')
-        #self.logger.info(f'Caching aggregated tensor {agg_tag_tk}')
         self.tensor_db.cache_tensor({agg_tag_tk: agg_results})
 
         # Create delta and save it in TensorDB
@@ -648,8 +628,6 @@ class Aggregator:
             report,
             ('model',)
         )
-        # REMOVE
-        #self.logger.info(f'Getting {base_model_tk} from TensorDB')
         base_model_nparray = self.tensor_db.get_tensor_from_cache(base_model_tk)
         if base_model_nparray is not None:
             delta_tk, delta_nparray = self.tensor_codec.generate_delta(
@@ -657,8 +635,6 @@ class Aggregator:
                 agg_results,
                 base_model_nparray
             )
-            #self.logger.info(f'Caching delta tensor {delta_tk}')
-            #self.tensor_db.cache_tensor({delta_tk: delta_nparray})
         else:
             # This condition is possible for base model
             # optimizer states (i.e. Adam/iter:0, SGD, etc.)
@@ -683,10 +659,6 @@ class Aggregator:
             metadata
         )
 
-        # REMOVE
-        if 'conv2d' in decompressed_delta_tk[0] and not 'Adam' in decompressed_delta_tk[0]:
-            self.logger.info(f'Decompressed delta tensor {decompressed_delta_tk} = {decompressed_delta_nparray}')
-        #self.logger.info(f'Caching decompressed delta tensor {decompressed_delta_tk}')
         self.tensor_db.cache_tensor({decompressed_delta_tk: decompressed_delta_nparray})
 
         # Apply delta (unless delta couldn't be created)
@@ -697,8 +669,6 @@ class Aggregator:
                 decompressed_delta_nparray,
                 base_model_nparray
             )
-            # REMOVE
-            #self.logger.info(f'Final model weights : {new_model_nparray}')
         else:
             new_model_tk, new_model_nparray = decompressed_delta_tk, decompressed_delta_nparray
 
@@ -716,15 +686,7 @@ class Aggregator:
         )
 
         # Finally, cache the updated model tensor
-        # REMOVE
-        #self.logger.info(f'Caching model tensor {final_model_tk}')
-        sha384_hash = sha384()
-        sha384_hash.update(new_model_nparray.data.tobytes())
-        self.logger.info(f'Model layer {final_model_tk} hash : {sha384_hash.hexdigest()}')
         self.tensor_db.cache_tensor({final_model_tk: new_model_nparray})
-        # self.logger.debug('TensorDB contents after
-        # training round {}:
-        # {}'.format(self.round_number,self.tensor_db))
 
     def _compute_validation_related_task_metrics(self, task_name):
         """
@@ -798,8 +760,6 @@ class Aggregator:
                         self.best_model_score = agg_results
                         self._save_model(round_number, self.best_state_path)
             if 'trained' in tags:
-                # REMOVE
-                #self.logger.info(f'Calling prepare trained for {tensor_name}, {origin}, {round_number}, {tags}')
                 self._prepare_trained(tensor_name, origin, round_number, report, agg_results)
 
     def _end_of_round_check(self):

--- a/openfl/component/aggregator/aggregator.py
+++ b/openfl/component/aggregator/aggregator.py
@@ -573,8 +573,8 @@ class Aggregator:
                 raise ValueError('Base model {} not present in'
                                  ' TensorDB'.format(base_model_tensor_key))
             # REMOVE
-            #self.logger.info(f'Applying delta for tensorkey {decompressed_tensor_key}')
-            #self.logger.info(f'Checking math : {decompressed_nparray + base_model_nparray}')
+            self.logger.info(f'Applying delta for tensorkey {decompressed_tensor_key}')
+            self.logger.info(f'Delta tensorkey: {decompressed_nparray}')
             final_tensor_key, final_nparray = self.tensor_codec.apply_delta(
                 decompressed_tensor_key,
                 decompressed_nparray, base_model_nparray
@@ -684,6 +684,8 @@ class Aggregator:
         )
 
         # REMOVE
+        if 'conv2d' in decompressed_delta_tk[0] and not 'Adam' in decompressed_delta_tk[0]:
+            self.logger.info(f'Decompressed delta tensor {decompressed_delta_tk} = {decompressed_delta_nparray}')
         #self.logger.info(f'Caching decompressed delta tensor {decompressed_delta_tk}')
         self.tensor_db.cache_tensor({decompressed_delta_tk: decompressed_delta_nparray})
 

--- a/openfl/component/aggregator/aggregator.py
+++ b/openfl/component/aggregator/aggregator.py
@@ -359,13 +359,13 @@ class Aggregator:
             # Should get the pretrained model to create the delta. If training
             # has happened, Model should already be stored in the TensorDB
             model_tk = TensorKey(tensor_name,
-                          origin,
-                          round_number - 1,
-                          report,
-                          ('model',))
+                                 origin,
+                                 round_number - 1,
+                                 report,
+                                 ('model',))
 
             model_nparray = self.tensor_db.get_tensor_from_cache(model_tk)
-                
+
             assert (model_nparray is not None), (
                 "The original model layer should be present if the latest "
                 "aggregated model is present")

--- a/openfl/component/collaborator/collaborator.py
+++ b/openfl/component/collaborator/collaborator.py
@@ -412,11 +412,23 @@ class Collaborator:
                         model_nparray
                     )
                 # REMOVE
-                #self.logger.info(f'Generated delta : {delta_tensor_key}')
+                self.logger.info(f'Generated delta : {delta_tensor_key}')
                 #self.logger.info(f'Checking delta calculation : {nparray - model_nparray}')
-                #self.logger.info(f'delta_nparray : {delta_nparray}')
+                self.logger.info(f'delta_nparray : {delta_nparray}')
                 delta_comp_tensor_key, delta_comp_nparray, metadata = \
                     self.tensor_codec.compress(delta_tensor_key, delta_nparray)
+                # REMOVE
+                #dec_tk, decompressed_nparray = self.tensor_codec.decompress(
+                #    delta_comp_tensor_key,
+                #    data=delta_comp_nparray,
+                #    transformer_metadata=metadata,
+                #    require_lossless=False
+                #)
+                #self.logger.info(f'Decompressed delta : {dec_tk}')
+                ##self.logger.info(f'Checking delta calculation : {nparray - model_nparray}')
+                #self.logger.info(f'decompressed delta_nparray : {decompressed_nparray}')
+
+
                 named_tensor = utils.construct_named_tensor(
                     delta_comp_tensor_key,
                     delta_comp_nparray,

--- a/openfl/component/collaborator/collaborator.py
+++ b/openfl/component/collaborator/collaborator.py
@@ -278,7 +278,8 @@ class Collaborator:
                     )
                     self.tensor_db.cache_tensor({new_model_tk: nparray})
                 else:
-                    self.logger.info(f'Count not find previous model layer. Fetching latest layer from aggregator')
+                    self.logger.info(f'Count not find previous model layer.'
+                                     f'Fetching latest layer from aggregator')
                     # The original model tensor should be fetched from client
                     nparray = self.get_aggregated_tensor_from_aggregator(
                         tensor_key,

--- a/openfl/component/collaborator/collaborator.py
+++ b/openfl/component/collaborator/collaborator.py
@@ -11,7 +11,6 @@ from openfl.protocols import utils
 from openfl.utilities import TensorKey
 from openfl.pipelines import TensorCodec, NoCompressionPipeline
 from openfl.databases import TensorDB
-from hashlib import sha384
 
 
 class OptTreatment(Enum):
@@ -257,9 +256,6 @@ class Collaborator:
             tensor_dependencies = self.tensor_codec.find_dependencies(
                 tensor_key, self.delta_updates
             )
-            # REMOVE
-            self.logger.info('tensor_dependencies = {}'.format(
-            tensor_dependencies))
             if len(tensor_dependencies) > 0:
                 # Resolve dependencies
                 # tensor_dependencies[0] corresponds to the prior version
@@ -274,19 +270,12 @@ class Collaborator:
                         self.get_aggregated_tensor_from_aggregator(
                             tensor_dependencies[1]
                         )
-                    self.logger.info(f'Uncompressed delta = {uncompressed_delta}')
                     new_model_tk, nparray = self.tensor_codec.apply_delta(
                         tensor_dependencies[1],
                         uncompressed_delta,
                         prior_model_layer,
                         creates_model=True,
                     )
-                    # REMOVE
-                    #self.logger.info(f'Applied delta {tensor_dependencies[1]} to base {tensor_dependencies[0]}')
-                    self.logger.info(f'Caching tensor {new_model_tk}')
-                    sha384_hash = sha384()
-                    sha384_hash.update(nparray.data.tobytes())
-                    self.logger.info(f'Model layer {new_model_tk} hash : {sha384_hash.hexdigest()}')
                     self.tensor_db.cache_tensor({new_model_tk: nparray})
                 else:
                     self.logger.info(f'Count not find previous model layer. Fetching latest layer from aggregator')
@@ -344,8 +333,6 @@ class Collaborator:
 
         # cache this tensor
         self.tensor_db.cache_tensor({tensor_key: nparray})
-        # self.logger.info('Printing updated TensorDB: {}'.format(
-        # self.tensor_db))
 
         return nparray
 
@@ -411,23 +398,8 @@ class Collaborator:
                         nparray,
                         model_nparray
                     )
-                # REMOVE
-                self.logger.info(f'Generated delta : {delta_tensor_key}')
-                #self.logger.info(f'Checking delta calculation : {nparray - model_nparray}')
-                self.logger.info(f'delta_nparray : {delta_nparray}')
                 delta_comp_tensor_key, delta_comp_nparray, metadata = \
                     self.tensor_codec.compress(delta_tensor_key, delta_nparray)
-                # REMOVE
-                #dec_tk, decompressed_nparray = self.tensor_codec.decompress(
-                #    delta_comp_tensor_key,
-                #    data=delta_comp_nparray,
-                #    transformer_metadata=metadata,
-                #    require_lossless=False
-                #)
-                #self.logger.info(f'Decompressed delta : {dec_tk}')
-                ##self.logger.info(f'Checking delta calculation : {nparray - model_nparray}')
-                #self.logger.info(f'decompressed delta_nparray : {decompressed_nparray}')
-
 
                 named_tensor = utils.construct_named_tensor(
                     delta_comp_tensor_key,
@@ -479,8 +451,6 @@ class Collaborator:
                     require_lossless=True
                 )
         elif 'lossy_compressed' in tags:
-            # REMOVE 
-            #self.logger.info(f'Decompressing lossy {tensor_key}')
             decompressed_tensor_key, decompressed_nparray = \
                 self.tensor_codec.decompress(
                     tensor_key,

--- a/openfl/component/collaborator/collaborator.py
+++ b/openfl/component/collaborator/collaborator.py
@@ -278,8 +278,8 @@ class Collaborator:
                     )
                     self.tensor_db.cache_tensor({new_model_tk: nparray})
                 else:
-                    self.logger.info(f'Count not find previous model layer.'
-                                     f'Fetching latest layer from aggregator')
+                    self.logger.info('Count not find previous model layer.'
+                                     'Fetching latest layer from aggregator')
                     # The original model tensor should be fetched from client
                     nparray = self.get_aggregated_tensor_from_aggregator(
                         tensor_key,

--- a/openfl/databases/tensor_db.py
+++ b/openfl/databases/tensor_db.py
@@ -3,7 +3,6 @@
 
 """TensorDB Module."""
 
-from logging import getLogger
 import pandas as pd
 import numpy as np
 
@@ -27,7 +26,6 @@ class TensorDB:
         self.tensor_db = pd.DataFrame([], columns=[
             'tensor_name', 'origin', 'round', 'report', 'tags', 'nparray'
         ])
-        self.logger = getLogger(__name__)
         self.mutex = Lock()
 
     def __repr__(self):
@@ -48,11 +46,9 @@ class TensorDB:
             # Getting a negative argument calls off cleaning
             return
         current_round = int(self.tensor_db['round'].max())
-        self.logger.debug(f'TensorDB Length before cleanup : {len(self.tensor_db)}')
         self.tensor_db = self.tensor_db[
             self.tensor_db['round'] > current_round - remove_older_than
         ].reset_index(drop=True)
-        self.logger.debug(f'TensorDB Length after cleanup : {len(self.tensor_db)}')
 
     def cache_tensor(self, tensor_key_dict):
         """Insert tensor into TensorDB (dataframe).

--- a/openfl/databases/tensor_db.py
+++ b/openfl/databases/tensor_db.py
@@ -11,7 +11,6 @@ from threading import Lock
 from openfl.utilities import TensorKey
 
 
-
 class TensorDB:
     """
     The TensorDB stores a tensor key and the data that it corresponds to.

--- a/openfl/databases/tensor_db.py
+++ b/openfl/databases/tensor_db.py
@@ -3,12 +3,14 @@
 
 """TensorDB Module."""
 
+from logging import getLogger
 import pandas as pd
 import numpy as np
 
 from threading import Lock
 
 from openfl.utilities import TensorKey
+
 
 
 class TensorDB:
@@ -25,6 +27,7 @@ class TensorDB:
         self.tensor_db = pd.DataFrame([], columns=[
             'tensor_name', 'origin', 'round', 'report', 'tags', 'nparray'
         ])
+        self.logger = getLogger(__name__)
         self.mutex = Lock()
 
     def __repr__(self):
@@ -45,9 +48,11 @@ class TensorDB:
             # Getting a negative argument calls off cleaning
             return
         current_round = int(self.tensor_db['round'].max())
+        self.logger.debug(f'TensorDB Length before cleanup : {len(self.tensor_db)}')
         self.tensor_db = self.tensor_db[
             self.tensor_db['round'] > current_round - remove_older_than
         ].reset_index(drop=True)
+        self.logger.debug(f'TensorDB Length after cleanup : {len(self.tensor_db)}')
 
     def cache_tensor(self, tensor_key_dict):
         """Insert tensor into TensorDB (dataframe).

--- a/openfl/federated/plan/plan.py
+++ b/openfl/federated/plan/plan.py
@@ -249,6 +249,7 @@ class Plan(object):
         defaults[SETTINGS]['federation_uuid'] = self.federation_uuid
         defaults[SETTINGS]['authorized_cols'] = self.authorized_cols
         defaults[SETTINGS]['assigner'] = self.get_assigner()
+        defaults[SETTINGS]['compression_pipeline'] = self.get_tensor_pipe()
 
         if self.aggregator_ is None:
             self.aggregator_ = Plan.Build(**defaults)
@@ -324,7 +325,7 @@ class Plan(object):
             defaults[SETTINGS]['task_runner'] = self.get_task_runner(
                 collaborator_name
             )
-        defaults[SETTINGS]['tensor_pipe'] = self.get_tensor_pipe()
+        defaults[SETTINGS]['compression_pipeline'] = self.get_tensor_pipe()
         defaults[SETTINGS]['task_config'] = self.config.get('tasks', {})
         if client is not None:
             defaults[SETTINGS]['client'] = client

--- a/openfl/pipelines/kc_pipeline.py
+++ b/openfl/pipelines/kc_pipeline.py
@@ -48,10 +48,6 @@ class KmeansTransformer(Transformer):
         else:
             quant_array = data
 
-        #k_means.fit(data)
-        #quantized_values = k_means.cluster_centers_.squeeze()
-        #indices = k_means.labels_
-        #quant_array = np.choose(indices, quantized_values)
         int_array, int2float_map = self._float_to_int(quant_array)
         metadata['int_to_float'] = int2float_map
 

--- a/openfl/pipelines/kc_pipeline.py
+++ b/openfl/pipelines/kc_pipeline.py
@@ -38,10 +38,20 @@ class KmeansTransformer(Transformer):
         # clustering
         k_means = cluster.KMeans(n_clusters=self.n_cluster, n_init=self.n_cluster)
         data = data.reshape((-1, 1))
-        k_means.fit(data)
-        quantized_values = k_means.cluster_centers_.squeeze()
-        indices = k_means.labels_
-        quant_array = np.choose(indices, quantized_values)
+        if data.shape[0] >= self.n_cluster:
+            k_means = cluster.KMeans(
+                n_clusters=self.n_cluster, n_init=self.n_cluster)
+            k_means.fit(data)
+            quantized_values = k_means.cluster_centers_.squeeze()
+            indices = k_means.labels_
+            quant_array = np.choose(indices, quantized_values)
+        else:
+            quant_array = data
+
+        #k_means.fit(data)
+        #quantized_values = k_means.cluster_centers_.squeeze()
+        #indices = k_means.labels_
+        #quant_array = np.choose(indices, quantized_values)
         int_array, int2float_map = self._float_to_int(quant_array)
         metadata['int_to_float'] = int2float_map
 

--- a/openfl/pipelines/skc_pipeline.py
+++ b/openfl/pipelines/skc_pipeline.py
@@ -226,7 +226,7 @@ class SKCPipeline(TransformationPipeline):
         self.n_cluster = n_clusters
         transformers = [
             SparsityTransformer(self.p),
-            KmeansTransformer(self.n_cluster),
+            #KmeansTransformer(self.n_cluster),
             GZIPTransformer()
         ]
         super(SKCPipeline, self).__init__(transformers=transformers, **kwargs)

--- a/openfl/pipelines/skc_pipeline.py
+++ b/openfl/pipelines/skc_pipeline.py
@@ -35,7 +35,6 @@ class SparsityTransformer(Transformer):
             condensed_data: an numpy array being sparsified.
             metadata: dictionary to store a list of meta information.
         """
-        self.p = 1
         metadata = {'int_list': list(data.shape)}
         # sparsification
         data = data.astype(np.float32)
@@ -115,12 +114,15 @@ class KmeansTransformer(Transformer):
         """
         # clustering
         data = data.reshape((-1, 1))
-        k_means = cluster.KMeans(
-            n_clusters=self.n_cluster, n_init=self.n_cluster)
-        k_means.fit(data)
-        quantized_values = k_means.cluster_centers_.squeeze()
-        indices = k_means.labels_
-        quant_array = np.choose(indices, quantized_values)
+        if data.shape[0] >= self.n_cluster:
+            k_means = cluster.KMeans(
+                n_clusters=self.n_cluster, n_init=self.n_cluster)
+            k_means.fit(data)
+            quantized_values = k_means.cluster_centers_.squeeze()
+            indices = k_means.labels_
+            quant_array = np.choose(indices, quantized_values)
+        else:
+            quant_array = data
         int_array, int2float_map = self._float_to_int(quant_array)
         metadata = {'int_to_float': int2float_map}
         int_array = int_array.reshape(-1)

--- a/openfl/pipelines/skc_pipeline.py
+++ b/openfl/pipelines/skc_pipeline.py
@@ -32,7 +32,7 @@ class SparsityTransformer(Transformer):
             data: an numpy array from the model tensor_dict.
 
         Returns:
-            condensed_data: an numpy array being sparsified.
+            sparse_data: a flattened, sparse representation of the input tensor 
             metadata: dictionary to store a list of meta information.
         """
         metadata = {'int_list': list(data.shape)}
@@ -42,11 +42,8 @@ class SparsityTransformer(Transformer):
         n_elements = flatten_data.shape[0]
         k_op = int(np.ceil(n_elements * self.p))
         topk, topk_indices = self._topk_func(flatten_data, k_op)
-        condensed_data = topk
         sparse_data = np.zeros(flatten_data.shape)
         sparse_data[topk_indices] = topk
-        nonzero_element_bool_indices = sparse_data != 0.0
-        metadata['bool_list'] = list(nonzero_element_bool_indices)
         return sparse_data, metadata
 
     def backward(self, data, metadata, **kwargs):
@@ -62,9 +59,6 @@ class SparsityTransformer(Transformer):
         """
         data = data.astype(np.float32)
         data_shape = metadata['int_list']
-        #nonzero_element_bool_indices = list(metadata['bool_list'])
-        #recovered_data = np.zeros(data_shape).reshape(-1).astype(np.float32)
-        #recovered_data[nonzero_element_bool_indices] = data
         recovered_data = data.reshape(data_shape)
         return recovered_data
 
@@ -210,11 +204,11 @@ class GZIPTransformer(Transformer):
 class SKCPipeline(TransformationPipeline):
     """A pipeline class to compress data lossly using sparsity and k-means methods."""
 
-    def __init__(self, p_sparsity=0.01, n_clusters=6, **kwargs):
+    def __init__(self, p_sparsity=0.1, n_clusters=6, **kwargs):
         """Initialize a pipeline of transformers.
 
         Args:
-            p_sparsity (float): Sparsity factor (Default=0.01)
+            p_sparsity (float): Sparsity factor (Default=0.1)
             n_cluster (int): Number of K-Means clusters (Default=6)
 
         Returns:

--- a/openfl/pipelines/skc_pipeline.py
+++ b/openfl/pipelines/skc_pipeline.py
@@ -32,7 +32,7 @@ class SparsityTransformer(Transformer):
             data: an numpy array from the model tensor_dict.
 
         Returns:
-            sparse_data: a flattened, sparse representation of the input tensor 
+            sparse_data: a flattened, sparse representation of the input tensor
             metadata: dictionary to store a list of meta information.
         """
         metadata = {'int_list': list(data.shape)}

--- a/openfl/pipelines/skc_pipeline.py
+++ b/openfl/pipelines/skc_pipeline.py
@@ -42,13 +42,12 @@ class SparsityTransformer(Transformer):
         n_elements = flatten_data.shape[0]
         k_op = int(np.ceil(n_elements * self.p))
         topk, topk_indices = self._topk_func(flatten_data, k_op)
-        #
         condensed_data = topk
         sparse_data = np.zeros(flatten_data.shape)
         sparse_data[topk_indices] = topk
         nonzero_element_bool_indices = sparse_data != 0.0
         metadata['bool_list'] = list(nonzero_element_bool_indices)
-        return condensed_data, metadata
+        return sparse_data, metadata
 
     def backward(self, data, metadata, **kwargs):
         """Recover data array with the right shape and numerical type.
@@ -63,10 +62,10 @@ class SparsityTransformer(Transformer):
         """
         data = data.astype(np.float32)
         data_shape = metadata['int_list']
-        nonzero_element_bool_indices = list(metadata['bool_list'])
-        recovered_data = np.zeros(data_shape).reshape(-1).astype(np.float32)
-        recovered_data[nonzero_element_bool_indices] = data
-        recovered_data = recovered_data.reshape(data_shape)
+        #nonzero_element_bool_indices = list(metadata['bool_list'])
+        #recovered_data = np.zeros(data_shape).reshape(-1).astype(np.float32)
+        #recovered_data[nonzero_element_bool_indices] = data
+        recovered_data = data.reshape(data_shape)
         return recovered_data
 
     @staticmethod
@@ -226,7 +225,7 @@ class SKCPipeline(TransformationPipeline):
         self.n_cluster = n_clusters
         transformers = [
             SparsityTransformer(self.p),
-            #KmeansTransformer(self.n_cluster),
+            KmeansTransformer(self.n_cluster),
             GZIPTransformer()
         ]
         super(SKCPipeline, self).__init__(transformers=transformers, **kwargs)

--- a/openfl/pipelines/stc_pipeline.py
+++ b/openfl/pipelines/stc_pipeline.py
@@ -22,13 +22,14 @@ class SparsityTransformer(Transformer):
         self.p = p
 
     def forward(self, data, **kwargs):
-        """Sparsify data and pass over only non-sparsified elements by reducing the array size.
+        """
+        Sparsify data and pass over only non-sparsified elements by reducing the array size.
 
         Args:
-            data: an numpy array from the model tensor_dict
+            data: an numpy array from the model tensor_dict.
 
         Returns:
-            condensed_data: an numpy array being sparsified.
+            sparse_data: a flattened, sparse representation of the input tensor 
             metadata: dictionary to store a list of meta information.
         """
         metadata = {'int_list': list(data.shape)}
@@ -38,31 +39,24 @@ class SparsityTransformer(Transformer):
         n_elements = flatten_data.shape[0]
         k_op = int(np.ceil(n_elements * self.p))
         topk, topk_indices = self._topk_func(flatten_data, k_op)
-        #
-        condensed_data = topk
         sparse_data = np.zeros(flatten_data.shape)
         sparse_data[topk_indices] = topk
-        nonzero_element_bool_indices = sparse_data != 0.0
-        metadata['bool_list'] = list(nonzero_element_bool_indices)
-        return condensed_data, metadata
-        # return sparse_data, metadata
+        return sparse_data, metadata
 
     def backward(self, data, metadata, **kwargs):
         """Recover data array with the right shape and numerical type.
 
         Args:
             data: an numpy array with non-zero values.
-            metadata: dictionary to contain information for recovering back to original data array.
+            metadata: dictionary to contain information for recovering back
+             to original data array.
 
         Returns:
             recovered_data: an numpy array with original shape.
         """
         data = data.astype(np.float32)
         data_shape = metadata['int_list']
-        nonzero_element_bool_indices = list(metadata['bool_list'])
-        recovered_data = np.zeros(data_shape).reshape(-1).astype(np.float32)
-        recovered_data[nonzero_element_bool_indices] = data
-        recovered_data = recovered_data.reshape(data_shape)
+        recovered_data = data.reshape(data_shape)
         return recovered_data
 
     @staticmethod
@@ -203,7 +197,7 @@ class GZIPTransformer(Transformer):
 class STCPipeline(TransformationPipeline):
     """A pipeline class to compress data lossly using sparsity and ternerization methods."""
 
-    def __init__(self, p_sparsity=0.01, n_clusters=6, **kwargs):
+    def __init__(self, p_sparsity=0.1, n_clusters=6, **kwargs):
         """Initialize a pipeline of transformers.
 
         Args:

--- a/openfl/pipelines/stc_pipeline.py
+++ b/openfl/pipelines/stc_pipeline.py
@@ -29,7 +29,7 @@ class SparsityTransformer(Transformer):
             data: an numpy array from the model tensor_dict.
 
         Returns:
-            sparse_data: a flattened, sparse representation of the input tensor 
+            sparse_data: a flattened, sparse representation of the input tensor
             metadata: dictionary to store a list of meta information.
         """
         metadata = {'int_list': list(data.shape)}

--- a/openfl/pipelines/tensor_codec.py
+++ b/openfl/pipelines/tensor_codec.py
@@ -215,7 +215,7 @@ class TensorCodec:
                 tensor_name, origin, round_number, report, new_tags)
         else:
             new_model_tensor_key = TensorKey(
-              tensor_name, origin, round_number, report, ('model',))
+                tensor_name, origin, round_number, report, ('model',))
 
         return new_model_tensor_key, base_model_nparray + delta
 

--- a/openfl/pipelines/tensor_codec.py
+++ b/openfl/pipelines/tensor_codec.py
@@ -179,7 +179,7 @@ class TensorCodec:
         return delta_tensor_key, nparray - base_model_nparray
 
     @staticmethod
-    def apply_delta(tensor_key, delta, base_model_nparray):
+    def apply_delta(tensor_key, delta, base_model_nparray, creates_model=False):
         """
         Add delta to the nparray.
 
@@ -191,6 +191,8 @@ class TensorCodec:
                                     old model
             base_model_nparray:     The nparray that corresponds to the prior
                                     weights
+            creates_model:          If flag is set, the tensorkey returned
+                                    will correspond to the aggregator model
 
         Returns:
             new_model_tensor_key:   Latest model layer tensorkey
@@ -205,7 +207,7 @@ class TensorCodec:
         # assert('model' in tensor_key[3]), 'The tensorkey should be provided
         # from the base model'
         # Aggregator UUID has the prefix 'aggregator'
-        if 'aggregator' in origin:
+        if 'aggregator' in origin and not creates_model:
             tags = list(tags)
             tags.remove('delta')
             new_tags = tuple(tags)
@@ -213,7 +215,7 @@ class TensorCodec:
                 tensor_name, origin, round_number, report, new_tags)
         else:
             new_model_tensor_key = TensorKey(
-                tensor_name, origin, round_number, report, ('model',))
+              tensor_name, origin, round_number, report, ('model',))
 
         return new_model_tensor_key, base_model_nparray + delta
 

--- a/tests/openfl/component/collaborator/test_collaborator.py
+++ b/tests/openfl/component/collaborator/test_collaborator.py
@@ -15,7 +15,7 @@ from openfl.utilities.types import TensorKey
 def collaborator_mock():
     """Initialize the collaborator mock."""
     col = Collaborator('col1', 'some_uuid', 'federation_uuid',
-                       mock.Mock(), mock.Mock(), None, mock.Mock(), opt_treatment='RESET')
+                       mock.Mock(), mock.Mock(), mock.Mock(), opt_treatment='RESET')
     col.tensor_db = mock.Mock()
 
     return col


### PR DESCRIPTION
This PR:
- Fixes some of the lossy compression logic around how delta updates are applied
- Provides a new example for a KMeans pipeline applied to the Keras CNN template (*keras_cnn_with_compression*)
- Fixes a bug in the sparsity pipelines (applies to the SKC and STC pipelines)
- Adds documentation for compression pipelines under advanced topics