### PR TITLE
Exclude path traversal from cli for internal paths

### DIFF
--- a/openfl/interface/aggregator.py
+++ b/openfl/interface/aggregator.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Aggregator module."""
 
+import sys
 from logging import getLogger
 
 from click import echo
@@ -12,6 +13,7 @@ from click import Path as ClickPath
 from click import style
 
 from openfl.utilities import click_types
+from openfl.utilities.path_check import is_directory_traversal
 from openfl.utilities.utils import getfqdn_env
 
 logger = getLogger(__name__)
@@ -39,6 +41,13 @@ def start_(plan, authorized_cols, secure):
     from pathlib import Path
 
     from openfl.federated import Plan
+
+    if is_directory_traversal(plan):
+        echo('Federated learning plan path is out of the openfl workspace scope.')
+        sys.exit(1)
+    if is_directory_traversal(authorized_cols):
+        echo('Authorized collaborator list file path is out of the openfl workspace scope.')
+        sys.exit(1)
 
     plan = Plan.parse(plan_config_path=Path(plan).absolute(),
                       cols_config_path=Path(authorized_cols).absolute())

--- a/openfl/interface/collaborator.py
+++ b/openfl/interface/collaborator.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Collaborator module."""
 
+import sys
 from logging import getLogger
 
 from click import echo
@@ -10,6 +11,8 @@ from click import option
 from click import pass_context
 from click import Path as ClickPath
 from click import style
+
+from openfl.utilities.path_check import is_directory_traversal
 
 logger = getLogger(__name__)
 
@@ -39,6 +42,13 @@ def start_(plan, collaborator_name, data_config, secure):
 
     from openfl.federated import Plan
 
+    if plan and is_directory_traversal(plan):
+        echo('Federated learning plan path is out of the openfl workspace scope.')
+        sys.exit(1)
+    if data_config and is_directory_traversal(data_config):
+        echo('The data set/shard configuration file path is out of the openfl workspace scope.')
+        sys.exit(1)
+
     plan = Plan.parse(plan_config_path=Path(plan).absolute(),
                       data_config_path=Path(data_config).absolute())
 
@@ -60,6 +70,10 @@ def register_data_path(collaborator_name, data_path=None, silent=False):
     """
     from click import prompt
     from os.path import isfile
+
+    if data_path and is_directory_traversal(data_path):
+        echo('Data path is out of the openfl workspace scope.')
+        sys.exit(1)
 
     # Ask for the data directory
     default_data_path = f'data/{collaborator_name}'
@@ -105,6 +119,9 @@ def register_data_path(collaborator_name, data_path=None, silent=False):
 def generate_cert_request_(collaborator_name,
                            data_path, silent, skip_package):
     """Generate certificate request for the collaborator."""
+    if data_path and is_directory_traversal(data_path):
+        echo('Data path is out of the openfl workspace scope.')
+        sys.exit(1)
     generate_cert_request(collaborator_name, data_path, silent, skip_package)
 
 

--- a/openfl/interface/director.py
+++ b/openfl/interface/director.py
@@ -17,6 +17,7 @@ from yaml import safe_load
 from openfl.component.director import Director
 from openfl.interface.cli_helper import WORKSPACE
 from openfl.transport import DirectorGRPCServer
+from openfl.utilities.path_check import is_directory_traversal
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +47,9 @@ def start(director_config_path, tls, root_certificate, private_key, certificate)
     """Start the director service."""
     director_config_path = Path(director_config_path).absolute()
     logger.info('🧿 Starting the Director Service.')
+    if is_directory_traversal(director_config_path):
+        click.echo('The director config file path is out of the openfl workspace scope.')
+        sys.exit(1)
     with open(director_config_path) as stream:
         director_config = safe_load(stream)
     settings = director_config.get('settings', {})
@@ -91,6 +95,9 @@ def start(director_config_path, tls, root_certificate, private_key, certificate)
         help='The director path', type=ClickPath())
 def create(director_path):
     """Create a director workspace."""
+    if is_directory_traversal(director_path):
+        click.echo('The director path is out of the openfl workspace scope.')
+        sys.exit(1)
     director_path = Path(director_path).absolute()
     if director_path.exists():
         if not click.confirm('Director workspace already exists. Recreate?', default=True):

--- a/openfl/interface/envoy.py
+++ b/openfl/interface/envoy.py
@@ -18,7 +18,7 @@ from yaml import safe_load
 from openfl.component.envoy.envoy import Envoy
 from openfl.interface.cli_helper import WORKSPACE
 from openfl.utilities import click_types
-
+from openfl.utilities.path_check import is_directory_traversal
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +51,9 @@ def start_(shard_name, director_host, director_port, tls, shard_config_path,
            root_certificate, private_key, certificate):
     """Start the Envoy."""
     logger.info('🧿 Starting the Envoy.')
+    if is_directory_traversal(shard_config_path):
+        click.echo('The shard config path is out of the openfl workspace scope.')
+        sys.exit(1)
 
     shard_config_path = Path(shard_config_path).absolute()
     if root_certificate:
@@ -80,6 +83,9 @@ def start_(shard_name, director_host, director_port, tls, shard_config_path,
         help='The Envoy path', type=ClickPath())
 def create(envoy_path):
     """Create an envoy workspace."""
+    if is_directory_traversal(envoy_path):
+        click.echo('The Envoy path is out of the openfl workspace scope.')
+        sys.exit(1)
     envoy_path = Path(envoy_path).absolute()
     if envoy_path.exists():
         if not click.confirm('Envoy workspace already exists. Recreate?',

--- a/openfl/interface/plan.py
+++ b/openfl/interface/plan.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Plan module."""
 
+import sys
 from logging import getLogger
 
 from click import echo
@@ -9,6 +10,8 @@ from click import group
 from click import option
 from click import pass_context
 from click import Path as ClickPath
+
+from openfl.utilities.path_check import is_directory_traversal
 
 logger = getLogger(__name__)
 
@@ -49,6 +52,11 @@ def initialize(context, plan_config, cols_config, data_config,
     from openfl.protocols import utils
     from openfl.utilities import split_tensor_dict_for_holdouts
     from openfl.utilities.utils import getfqdn_env
+
+    for p in [plan_config, cols_config, data_config]:
+        if is_directory_traversal(p):
+            echo(f'{p} is out of the openfl workspace scope.')
+            sys.exit(1)
 
     plan_config = Path(plan_config).absolute()
     cols_config = Path(cols_config).absolute()
@@ -145,6 +153,9 @@ def freeze(plan_config):
     Create a new plan file that embeds its hash in the file name
     (plan.yaml -> plan_{hash}.yaml) and changes the permissions to read only
     """
+    if is_directory_traversal(plan_config):
+        echo('Plan config path is out of the openfl workspace scope.')
+        sys.exit(1)
     freeze_plan(plan_config)
 
 

--- a/openfl/interface/workspace.py
+++ b/openfl/interface/workspace.py
@@ -187,10 +187,6 @@ def import_(archive):
     from subprocess import check_call
     from sys import executable
 
-    if is_directory_traversal(archive):
-        echo('Archive path is out of the openfl workspace scope.')
-        sys.exit(1)
-
     archive = Path(archive).absolute()
 
     dir_path = basename(archive).split('.')[0]

--- a/openfl/interface/workspace.py
+++ b/openfl/interface/workspace.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Workspace module."""
 
+import sys
 from pathlib import Path
 
 from click import Choice
@@ -11,6 +12,8 @@ from click import group
 from click import option
 from click import pass_context
 from click import Path as ClickPath
+
+from openfl.utilities.path_check import is_directory_traversal
 
 
 @group()
@@ -65,6 +68,9 @@ def get_templates():
 @option('--template', required=True, type=Choice(get_templates()))
 def create_(prefix, template):
     """Create the workspace."""
+    if is_directory_traversal(prefix):
+        echo('Workspace name or path is out of the openfl workspace scope.')
+        sys.exit(1)
     create(prefix, template)
 
 
@@ -180,6 +186,10 @@ def import_(archive):
     from shutil import unpack_archive
     from subprocess import check_call
     from sys import executable
+
+    if is_directory_traversal(archive):
+        echo('Archive path is out of the openfl workspace scope.')
+        sys.exit(1)
 
     archive = Path(archive).absolute()
 

--- a/openfl/utilities/path_check.py
+++ b/openfl/utilities/path_check.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Union
 
 
-def is_directory_traversal(directory: Union[str, Path]):
+def is_directory_traversal(directory: Union[str, Path]) -> bool:
     """Check if the directory is traversal."""
     cwd = os.path.abspath(os.getcwd())
     requested_path = os.path.relpath(directory, start=cwd)

--- a/openfl/utilities/path_check.py
+++ b/openfl/utilities/path_check.py
@@ -9,7 +9,7 @@ from typing import Union
 
 
 def is_directory_traversal(directory: Union[str, Path]) -> bool:
-    """Check if the directory is traversal."""
+    """Check for directory traversal."""
     cwd = os.path.abspath(os.getcwd())
     requested_path = os.path.relpath(directory, start=cwd)
     requested_path = os.path.abspath(requested_path)

--- a/openfl/utilities/path_check.py
+++ b/openfl/utilities/path_check.py
@@ -1,0 +1,17 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""openfl path checks."""
+
+import os
+from pathlib import Path
+from typing import Union
+
+
+def is_directory_traversal(directory: Union[str, Path]):
+    """Check if the directory is traversal."""
+    cwd = os.path.abspath(os.getcwd())
+    requested_path = os.path.relpath(directory, start=cwd)
+    requested_path = os.path.abspath(requested_path)
+    common_prefix = os.path.commonprefix([requested_path, cwd])
+    return common_prefix != cwd

--- a/tests/openfl/utilities/__init__.py
+++ b/tests/openfl/utilities/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""tests.openfl.utilities package."""

--- a/tests/openfl/utilities/path_check.py
+++ b/tests/openfl/utilities/path_check.py
@@ -21,5 +21,5 @@ from openfl.utilities.path_check import is_directory_traversal
         ('../../file', True),
     ])
 def test_is_directory_traversal(directory, expected_result):
-    """Test that is_directory_traversal works correctly."""
+    """Test that is_directory_traversal works."""
     assert is_directory_traversal(directory) is expected_result

--- a/tests/openfl/utilities/path_check.py
+++ b/tests/openfl/utilities/path_check.py
@@ -21,5 +21,5 @@ from openfl.utilities.path_check import is_directory_traversal
         ('../../file', True),
     ])
 def test_is_directory_traversal(directory, expected_result):
-    """Test that is_directory_traversal works."""
+    """Test that is_directory_traversal works correctly."""
     assert is_directory_traversal(directory) is expected_result

--- a/tests/openfl/utilities/path_check.py
+++ b/tests/openfl/utilities/path_check.py
@@ -21,5 +21,5 @@ from openfl.utilities.path_check import is_directory_traversal
         ('../../file', True),
     ])
 def test_is_directory_traversal(directory, expected_result):
-    """Test that si_directory_traversal works."""
+    """Test that is_directory_traversal works."""
     assert is_directory_traversal(directory) is expected_result

--- a/tests/openfl/utilities/path_check.py
+++ b/tests/openfl/utilities/path_check.py
@@ -17,6 +17,12 @@ from openfl.utilities.path_check import is_directory_traversal
         (os.getcwd(), False),
         (Path(os.getcwd(), 'first_level'), False),
         (Path(os.getcwd(), 'first_level/second_level'), False),
+        ('first_level/second_level/..', False),
+        ('first_level/../first_level', False),
+        ('..', True),
+        ('../../file', True),
+        ('/home/naive_hacker', True),
+        ('first_level/second_level/../../..', True),
         ('..', True),
         ('../../file', True),
     ])

--- a/tests/openfl/utilities/path_check.py
+++ b/tests/openfl/utilities/path_check.py
@@ -1,0 +1,25 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Path checks tests module."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from openfl.utilities.path_check import is_directory_traversal
+
+
+@pytest.mark.parametrize(
+    'directory,expected_result', [
+        ('first_level', False),
+        ('first_level/second_level', False),
+        (os.getcwd(), False),
+        (Path(os.getcwd(), 'first_level'), False),
+        (Path(os.getcwd(), 'first_level/second_level'), False),
+        ('..', True),
+        ('../../file', True),
+    ])
+def test_is_directory_traversal(directory, expected_result):
+    """Test that si_directory_traversal works."""
+    assert is_directory_traversal(directory) is expected_result


### PR DESCRIPTION
Checking that the internal paths obtained through the cli are not outside the openfl directory.
It does not apply to paths with certificate or external configuration.
