### PR TITLE
Python3.6 and python3.7 test compatibility

### DIFF
--- a/tests/openfl/communication/test_api_client.py
+++ b/tests/openfl/communication/test_api_client.py
@@ -55,7 +55,7 @@ def test_get_best_model(deconstruct_model_proto, director_client,
 
     request = director_client.stub.GetTrainedModel.call_args
     if sys.version_info < (3, 8):
-        model_type = request[0][0].model_type
+        incoming_model_type = request[0][0].model_type
     else:
-        model_type = request.args[0].model_type
-    assert model_type == getattr(director_pb2.GetTrainedModelRequest, model_type)
+        incoming_model_type = request.args[0].model_type
+    assert incoming_model_type == getattr(director_pb2.GetTrainedModelRequest, model_type)

--- a/tests/openfl/communication/test_api_client.py
+++ b/tests/openfl/communication/test_api_client.py
@@ -55,6 +55,7 @@ def test_get_best_model(deconstruct_model_proto, director_client,
 
     request = director_client.stub.GetTrainedModel.call_args
     if sys.version_info < (3, 8):
-        assert request[0][0].model_type == getattr(director_pb2.GetTrainedModelRequest, model_type)
+        model_type = request[0][0].model_type
     else:
-        assert request.args[0].model_type == getattr(director_pb2.GetTrainedModelRequest, model_type)
+        model_type = request.args[0].model_type
+    assert model_type == getattr(director_pb2.GetTrainedModelRequest, model_type)

--- a/tests/openfl/communication/test_api_client.py
+++ b/tests/openfl/communication/test_api_client.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Derector API's client tests module."""
 
+import sys
 from unittest import mock
 
 import pytest
@@ -53,4 +54,7 @@ def test_get_best_model(deconstruct_model_proto, director_client,
     director_client.stub.GetTrainedModel.assert_called_once()
 
     request = director_client.stub.GetTrainedModel.call_args
-    assert request.args[0].model_type == getattr(director_pb2.GetTrainedModelRequest, model_type)
+    if sys.version_info < (3, 8):
+        assert request[0][0].model_type == getattr(director_pb2.GetTrainedModelRequest, model_type)
+    else:
+        assert request.args[0].model_type == getattr(director_pb2.GetTrainedModelRequest, model_type)

--- a/tests/openfl/communication/test_envoys_client.py
+++ b/tests/openfl/communication/test_envoys_client.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Derector Envoy's client tests module."""
 
+import sys
 from unittest import mock
 
 import pytest
@@ -43,7 +44,10 @@ def test_report_shard_info(director_client):
     director_client.report_shard_info(shard_descriptor)
 
     director_client.stub.AcknowledgeShard.assert_called_once()
-    shard_info = director_client.stub.AcknowledgeShard.call_args.args[0]
+    if sys.version_info < (3, 8):
+        shard_info = director_client.stub.AcknowledgeShard.call_args[0][0]
+    else:
+        shard_info = director_client.stub.AcknowledgeShard.call_args.args[0]
     assert shard_info.shard_description == shard_descriptor.dataset_description
     assert shard_info.n_samples == 10
     assert shard_info.sample_shape == shard_descriptor.sample_shape


### PR DESCRIPTION
unittest mock has different version for python3.6, 3.7 and 3.8. Since python3.8 mock class has some changes without backward compatibility.