### PR TITLE
Remove redunant assignment

### DIFF
--- a/openfl/transport/grpc/client.py
+++ b/openfl/transport/grpc/client.py
@@ -205,7 +205,7 @@ class CollaboratorGRPCClient:
             uri, credentials, options=self.channel_options)
 
     def _set_header(self, collaborator_name):
-        self.header = self.header = MessageHeader(
+        self.header = MessageHeader(
             sender=collaborator_name,
             receiver=self.aggregator_uuid,
             federation_uuid=self.federation_uuid,


### PR DESCRIPTION
Removes redundant assignment of variable to itself. Just saw it while reading the code out of interest. Am I missing something?