### PR TITLE
Fix loss functions in PyTorch notebooks

### DIFF
--- a/openfl-tutorials/Federated_PyTorch_TinyImageNet.ipynb
+++ b/openfl-tutorials/Federated_PyTorch_TinyImageNet.ipynb
@@ -124,11 +124,12 @@
     "    shard_num: int\n",
     "        Current shard number, starting from 0\n",
     "    \"\"\"\n",
-    "    def __init__(self, root, split='train', collabs=1, shard_num=0, transform=None):\n",
+    "    def __init__(self, root, split='train', collabs=1, shard_num=0, transform=None, target_transform=None):\n",
     "        assert collabs > shard_num, \"Incorrect shard number\"\n",
     "        NUM_IMAGES_PER_CLASS = 500\n",
     "        self.root = os.path.expanduser(root)\n",
     "        self.transform = transform\n",
+    "        self.target_transform = target_transform\n",
     "        self.split_dir = os.path.join(self.root, split)\n",
     "        self.image_paths = sorted(glob.iglob(os.path.join(self.split_dir, '**', '*.JPEG'), recursive=True))\n",
     "        # DO the SHARDING\n",
@@ -160,13 +161,15 @@
     "    def __getitem__(self, index):\n",
     "        file_path = self.image_paths[index]\n",
     "        label = self.labels[os.path.basename(file_path)]\n",
-    "        one_hot = np.zeros((200))\n",
-    "        one_hot[label] = 1\n",
-    "        return self.read_image(file_path), one_hot\n",
+    "        label = self.target_transform(label) if self.target_transform else label\n",
+    "        return self.read_image(file_path), label\n",
     "\n",
     "    def read_image(self, path):\n",
     "        img = Image.open(path)\n",
-    "        return self.transform(img) if self.transform else img\n"
+    "        return self.transform(img) if self.transform else img\n",
+    "\n",
+    "def one_hot(labels, classes):\n",
+    "    return np.eye(classes)[labels]"
    ]
   },
   {
@@ -227,7 +230,8 @@
     "\n",
     "        self.training_set = TinyImageNet(TINY_IMAGENET_ROOT, 'train', transform=training_transform, \\\n",
     "                collabs=self.fed_size, shard_num=self.rank)\n",
-    "        self.valid_set = TinyImageNet(TINY_IMAGENET_ROOT, 'val', transform=valid_transform)\n",
+    "        self.valid_set = TinyImageNet(TINY_IMAGENET_ROOT, 'val', transform=valid_transform, \\\n",
+    "                                      target_transform=lambda target: one_hot(target, 200))\n",
     "\n",
     "        self.train_loader = self.get_train_loader()\n",
     "        \n",
@@ -281,7 +285,7 @@
     "\n",
     "    def forward(self, x):\n",
     "        x = self.model.forward(x)\n",
-    "        return F.log_softmax(x, dim=1)\n",
+    "        return x\n",
     "\n",
     "    \n",
     "optimizer = lambda x: optim.Adam(x, lr=1e-4)\n",
@@ -289,7 +293,7 @@
     "def cross_entropy(output, target):\n",
     "    \"\"\"Binary cross-entropy metric\n",
     "    \"\"\"\n",
-    "    return F.binary_cross_entropy_with_logits(input=output,target=target)"
+    "    return F.cross_entropy(input=output,target=target)"
    ]
   },
   {
@@ -364,6 +368,13 @@
     "#Save final model\n",
     "final_fl_model.save_native('final_model.pth')"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/openfl-tutorials/Federated_Pytorch_MNIST_Tutorial.ipynb
+++ b/openfl-tutorials/Federated_Pytorch_MNIST_Tutorial.ipynb
@@ -77,7 +77,6 @@
     "\n",
     "train_images,train_labels = trainset.train_data, np.array(trainset.train_labels)\n",
     "train_images = torch.from_numpy(np.expand_dims(train_images, axis=1)).float()\n",
-    "train_labels = one_hot(train_labels,10)\n",
     "\n",
     "validset = torchvision.datasets.MNIST(root='./data', train=False,\n",
     "                                       download=True, transform=transform)\n",
@@ -122,7 +121,7 @@
     "def cross_entropy(output, target):\n",
     "    \"\"\"Binary cross-entropy metric\n",
     "    \"\"\"\n",
-    "    return F.binary_cross_entropy_with_logits(input=output,target=target)"
+    "    return F.cross_entropy(input=output,target=target)"
    ]
   },
   {

--- a/openfl/federated/task/runner_pt.py
+++ b/openfl/federated/task/runner_pt.py
@@ -450,7 +450,7 @@ class PyTorchTaskRunner(nn.Module, TaskRunner):
         losses = []
         for data, target in batch_generator:
             data, target = pt.tensor(data).to(self.device), pt.tensor(
-                target).to(self.device, dtype=pt.int64)
+                target).to(self.device)
             self.optimizer.zero_grad()
             output = self(data)
             loss = self.loss_fn(output=output, target=target)


### PR DESCRIPTION
Bugfix for notebooks:
 - `openfl-tutorials/Federated_Pytorch_MNIST_Tutorial.ipynb`
 - `openfl-tutorials/Federated_PyTorch_TinyImageNet.ipynb`

Steps to reproduce:
 1. Run all cells in any notebook listed above.

Error:
```
RuntimeError: result type Float can't be cast to the desired output type Long
```
<details>
  <summary>Traceback</summary>

```
    <ipython-input-10-1f104c516d47> in <module>
        1 #Run experiment, return trained FederatedModel
  ----> 2 final_fl_model = fx.run_experiment(collaborators,{'aggregator.settings.rounds_to_train':5})
  
  ~/.virtualenvs/openfl_research/lib/python3.8/site-packages/openfl/native/native.py in run_experiment(collaborator_dict, override_config)
      295             collaborator = collaborators[col]
      296 
  --> 297             collaborator.run_simulation()
      298             model_states[col] = collaborator.task_runner.get_tensor_dict(with_opt_vars=True)
      299 
  
  ~/.virtualenvs/openfl_research/lib/python3.8/site-packages/openfl/component/collaborator/collaborator.py in run_simulation(self)
      145                     'Received the following tasks: {}'.format(tasks))
      146                 for task in tasks:
  --> 147                     self.do_task(task, round_number)
      148                 self.logger.info(
      149                     'All tasks completed on {} for round {}...'.format(
  
  ~/.virtualenvs/openfl_research/lib/python3.8/site-packages/openfl/component/collaborator/collaborator.py in do_task(self, task, round_number)
      206             self.logger.info('Using TaskRunner subclassing API')
      207 
  --> 208         global_output_tensor_dict, local_output_tensor_dict = func(
      209             col_name=self.collaborator_name,
      210             round_num=round_number,

  ~/.virtualenvs/openfl_research/lib/python3.8/site-packages/openfl/federated/task/runner_pt.py in train_batches(self, col_name, round_num, input_tensor_dict, num_batches, use_tqdm, **kwargs)
      149         if use_tqdm:
      150             loader = tqdm.tqdm(loader, desc="train epoch")
  --> 151         metric = self.train_epoch(loader)
      152         # Output metric tensors (scalar)
      153         origin = col_name
  
  ~/.virtualenvs/openfl_research/lib/python3.8/site-packages/openfl/federated/task/runner_pt.py in train_epoch(self, batch_generator)
      454             self.optimizer.zero_grad()
      455             output = self(data)
  --> 456             loss = self.loss_fn(output=output, target=target)
      457             loss.backward()
      458             self.optimizer.step()
  
  <ipython-input-5-241f306655cc> in cross_entropy(output, target)
       28     """Binary cross-entropy metric
       29     """
  ---> 30     return F.binary_cross_entropy_with_logits(input=output,target=target)
  
  ~/.virtualenvs/openfl_research/lib/python3.8/site-packages/torch/nn/functional.py in binary_cross_entropy_with_logits(input, target, weight, size_average, reduce, reduction, pos_weight)
     2580             Default: ``'mean'``
     2581         log_target (bool): A flag indicating whether ``target`` is passed in the log space.
  -> 2582             It is recommended to pass certain distributions (like ``softmax``)
     2583             in the log space to avoid numerical issues caused by explicit ``log``.
     2584             Default: ``False``
```
</details>
/cc @maradionov 