### PR TITLE
Fix DNNL optimization check in Keras notebooks

### DIFF
--- a/openfl-tutorials/Federated_FedProx_Keras_MNIST_Tutorial.ipynb
+++ b/openfl-tutorials/Federated_FedProx_Keras_MNIST_Tutorial.ipynb
@@ -60,7 +60,7 @@
     "\n",
     "    major_version = int(tf.__version__.split(\".\")[0])\n",
     "    if major_version >= 2:\n",
-    "        from tensorflow.python import _pywrap_util_port\n",
+    "        from tensorflow.python.util import _pywrap_util_port\n",
     "        print(\"Intel-optimizations (DNNL) enabled:\",\n",
     "              _pywrap_util_port.IsMklEnabled())\n",
     "    else:\n",
@@ -369,7 +369,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/openfl-tutorials/Federated_FedProx_Keras_MNIST_Tutorial.ipynb
+++ b/openfl-tutorials/Federated_FedProx_Keras_MNIST_Tutorial.ipynb
@@ -369,7 +369,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/openfl-tutorials/Federated_Keras_MNIST_Tutorial.ipynb
+++ b/openfl-tutorials/Federated_Keras_MNIST_Tutorial.ipynb
@@ -57,7 +57,7 @@
     "\n",
     "    major_version = int(tf.__version__.split(\".\")[0])\n",
     "    if major_version >= 2:\n",
-    "        from tensorflow.python import _pywrap_util_port\n",
+    "        from tensorflow.python.util import _pywrap_util_port\n",
     "        print(\"Intel-optimizations (DNNL) enabled:\",\n",
     "              _pywrap_util_port.IsMklEnabled())\n",
     "    else:\n",
@@ -272,7 +272,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/openfl-tutorials/Federated_Keras_MNIST_Tutorial.ipynb
+++ b/openfl-tutorials/Federated_Keras_MNIST_Tutorial.ipynb
@@ -272,7 +272,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In TensorFlow 2.5 `_pywrap_util_port` function had been moved to another module. This change caused an error in notebooks:

- `openfl-tutorials/Federated_Keras_MNIST_Tutorial.ipynb`
- `openfl-tutorials/Federated_FedProx_Keras_MNIST_Tutorial.ipynb`

## Code cell
```
def test_intel_tensorflow():
    """
    Check if Intel version of TensorFlow is installed
    """
    import tensorflow as tf

    print("We are using Tensorflow version {}".format(tf.__version__))

    major_version = int(tf.__version__.split(".")[0])
    if major_version >= 2:
        from tensorflow.python import _pywrap_util_port
        print("Intel-optimizations (DNNL) enabled:",
              _pywrap_util_port.IsMklEnabled())
    else:
        print("Intel-optimizations (DNNL) enabled:")

test_intel_tensorflow()
```
## Output
```
We are using Tensorflow version 2.5.0
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-4-1f6d4c6d492b> in <module>
     15         print("Intel-optimizations (DNNL) enabled:")
     16 
---> 17 test_intel_tensorflow()

<ipython-input-4-1f6d4c6d492b> in test_intel_tensorflow()
      9     major_version = int(tf.__version__.split(".")[0])
     10     if major_version >= 2:
---> 11         from tensorflow.python import _pywrap_util_port
     12         print("Intel-optimizations (DNNL) enabled:",
     13               _pywrap_util_port.IsMklEnabled())

ImportError: cannot import name '_pywrap_util_port' from 'tensorflow.python' (~/.virtualenvs/openfl/lib/python3.8/site-packages/tensorflow/python/__init__.py)
```