### PR TITLE
Exclude OS-specific and local-specific packages to avoid errors

### DIFF
--- a/openfl/interface/interactive_api/experiment.py
+++ b/openfl/interface/interactive_api/experiment.py
@@ -183,7 +183,10 @@ class FLExperiment:
         requirements_generator = freeze.freeze()
 
         def is_package_has_version(package: str) -> bool:
-            return '==' in package and package != 'pkg-resources==0.0.0'
+            return ('==' in package
+                    and package not in ['pkg-resources==0.0.0', 'pkg_resources==0.0.0']
+                    and '-e ' not in package
+                    )
 
         with open('./requirements.txt', 'w') as f:
             for pack in requirements_generator:


### PR DESCRIPTION
Additional exclusion conditions were added when preparing the environment for the experiment:
`pkg_resources==0.0.0` was added in addition to `pkg-recources=0.0.0`. (The pkg_resources module distributed with setuptools and it's not part of openfl environment).
`-e ` was added in addition to `==` to exclude local-specific packages like:
`# Editable install with no version control (openfl==1.1)
-e /home/user/pycharm/openfl`
or
`-e git+https://github.com/intel/openfl.git@aed8452b12d20dcc80bd722336246d679fa41484#egg=openfl`.