### PR TITLE
Fix director server test

### DIFF
--- a/tests/openfl/transport/grpc/test_director_server.py
+++ b/tests/openfl/transport/grpc/test_director_server.py
@@ -45,11 +45,7 @@ def test_fill_certs(insecure_director, secure_director):
         secure_director._fill_certs('.', None, '.')
     with pytest.raises(Exception):
         secure_director._fill_certs(None, '.', '.')
-
-    try:
-        secure_director._fill_certs('.', '.', '.')
-    except Exception as exc:
-        raise AssertionError(f'_fill_certs method raised an exception: {exc}')
+    secure_director._fill_certs('.', '.', '.')
 
 
 def test_get_caller_tls(insecure_director):

--- a/tests/openfl/transport/grpc/test_director_server.py
+++ b/tests/openfl/transport/grpc/test_director_server.py
@@ -40,11 +40,16 @@ def test_fill_certs(insecure_director, secure_director):
     assert isinstance(secure_director.private_key, Path)
     assert isinstance(secure_director.certificate, Path)
     with pytest.raises(Exception):
-        secure_director.test_fill_certs('.', '.', None)
+        secure_director._fill_certs('.', '.', None)
     with pytest.raises(Exception):
-        secure_director.test_fill_certs('.', None, '.')
+        secure_director._fill_certs('.', None, '.')
     with pytest.raises(Exception):
-        secure_director.test_fill_certs(None, '.', '.')
+        secure_director._fill_certs(None, '.', '.')
+    
+    try:
+        secure_director._fill_certs('.', '.', '.')
+    except Exception as exc:
+        assert False, f'_fill_certs method raised an exception: {exc}'
 
 
 def test_get_caller_tls(insecure_director):

--- a/tests/openfl/transport/grpc/test_director_server.py
+++ b/tests/openfl/transport/grpc/test_director_server.py
@@ -45,11 +45,11 @@ def test_fill_certs(insecure_director, secure_director):
         secure_director._fill_certs('.', None, '.')
     with pytest.raises(Exception):
         secure_director._fill_certs(None, '.', '.')
-    
+
     try:
         secure_director._fill_certs('.', '.', '.')
     except Exception as exc:
-        assert False, f'_fill_certs method raised an exception: {exc}'
+        raise AssertionError(f'_fill_certs method raised an exception: {exc}')
 
 
 def test_get_caller_tls(insecure_director):


### PR DESCRIPTION
Problem: test `test_fill_certs` always passed because there is no `test_fill_certs` method in the` DirectorGRPCServer` class and `AttributeError` is raised as required