### PR TITLE
Custom aggregation functions in CLI

### DIFF
--- a/docs/overriding_agg_fn.rst
+++ b/docs/overriding_agg_fn.rst
@@ -2,20 +2,64 @@
 .. # SPDX-License-Identifier: Apache-2.0
 
 .. _overriding_agg_fn:
-
+===============================
 Overriding aggregation function
-#######################
+===============================
 
+-------------------------------
 Usage
-=====================
+-------------------------------
 |productName| allows developers to use custom aggregation functions per task.
-In order to do this, you should create an implementation of :class:`openfl.component.aggregation_functions.AggregationFunctionInterface`
+In order to do this, you should:
+
+Python API
+==========
+
+Create an implementation of :class:`openfl.component.aggregation_functions.AggregationFunctionInterface`
 and pass it as ``tasks.{task_name}.aggregation_type`` parameter of ``override_config`` keyword argument of :func:`openfl.native.run_experiment` native function.
 
-.. warning::
+CLI
+====
 
-    Currently custom aggregation functions supported in native API (``fx.run_experiment(...)``) only.
-    Command Line Interface always uses FedAvg and this behavior cannot be overriden due to disability of serialization and deserialization of complex Python objects in Plan files.
+Choose from predefined |productName| aggregation functions:
+
+- ``openfl.component.aggregation_functions.WeightedAverage`` (default)
+- ``openfl.component.aggregation_functions.Median``
+- ``openfl.component.aggregation_functions.GeometricMedian``
+Or create your own implementation of :class:`openfl.component.aggregation_functions.AggregationFunctionInterface`.
+After defining the aggregation behavior, you need to include it in ``plan/plan.yaml`` file of your workspace.
+Inside ``tasks`` section pick a task for which you want to change the aggregation
+and insert ``aggregation_type`` section with a single ``template`` key that defines a module path to your class.
+
+Example of ``plan/plan.yaml`` with modified aggregation function:
+  
+.. code-block:: yaml
+
+  # ...
+  # other top-level sections
+  # ...
+  tasks:
+    aggregated_model_validation:
+      function: validate
+      kwargs:
+        apply: global
+        metrics:
+        - acc
+    defaults: plan/defaults/tasks_torch.yaml
+    locally_tuned_model_validation:
+      function: validate
+      kwargs:
+      apply: local
+      metrics:
+      - acc
+    settings: {}
+    train:
+      function: train_batches
+      aggregation_type:
+        template: openfl.component.aggregation_functions.Median  
+      kwargs:
+        metrics:
+        - loss
 
 ``AggregationFunctionInterface`` requires a single ``call`` function.
 This function receives tensors for a single parameter from multiple collaborators with additional metadata (see definition of :meth:`openfl.component.aggregation_functions.AggregationFunctionInterface.call`) and returns a single tensor that represents the result of aggregation.
@@ -26,7 +70,7 @@ This function receives tensors for a single parameter from multiple collaborator
 Example
 =======================
 
-Below is an example of custom tensor clipping aggregation function that multiplies all local tensors by 0.3 and averages them according to weights equal to data parts to produce the resulting global tensor.
+Below is an example of a custom tensor clipping aggregation function that multiplies all local tensors by 0.3 and averages them according to weights equal to data parts to produce the resulting global tensor.
 
 .. code-block:: python
 

--- a/openfl-tutorials/Federated_Pytorch_MNIST_custom_aggregation_Tutorial.ipynb
+++ b/openfl-tutorials/Federated_Pytorch_MNIST_custom_aggregation_Tutorial.ipynb
@@ -373,8 +373,8 @@
     "        if not selected_tensors:\n",
     "            if self.logged_round < fl_round:\n",
     "                fx.logger.warning('No collaborators match threshold condition. Performing simple averaging...')\n",
-    "            selected_tensors = [local_tensor.tensor for tensor in local_tensors]\n",
-    "            selected_weights = [local_tensor.weight for tensor in local_tensors]\n",
+    "            selected_tensors = [local_tensor.tensor for local_tensor in local_tensors]\n",
+    "            selected_weights = [local_tensor.weight for local_tensor in local_tensors]\n",
     "        if self.logged_round < fl_round:\n",
     "            self.logged_round += 1\n",
     "        return np.average(selected_tensors, weights=selected_weights, axis=0)"

--- a/openfl-tutorials/Federated_Pytorch_MNIST_custom_aggregation_Tutorial.ipynb
+++ b/openfl-tutorials/Federated_Pytorch_MNIST_custom_aggregation_Tutorial.ipynb
@@ -245,8 +245,6 @@
     "        tensors, weights = zip(*[(x.tensor, x.weight) for x in local_tensors])\n",
     "        tensors, weights = np.array(tensors), np.array(weights)\n",
     "        average = np.average(tensors, weights=weights, axis=0)\n",
-    "        if 'metric' in tags:\n",
-    "            return average\n",
     "        previous_tensor_values = []\n",
     "        for record in db_iterator:\n",
     "            if (\n",

--- a/openfl/component/aggregation_functions/interface.py
+++ b/openfl/component/aggregation_functions/interface.py
@@ -2,14 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 """Aggregation function interface module."""
 from typing import Iterator, Tuple, List
-from openfl.utilities import LocalTensor
+from openfl.utilities import LocalTensor, SingletonABCMeta
 import numpy as np
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 
 import pandas as pd
 
 
-class AggregationFunctionInterface(ABC):
+class AggregationFunctionInterface(metaclass=SingletonABCMeta):
     """Interface for specifying aggregation function."""
 
     @abstractmethod

--- a/openfl/component/aggregation_functions/weighted_average.py
+++ b/openfl/component/aggregation_functions/weighted_average.py
@@ -5,7 +5,6 @@
 
 from .interface import AggregationFunctionInterface
 import numpy as np
-from openfl.utilities import Singleton
 
 
 def weighted_average(tensors, weights):
@@ -13,7 +12,7 @@ def weighted_average(tensors, weights):
     return np.average(tensors, weights=weights, axis=0)
 
 
-class WeightedAverage(AggregationFunctionInterface, Singleton):
+class WeightedAverage(AggregationFunctionInterface):
     """Weighted average aggregation."""
 
     def call(self, local_tensors, *_):

--- a/openfl/component/aggregation_functions/weighted_average.py
+++ b/openfl/component/aggregation_functions/weighted_average.py
@@ -15,6 +15,15 @@ def weighted_average(tensors, weights):
 class WeightedAverage(AggregationFunctionInterface):
     """Weighted average aggregation."""
 
+    _instance = None
+
+    def __new__(cls, *args, **kwargs):
+        """Use the singleton instance if it has already been created."""
+        if not isinstance(cls._instance, cls):
+            cls._instance = object.__new__(cls, *args, **kwargs)
+
+        return cls._instance
+
     def call(self, local_tensors, *_):
         """Aggregate tensors.
 

--- a/openfl/component/aggregation_functions/weighted_average.py
+++ b/openfl/component/aggregation_functions/weighted_average.py
@@ -5,6 +5,7 @@
 
 from .interface import AggregationFunctionInterface
 import numpy as np
+from openfl.utilities import Singleton
 
 
 def weighted_average(tensors, weights):
@@ -12,17 +13,8 @@ def weighted_average(tensors, weights):
     return np.average(tensors, weights=weights, axis=0)
 
 
-class WeightedAverage(AggregationFunctionInterface):
+class WeightedAverage(AggregationFunctionInterface, Singleton):
     """Weighted average aggregation."""
-
-    _instance = None
-
-    def __new__(cls, *args, **kwargs):
-        """Use the singleton instance if it has already been created."""
-        if not isinstance(cls._instance, cls):
-            cls._instance = object.__new__(cls, *args, **kwargs)
-
-        return cls._instance
 
     def call(self, local_tensors, *_):
         """Aggregate tensors.

--- a/openfl/databases/tensor_db.py
+++ b/openfl/databases/tensor_db.py
@@ -101,7 +101,7 @@ class TensorDB:
         return np.array(df['nparray'].iloc[0])
 
     def get_aggregated_tensor(self, tensor_key, collaborator_weight_dict,
-                              aggregation_function=None):
+                              aggregation_function):
         """
         Determine whether all of the collaborator tensors are present for a given tensor key.
 

--- a/openfl/databases/tensor_db.py
+++ b/openfl/databases/tensor_db.py
@@ -9,8 +9,6 @@ import numpy as np
 from threading import Lock
 
 from openfl.utilities import TensorKey, LocalTensor
-from openfl.component.aggregation_functions import (WeightedAverage, Median, GeometricMedian,
-                                                    AggregationFunctionInterface)
 
 
 class TensorDB:
@@ -21,12 +19,6 @@ class TensorDB:
     for it's easy insertion, retreival and aggregation capabilities. Each
     collaborator and aggregator has its own TensorDB.
     """
-
-    aggregation_fns = {
-        'weighted_average': WeightedAverage(),
-        'median': Median(),
-        'geometric_median': GeometricMedian()
-    }
 
     def __init__(self):
         """Initialize."""
@@ -129,17 +121,6 @@ class TensorDB:
             None if not all values are present
 
         """
-        if aggregation_function is None:
-            aggregation_function = 'weighted_average'
-        if aggregation_function in self.aggregation_fns:
-            aggregation_function = self.aggregation_fns[aggregation_function]
-        elif not isinstance(aggregation_function, AggregationFunctionInterface):
-            raise NotImplementedError(
-                'Aggregation function should either '
-                + f'implement {AggregationFunctionInterface.__name__} interface '
-                + 'or be one of '
-                + f'{list(TensorDB.aggregation_fns.keys())}')
-
         if len(collaborator_weight_dict) != 0:
             assert (np.abs(
                 1.0 - sum(collaborator_weight_dict.values())

--- a/openfl/databases/tensor_db.py
+++ b/openfl/databases/tensor_db.py
@@ -9,6 +9,7 @@ import numpy as np
 from threading import Lock
 
 from openfl.utilities import TensorKey, LocalTensor
+from openfl.component.aggregation_functions import WeightedAverage
 
 
 class TensorDB:
@@ -170,6 +171,8 @@ class TensorDB:
                          for col_name in collaborator_names]
 
         db_iterator = self._iterate()
+        if 'metric' in tags:
+            aggregation_function = WeightedAverage()  # force simple averaging for metrics
         agg_nparray = aggregation_function(local_tensors,
                                            db_iterator,
                                            tensor_name,

--- a/openfl/federated/plan/plan.py
+++ b/openfl/federated/plan/plan.py
@@ -268,9 +268,7 @@ class Plan(object):
         tasks = self.config.get('tasks', {})
         tasks.pop(DEFAULTS)
         tasks.pop(SETTINGS)
-        print(f'tasks={tasks}')
         for task in tasks:
-            print(f'task={task}')
             aggregation_type = tasks[task].get('aggregation_type')
             if aggregation_type is None:
                 aggregation_type = WeightedAverage()

--- a/openfl/utilities/types.py
+++ b/openfl/utilities/types.py
@@ -4,6 +4,7 @@
 """openfl common object types."""
 
 from collections import namedtuple
+from abc import ABCMeta
 
 TensorKey = namedtuple('TensorKey', ['tensor_name', 'origin', 'round_number', 'report', 'tags'])
 TaskResultKey = namedtuple('TaskResultKey', ['task_name', 'owner', 'round_number'])
@@ -12,13 +13,13 @@ Metric = namedtuple('Metric', ['name', 'value'])
 LocalTensor = namedtuple('LocalTensor', ['col_name', 'tensor', 'weight'])
 
 
-class Singleton:
+class SingletonABCMeta(ABCMeta):
     """Metaclass for singleton instances."""
 
-    _instance = None
+    _instances = {}
 
-    def __new__(cls, *args, **kwargs):
+    def __call__(cls, *args, **kwargs):
         """Use the singleton instance if it has already been created."""
-        if not cls._instance:
-            cls._instance = object.__new__(cls, *args, **kwargs)
-        return cls._instance
+        if cls not in cls._instances:
+            cls._instances[cls] = super(SingletonABCMeta, cls).__call__(*args, **kwargs)
+        return cls._instances[cls]

--- a/openfl/utilities/types.py
+++ b/openfl/utilities/types.py
@@ -10,3 +10,15 @@ TaskResultKey = namedtuple('TaskResultKey', ['task_name', 'owner', 'round_number
 
 Metric = namedtuple('Metric', ['name', 'value'])
 LocalTensor = namedtuple('LocalTensor', ['col_name', 'tensor', 'weight'])
+
+
+class Singleton:
+    """Metaclass for singleton instances."""
+
+    _instance = None
+
+    def __new__(cls, *args, **kwargs):
+        """Use the singleton instance if it has already been created."""
+        if not cls._instance:
+            cls._instance = object.__new__(cls, *args, **kwargs)
+        return cls._instance

--- a/tests/openfl/databases/test_tensor_db.py
+++ b/tests/openfl/databases/test_tensor_db.py
@@ -8,7 +8,7 @@ import numpy as np
 from openfl.databases.tensor_db import TensorDB
 from openfl.utilities.types import TensorKey
 from openfl.protocols import NamedTensor
-from openfl.component.aggregation_functions import AggregationFunctionInterface
+from openfl.component.aggregation_functions import AggregationFunctionInterface, WeightedAverage
 
 
 @pytest.fixture
@@ -121,7 +121,7 @@ def test_get_aggregated_tensor_directly(nparray, tensor_key):
     )
 
     db.cache_tensor({tensor_key: nparray})
-    agg_nparray, agg_metadata_dict = db.get_aggregated_tensor(tensor_key, {}, None)
+    agg_nparray, agg_metadata_dict = db.get_aggregated_tensor(tensor_key, {}, WeightedAverage())
 
     assert np.array_equal(nparray, agg_nparray)
 
@@ -137,7 +137,7 @@ def test_get_aggregated_tensor_only_col(nparray, tensor_key):
 
     collaborator_weight_dict = {'col1': 0.5, 'col2': 0.5}
     agg_nparray = db.get_aggregated_tensor(
-        tensor_key, collaborator_weight_dict, None)
+        tensor_key, collaborator_weight_dict, WeightedAverage())
 
     assert agg_nparray is None
 
@@ -154,7 +154,7 @@ def test_get_aggregated_tensor(nparray, tensor_key):
 
     collaborator_weight_dict = {'col1': 0.5, 'col2': 0.5}
     agg_nparray, agg_metadata_dict = db.get_aggregated_tensor(
-        tensor_key, collaborator_weight_dict, None)
+        tensor_key, collaborator_weight_dict, WeightedAverage())
 
     assert np.array_equal(nparray, agg_nparray)
 
@@ -167,7 +167,7 @@ def test_get_aggregated_tensor_raise_wrong_weights(nparray, tensor_key):
     collaborator_weight_dict = {'col1': 0.5, 'col2': 0.8}
     with pytest.raises(AssertionError):
         db.get_aggregated_tensor(
-            tensor_key, collaborator_weight_dict, None)
+            tensor_key, collaborator_weight_dict, WeightedAverage())
 
 
 @pytest.fixture
@@ -190,7 +190,7 @@ def test_get_aggregated_tensor_weights(tensor_db):
     collaborator_weight_dict = {'col1': 0.1, 'col2': 0.9}
     tensor_key = TensorKey('tensor_name', 'agg', 0, False, ())
     agg_nparray = tensor_db.get_aggregated_tensor(
-        tensor_key, collaborator_weight_dict, None)
+        tensor_key, collaborator_weight_dict, WeightedAverage())
 
     control_nparray = np.average(
         [np.array([0, 1, 2, 3, 4]), np.array([2, 3, 4, 5, 6])],
@@ -205,7 +205,7 @@ def test_get_aggregated_tensor_error_aggregation_function(tensor_db):
     """Test that get_aggregated_tensor raise error if aggregation function is not callable."""
     collaborator_weight_dict = {'col1': 0.1, 'col2': 0.9}
     tensor_key = TensorKey('tensor_name', 'agg', 0, False, ())
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(TypeError):
         tensor_db.get_aggregated_tensor(
             tensor_key, collaborator_weight_dict, 'fake_agg_function')
 


### PR DESCRIPTION
We need to support the overriding aggregation function in CLI using the plan YAML file. The idea is to specify module paths to pre-defined `AggregationFunctionInterface` implementations in `aggregation_type` section of specific task.

No changes required for Python native API.
/cc @maradionov 