### PR TITLE
Preload datasets for CI workspaces

### DIFF
--- a/openfl-workspace/fe_tf_adversarial_cifar/plan/plan.yaml
+++ b/openfl-workspace/fe_tf_adversarial_cifar/plan/plan.yaml
@@ -24,6 +24,7 @@ data_loader :
     collaborator_count : 2
     data_group_name    : cifar
     batch_size         : 32
+    data_dir           : ~/.openfl/data
 
 task_runner :
   defaults : plan/defaults/task_runner.yaml

--- a/openfl-workspace/fe_tf_adversarial_cifar/src/fecifar_inmemory.py
+++ b/openfl-workspace/fe_tf_adversarial_cifar/src/fecifar_inmemory.py
@@ -5,7 +5,6 @@
 
 import os
 from pathlib import Path
-from typing import Tuple
 
 import fastestimator as fe
 import numpy as np
@@ -18,7 +17,7 @@ from tensorflow.python.keras.utils.data_utils import get_file
 from openfl.federated import FastEstimatorDataLoader
 
 
-def load_data(cache_dir, image_key: str = 'x', label_key: str = 'y') -> Tuple[NumpyDataset, NumpyDataset]:
+def load_data(cache_dir, image_key: str = 'x', label_key: str = 'y'):
     """Load and return the CIFAR10 dataset.
 
     Args:

--- a/openfl-workspace/fe_tf_adversarial_cifar/src/fecifar_inmemory.py
+++ b/openfl-workspace/fe_tf_adversarial_cifar/src/fecifar_inmemory.py
@@ -3,17 +3,72 @@
 
 """You may copy this file as the starting point of your own model."""
 
+import os
+from pathlib import Path
+from typing import Tuple
+
 import fastestimator as fe
-from fastestimator.dataset.data import cifar10
+import numpy as np
+import tensorflow.keras.backend as K
+from fastestimator.dataset import NumpyDataset
 from fastestimator.op.numpyop.univariate import Normalize
+from tensorflow.python.keras.datasets.cifar import load_batch
+from tensorflow.python.keras.utils.data_utils import get_file
 
 from openfl.federated import FastEstimatorDataLoader
+
+
+def load_data(cache_dir, image_key: str = 'x', label_key: str = 'y') -> Tuple[NumpyDataset, NumpyDataset]:
+    """Load and return the CIFAR10 dataset.
+
+    Args:
+        image_key: The key for image.
+        label_key: The key for label.
+
+    Returns:
+        (train_data, eval_data)
+    """
+    cache_subdir = Path(cache_dir).expanduser().absolute()
+    dirname = 'cifar-10-batches-py'
+    origin = 'https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz'
+    path = get_file(
+        dirname,
+        origin=origin,
+        untar=True,
+        file_hash='6d958be074577803d12ecdefd02955f39262c83c16fe9348329d7fe0b5c001ce',
+        cache_subdir=cache_subdir)
+
+    num_train_samples = 50000
+
+    x_train = np.empty((num_train_samples, 3, 32, 32), dtype='uint8')
+    y_train = np.empty((num_train_samples,), dtype='uint8')
+
+    for i in range(1, 6):
+        fpath = os.path.join(path, 'data_batch_' + str(i))
+        (x_train[(i - 1) * 10000:i * 10000, :, :, :],
+         y_train[(i - 1) * 10000:i * 10000]) = load_batch(fpath)
+
+    fpath = os.path.join(path, 'test_batch')
+    x_test, y_test = load_batch(fpath)
+
+    y_train = np.reshape(y_train, (len(y_train), 1))
+    y_test = np.reshape(y_test, (len(y_test), 1))
+
+    if K.image_data_format() == 'channels_last':
+        x_train = x_train.transpose(0, 2, 3, 1)
+        x_test = x_test.transpose(0, 2, 3, 1)
+
+    x_test = x_test.astype(x_train.dtype)
+    y_test = y_test.astype(y_train.dtype)
+    train_data = NumpyDataset({image_key: x_train, label_key: y_train})
+    eval_data = NumpyDataset({image_key: x_test, label_key: y_test})
+    return train_data, eval_data
 
 
 class FastEstimatorCifarInMemory(FastEstimatorDataLoader):
     """TensorFlow Data Loader for MNIST Dataset."""
 
-    def __init__(self, data_path, batch_size, **kwargs):
+    def __init__(self, data_path, batch_size, data_dir, **kwargs):
         """
         Initialize.
 
@@ -29,7 +84,7 @@ class FastEstimatorCifarInMemory(FastEstimatorDataLoader):
         # Then we have a way to automatically shard based on rank and size
         # of collaborator list.
 
-        train_data, eval_data = cifar10.load_data()
+        train_data, eval_data = load_data(data_dir)
         test_data = eval_data.split(0.5)
 
         collaborator_count = kwargs['collaborator_count']

--- a/openfl-workspace/fe_torch_adversarial_cifar/plan/plan.yaml
+++ b/openfl-workspace/fe_torch_adversarial_cifar/plan/plan.yaml
@@ -24,6 +24,7 @@ data_loader :
     collaborator_count : 2
     data_group_name    : cifar
     batch_size         : 32
+    data_dir           : ~/.openfl/data
 
 task_runner :
   defaults : plan/defaults/task_runner.yaml

--- a/openfl-workspace/fe_torch_adversarial_cifar/src/fecifar_inmemory.py
+++ b/openfl-workspace/fe_torch_adversarial_cifar/src/fecifar_inmemory.py
@@ -3,18 +3,73 @@
 
 """You may copy this file as the starting point of your own model."""
 
+import os
+from pathlib import Path
+from typing import Tuple
+
 import fastestimator as fe
-from fastestimator.dataset.data import cifar10
+import numpy as np
+import tensorflow.keras.backend as K
+from fastestimator.dataset import NumpyDataset
 from fastestimator.op.numpyop.univariate import ChannelTranspose
 from fastestimator.op.numpyop.univariate import Normalize
+from tensorflow.python.keras.datasets.cifar import load_batch
+from tensorflow.python.keras.utils.data_utils import get_file
 
 from openfl.federated import FastEstimatorDataLoader
+
+
+def load_data(cache_dir, image_key: str = 'x', label_key: str = 'y') -> Tuple[NumpyDataset, NumpyDataset]:
+    """Load and return the CIFAR10 dataset.
+
+    Args:
+        image_key: The key for image.
+        label_key: The key for label.
+
+    Returns:
+        (train_data, eval_data)
+    """
+    cache_subdir = Path(cache_dir).expanduser().absolute()
+    dirname = 'cifar-10-batches-py'
+    origin = 'https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz'
+    path = get_file(
+        dirname,
+        origin=origin,
+        untar=True,
+        file_hash='6d958be074577803d12ecdefd02955f39262c83c16fe9348329d7fe0b5c001ce',
+        cache_subdir=cache_subdir)
+
+    num_train_samples = 50000
+
+    x_train = np.empty((num_train_samples, 3, 32, 32), dtype='uint8')
+    y_train = np.empty((num_train_samples,), dtype='uint8')
+
+    for i in range(1, 6):
+        fpath = os.path.join(path, 'data_batch_' + str(i))
+        (x_train[(i - 1) * 10000:i * 10000, :, :, :],
+         y_train[(i - 1) * 10000:i * 10000]) = load_batch(fpath)
+
+    fpath = os.path.join(path, 'test_batch')
+    x_test, y_test = load_batch(fpath)
+
+    y_train = np.reshape(y_train, (len(y_train), 1))
+    y_test = np.reshape(y_test, (len(y_test), 1))
+
+    if K.image_data_format() == 'channels_last':
+        x_train = x_train.transpose(0, 2, 3, 1)
+        x_test = x_test.transpose(0, 2, 3, 1)
+
+    x_test = x_test.astype(x_train.dtype)
+    y_test = y_test.astype(y_train.dtype)
+    train_data = NumpyDataset({image_key: x_train, label_key: y_train})
+    eval_data = NumpyDataset({image_key: x_test, label_key: y_test})
+    return train_data, eval_data
 
 
 class FastEstimatorCifarInMemory(FastEstimatorDataLoader):
     """TensorFlow Data Loader for MNIST Dataset."""
 
-    def __init__(self, data_path, batch_size, collaborator_count, **kwargs):
+    def __init__(self, data_path, batch_size, collaborator_count, data_dir, **kwargs):
         """
         Initialize.
 
@@ -29,7 +84,7 @@ class FastEstimatorCifarInMemory(FastEstimatorDataLoader):
         # Then we have a way to automatically shard based on rank and size of
         # collaborator list.
 
-        train_data, eval_data = cifar10.load_data()
+        train_data, eval_data = load_data(data_dir)
         test_data = eval_data.split(0.5)
 
         train_data, eval_data, test_data = self.split_data(

--- a/openfl-workspace/fe_torch_adversarial_cifar/src/fecifar_inmemory.py
+++ b/openfl-workspace/fe_torch_adversarial_cifar/src/fecifar_inmemory.py
@@ -5,7 +5,7 @@
 
 import os
 from pathlib import Path
-from typing import Tuple
+
 
 import fastestimator as fe
 import numpy as np
@@ -19,7 +19,7 @@ from tensorflow.python.keras.utils.data_utils import get_file
 from openfl.federated import FastEstimatorDataLoader
 
 
-def load_data(cache_dir, image_key: str = 'x', label_key: str = 'y') -> Tuple[NumpyDataset, NumpyDataset]:
+def load_data(cache_dir, image_key: str = 'x', label_key: str = 'y'):
     """Load and return the CIFAR10 dataset.
 
     Args:

--- a/openfl-workspace/keras_cnn_mnist/plan/plan.yaml
+++ b/openfl-workspace/keras_cnn_mnist/plan/plan.yaml
@@ -24,6 +24,7 @@ data_loader :
     collaborator_count : 2
     data_group_name    : mnist
     batch_size         : 256
+    data_dir           : ~/.openfl/data
 
 task_runner :
   defaults : plan/defaults/task_runner.yaml

--- a/openfl-workspace/keras_cnn_mnist/src/mnist_utils.py
+++ b/openfl-workspace/keras_cnn_mnist/src/mnist_utils.py
@@ -5,14 +5,15 @@
 
 from logging import getLogger
 from pathlib import Path
-from tensorflow.python.keras.utils.data_utils import get_file
 
 import numpy as np
+from tensorflow.python.keras.utils.data_utils import get_file
 
 logger = getLogger(__name__)
 
 
 def load_data(path='mnist.npz', cache_dir='~/.openfl/data'):
+    """Download MNIST dataset."""
     cache_dir = Path(cache_dir).expanduser().absolute()
     origin_folder = 'https://storage.googleapis.com/tensorflow/tf-keras-datasets/'
     path = get_file(
@@ -55,7 +56,7 @@ def _load_raw_datashards(shard_num, collaborator_count, data_dir):
         2 tuples: (image, label) of the training, validation dataset
     """
     (x_train, y_train), (x_test, y_test) = load_data(cache_dir=data_dir)
-    
+
     # create the shards
     shard_num = int(shard_num)
     X_train = x_train[shard_num::collaborator_count]

--- a/openfl-workspace/keras_cnn_mnist/src/tfmnist_inmemory.py
+++ b/openfl-workspace/keras_cnn_mnist/src/tfmnist_inmemory.py
@@ -10,7 +10,7 @@ from .mnist_utils import load_mnist_shard
 class TensorFlowMNISTInMemory(TensorFlowDataLoader):
     """TensorFlow Data Loader for MNIST Dataset."""
 
-    def __init__(self, data_path, batch_size, **kwargs):
+    def __init__(self, data_path, batch_size, data_dir, **kwargs):
         """
         Initialize.
 
@@ -28,7 +28,7 @@ class TensorFlowMNISTInMemory(TensorFlowDataLoader):
         # collaborator list.
 
         _, num_classes, X_train, y_train, X_valid, y_valid = load_mnist_shard(
-            shard_num=int(data_path), **kwargs
+            shard_num=int(data_path), data_dir=data_dir, **kwargs
         )
 
         self.X_train = X_train

--- a/openfl-workspace/keras_cnn_with_compression/plan/plan.yaml
+++ b/openfl-workspace/keras_cnn_with_compression/plan/plan.yaml
@@ -26,6 +26,7 @@ data_loader :
     collaborator_count : 2
     data_group_name    : mnist
     batch_size         : 256
+    data_dir           : ~/.openfl/data
 
 task_runner :
   defaults : plan/defaults/task_runner.yaml

--- a/openfl-workspace/keras_cnn_with_compression/src/mnist_utils.py
+++ b/openfl-workspace/keras_cnn_with_compression/src/mnist_utils.py
@@ -4,6 +4,7 @@
 """You may copy this file as the starting point of your own model."""
 
 from logging import getLogger
+from pathlib import Path
 
 import numpy as np
 from tensorflow.python.keras.utils.data_utils import get_file
@@ -25,7 +26,22 @@ def one_hot(labels, classes):
     return np.eye(classes)[labels]
 
 
-def _load_raw_datashards(shard_num, collaborator_count):
+def load_data(path='mnist.npz', cache_dir='~/.openfl/data'):
+    cache_dir = Path(cache_dir).expanduser().absolute()
+    origin_folder = 'https://storage.googleapis.com/tensorflow/tf-keras-datasets/'
+    path = get_file(
+        path,
+        origin=origin_folder + 'mnist.npz',
+        file_hash='731c5ac602752760c8e48fbffcf8c3b850d9dc2a2aedcf2cc48468fc17b673d1',
+        cache_subdir=cache_dir)
+    with np.load(path, allow_pickle=True) as f:
+        x_train, y_train = f['x_train'], f['y_train']
+        x_test, y_test = f['x_test'], f['y_test']
+
+    return (x_train, y_train), (x_test, y_test)
+
+
+def _load_raw_datashards(data_dir, shard_num, collaborator_count):
     """
     Load the raw data by shard.
 
@@ -38,31 +54,20 @@ def _load_raw_datashards(shard_num, collaborator_count):
     Returns:
         2 tuples: (image, label) of the training, validation dataset
     """
-    origin_folder = 'https://storage.googleapis.com/tensorflow/tf-keras-datasets/'
-    path = get_file('mnist.npz',
-                    origin=origin_folder + 'mnist.npz',
-                    file_hash='731c5ac602752760c8e48fbffcf8c3b850d9dc2a2aedcf2cc48468fc17b673d1')
-
-    with np.load(path) as f:
-        # get all of mnist
-        X_train_tot = f['x_train']
-        y_train_tot = f['y_train']
-
-        X_valid_tot = f['x_test']
-        y_valid_tot = f['y_test']
+    (x_train, y_train), (x_test, y_test) = load_data(cache_dir=data_dir)
 
     # create the shards
     shard_num = int(shard_num)
-    X_train = X_train_tot[shard_num::collaborator_count]
-    y_train = y_train_tot[shard_num::collaborator_count]
+    X_train = x_train[shard_num::collaborator_count]
+    y_train = y_train[shard_num::collaborator_count]
 
-    X_valid = X_valid_tot[shard_num::collaborator_count]
-    y_valid = y_valid_tot[shard_num::collaborator_count]
+    X_valid = x_test[shard_num::collaborator_count]
+    y_valid = y_test[shard_num::collaborator_count]
 
     return (X_train, y_train), (X_valid, y_valid)
 
 
-def load_mnist_shard(shard_num, collaborator_count, categorical=True,
+def load_mnist_shard(shard_num, collaborator_count, data_dir, categorical=True,
                      channels_last=True, **kwargs):
     """
     Load the MNIST dataset.
@@ -88,7 +93,7 @@ def load_mnist_shard(shard_num, collaborator_count, categorical=True,
     num_classes = 10
 
     (X_train, y_train), (X_valid, y_valid) = _load_raw_datashards(
-        shard_num, collaborator_count
+        data_dir, shard_num, collaborator_count
     )
 
     if channels_last:

--- a/openfl-workspace/keras_cnn_with_compression/src/mnist_utils.py
+++ b/openfl-workspace/keras_cnn_with_compression/src/mnist_utils.py
@@ -27,6 +27,7 @@ def one_hot(labels, classes):
 
 
 def load_data(path='mnist.npz', cache_dir='~/.openfl/data'):
+    """Download MNIST dataset."""
     cache_dir = Path(cache_dir).expanduser().absolute()
     origin_folder = 'https://storage.googleapis.com/tensorflow/tf-keras-datasets/'
     path = get_file(

--- a/openfl-workspace/keras_cnn_with_compression/src/tfmnist_inmemory.py
+++ b/openfl-workspace/keras_cnn_with_compression/src/tfmnist_inmemory.py
@@ -10,7 +10,7 @@ from .mnist_utils import load_mnist_shard
 class TensorFlowMNISTInMemory(TensorFlowDataLoader):
     """TensorFlow Data Loader for MNIST Dataset."""
 
-    def __init__(self, data_path, batch_size, **kwargs):
+    def __init__(self, data_path, batch_size, data_dir, **kwargs):
         """
         Initialize.
 
@@ -28,7 +28,7 @@ class TensorFlowMNISTInMemory(TensorFlowDataLoader):
         # collaborator list.
 
         _, num_classes, X_train, y_train, X_valid, y_valid = load_mnist_shard(
-            shard_num=int(data_path), **kwargs
+            shard_num=int(data_path), data_dir=data_dir, **kwargs
         )
 
         self.X_train = X_train

--- a/openfl-workspace/tf_cnn_histology/src/tfds_utils.py
+++ b/openfl-workspace/tf_cnn_histology/src/tfds_utils.py
@@ -38,7 +38,7 @@ def _load_raw_datashards(shard_num, collaborator_count):
     Returns:
         2 tuples: (image, label) of the training, validation dataset
     """
-    (ds), metadata = tfds.load('colorectal_histology', data_dir='.',
+    (ds), metadata = tfds.load('colorectal_histology', data_dir='~/.openfl/data',
                                shuffle_files=False, split='train', batch_size=-1,
                                with_info=True, as_supervised=True)
 

--- a/openfl-workspace/torch_cnn_histology/src/histology_utils.py
+++ b/openfl-workspace/torch_cnn_histology/src/histology_utils.py
@@ -38,6 +38,7 @@ class HistologyDataset(ImageFolder):
         makedirs(root, exist_ok=True)
         filepath = path.join(root, HistologyDataset.FILENAME)
         if not path.exists(filepath):
+            print(f'{filepath} does not exist. Downloading...')
             self.pbar = tqdm(total=None)
             urlretrieve(HistologyDataset.URL, filepath, self.report_hook)  # nosec
             validate_file_hash(filepath, HistologyDataset.ZIP_SHA384)

--- a/openfl-workspace/torch_cnn_mnist/plan/plan.yaml
+++ b/openfl-workspace/torch_cnn_mnist/plan/plan.yaml
@@ -27,6 +27,7 @@ data_loader :
     collaborator_count : 2
     data_group_name    : mnist
     batch_size         : 256
+    data_dir           : ~/.openfl/data # made for CI tests to use preloaded data
 
 task_runner :
   defaults : plan/defaults/task_runner.yaml

--- a/openfl-workspace/torch_cnn_mnist/src/mnist_utils.py
+++ b/openfl-workspace/torch_cnn_mnist/src/mnist_utils.py
@@ -42,7 +42,7 @@ def one_hot(labels, classes):
     return np.eye(classes)[labels]
 
 
-def _load_raw_datashards(shard_num, collaborator_count, transform=None):
+def _load_raw_datashards(shard_num, collaborator_count, data_dir='data', transform=None):
     """
     Load the raw data by shard.
 
@@ -57,7 +57,7 @@ def _load_raw_datashards(shard_num, collaborator_count, transform=None):
         2 tuples: (image, label) of the training, validation dataset
     """
     train_data, val_data = (
-        datasets.MNIST('data', train=train, download=True, transform=transform)
+        datasets.MNIST(data_dir, train=train, download=True, transform=transform)
         for train in (True, False)
     )
     X_train_tot, y_train_tot = train_data.train_data, train_data.train_labels
@@ -74,7 +74,7 @@ def _load_raw_datashards(shard_num, collaborator_count, transform=None):
     return (X_train, y_train), (X_valid, y_valid)
 
 
-def load_mnist_shard(shard_num, collaborator_count,
+def load_mnist_shard(shard_num, collaborator_count, data_dir,
                      categorical=False, channels_last=True, **kwargs):
     """
     Load the MNIST dataset.
@@ -100,7 +100,7 @@ def load_mnist_shard(shard_num, collaborator_count,
     num_classes = 10
 
     (X_train, y_train), (X_valid, y_valid) = _load_raw_datashards(
-        shard_num, collaborator_count, transform=transforms.ToTensor())
+        shard_num, collaborator_count, data_dir=data_dir, transform=transforms.ToTensor())
 
     logger.info(f'MNIST > X_train Shape : {X_train.shape}')
     logger.info(f'MNIST > y_train Shape : {y_train.shape}')

--- a/openfl-workspace/torch_cnn_mnist/src/ptmnist_inmemory.py
+++ b/openfl-workspace/torch_cnn_mnist/src/ptmnist_inmemory.py
@@ -10,7 +10,7 @@ from .mnist_utils import load_mnist_shard
 class PyTorchMNISTInMemory(PyTorchDataLoader):
     """PyTorch data loader for MNIST dataset."""
 
-    def __init__(self, data_path, batch_size, **kwargs):
+    def __init__(self, data_path, batch_size, data_dir, **kwargs):
         """Instantiate the data object.
 
         Args:
@@ -28,7 +28,7 @@ class PyTorchMNISTInMemory(PyTorchDataLoader):
         # of collaborator list.
 
         num_classes, X_train, y_train, X_valid, y_valid = load_mnist_shard(
-            shard_num=int(data_path), **kwargs)
+            shard_num=int(data_path), data_dir=data_dir, **kwargs)
 
         self.X_train = X_train
         self.y_train = y_train

--- a/tests/github/python_native_tf.py
+++ b/tests/github/python_native_tf.py
@@ -3,6 +3,8 @@
 
 """Python native tests."""
 
+from pathlib import Path
+
 import numpy as np
 
 import openfl.native as fx
@@ -90,8 +92,10 @@ if __name__ == '__main__':
     from tensorflow.python.keras.utils.data_utils import get_file
 
     origin_folder = 'https://storage.googleapis.com/tensorflow/tf-keras-datasets/'
+    cache_subdir = Path('~/.openfl/data').expanduser().absolute()
     path = get_file('mnist.npz',
                     origin=origin_folder + 'mnist.npz',
+                    cache_subdir=cache_subdir,
                     file_hash='731c5ac602752760c8e48fbffcf8c3b850d9dc2a2aedcf2cc48468fc17b673d1')
 
     with np.load(path) as f:

--- a/tests/github/python_native_torch.py
+++ b/tests/github/python_native_torch.py
@@ -56,7 +56,7 @@ if __name__ == '__main__':
     transform = transforms.Compose([transforms.ToTensor(),
                                     transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])
 
-    trainset = datasets.MNIST(root='./data', train=True,
+    trainset = datasets.MNIST(root='~/.openfl/data', train=True,
                               download=True, transform=transform)
 
     train_images, train_labels = trainset.train_data, np.array(trainset.train_labels)


### PR DESCRIPTION
Jenkins tests take too much time. The reason could be manual data downloading for every CLI and Python native test.
This PR redirects all tests datasets to `~/.openfl/data` folder.
