### PR TITLE
[tf_2dunet] Show error message if BraTS data is not found

### DIFF
--- a/openfl-workspace/tf_2dunet/code/brats_utils.py
+++ b/openfl-workspace/tf_2dunet/code/brats_utils.py
@@ -92,6 +92,11 @@ def load_from_NIfTI(parent_dir,
     path = os.path.join(parent_dir)
     subdirs = os.listdir(path)
     subdirs.sort()
+    if not subdirs:
+        raise SystemError(f'''{parent_dir} does not contain subdirectories.
+Please make sure you have BraTS dataset downloaded
+and located in data directory for this collaborator.
+        ''')
     subdir_paths = [os.path.join(path, subdir) for subdir in subdirs]
 
     imgs_all = []


### PR DESCRIPTION
Due to legal constraints, we cannot download the BraTS dataset automatically. We expect users to have data downloaded. During `fx plan initialize` execution in `tf_2dunet` workspace template, if the user has no folders inside the data directory, an error will be raised:
```
EXCEPTION : need at least one array to concatenate
```
<details><summary>Traceback (most recent call last)</summary>

```
File "c:\anaconda3\envs\open-fl\lib\runpy.py", line 194, in _run_module_as_main
return _run_code(code, main_globals, None,
File "c:\anaconda3\envs\open-fl\lib\runpy.py", line 87, in run_code
exec(code, run_globals)
File "C:\Anaconda3\envs\open-fl\Scripts\fx.exe_main.py", line 7, in
File "c:\anaconda3\envs\open-fl\lib\site-packages\openfl\interface\cli.py", line 194, in entry
error_handler(e)
File "c:\anaconda3\envs\open-fl\lib\site-packages\openfl\interface\cli.py", line 155, in error_handler
raise error
File "c:\anaconda3\envs\open-fl\lib\site-packages\openfl\interface\cli.py", line 192, in entry
cli()
File "c:\anaconda3\envs\open-fl\lib\site-packages\click\core.py", line 829, in call
return self.main(*args, **kwargs)
File "c:\anaconda3\envs\open-fl\lib\site-packages\click\core.py", line 782, in main
rv = self.invoke(ctx)
File "c:\anaconda3\envs\open-fl\lib\site-packages\click\core.py", line 1259, in invoke
return _process_result(sub_ctx.command.invoke(sub_ctx))
File "c:\anaconda3\envs\open-fl\lib\site-packages\click\core.py", line 1259, in invoke
return process_result(sub_ctx.command.invoke(sub_ctx))
File "c:\anaconda3\envs\open-fl\lib\site-packages\click\core.py", line 1066, in invoke
return ctx.invoke(self.callback, **ctx.params)
File "c:\anaconda3\envs\open-fl\lib\site-packages\click\core.py", line 610, in invoke
return callback(*args, **kwargs)
File "c:\anaconda3\envs\open-fl\lib\site-packages\click\decorators.py", line 21, in new_func
return f(get_current_context(), *args, **kwargs)
File "C:\Anaconda3\envs\open-fl\Lib\site-packages\openfl\interface\plan.py", line 77, in initialize
data_loader = plan.get_data_loader(collaborator_cname)
File "c:\anaconda3\envs\open-fl\lib\site-packages\openfl\federated\plan\plan.py", line 293, in get_data_loader
self.loader = Plan.Build(**defaults)
File "c:\anaconda3\envs\open-fl\lib\site-packages\openfl\federated\plan\plan.py", line 179, in Build
instance = getattr(module, class_name)(**settings)
File "C:\Users\rstoklas\cernbox\work\my-projects\FL-phase-3_network\federation-0.1\code\tfbrats_inmemory.py", line 29, in init
X_train, y_train, X_valid, y_valid = load_from_NIfTI(parent_dir=data_path,
File "C:\Users\rstoklas\cernbox\work\my-projects\FL-phase-3_network\federation-0.1\code\brats_utils.py", line 125, in load_from_NIfTI
imgs_train = np.concatenate(imgs_all_train, axis=0)
File "<array_function internals>", line 5, in concatenate
ValueError: need at least one array to concatenate
```
</details>
This PR adds handling of this error and closes #72.

Instructions on how to obtain the BraTS dataset can be found [here](https://www.med.upenn.edu/sbia/brats2017/registration.html).