### PR TITLE
Fix PyTorch test for Python native API

### DIFF
--- a/openfl-workspace/fe_tf_adversarial_cifar/requirements.txt
+++ b/openfl-workspace/fe_tf_adversarial_cifar/requirements.txt
@@ -1,4 +1,4 @@
-torch>=1.6
+torch==1.6
 tensorflow==2.5.1
 fastestimator==1.1.1
 albumentations==0.5.2

--- a/openfl-workspace/fe_torch_adversarial_cifar/requirements.txt
+++ b/openfl-workspace/fe_torch_adversarial_cifar/requirements.txt
@@ -1,4 +1,4 @@
-torch>=1.6
+torch==1.6
 tensorflow==2.5.1
 fastestimator==1.1.1
 albumentations==0.5.2

--- a/openfl-workspace/torch_cnn_mnist/requirements.txt
+++ b/openfl-workspace/torch_cnn_mnist/requirements.txt
@@ -1,3 +1,3 @@
-torch >= 1.2.0
-torchvision >= 0.9.1
+torch == 1.8.1
+torchvision == 0.9.1
 tensorboard


### PR DESCRIPTION
Latest nightly build failed with an error:
```
Traceback (most recent call last):
04:37:25    File "python_native_torch.py", line 23, in <module>
04:37:25      from torchvision import datasets
04:37:25    File "/usr/local/lib/python3.8/site-packages/torchvision/__init__.py", line 6, in <module>
04:37:25      from torchvision import models
04:37:25    File "/usr/local/lib/python3.8/site-packages/torchvision/models/__init__.py", line 8, in <module>
04:37:25      from .mobilenet import *
04:37:25    File "/usr/local/lib/python3.8/site-packages/torchvision/models/mobilenet.py", line 1, in <module>
04:37:25      from .mobilenetv2 import MobileNetV2, mobilenet_v2, __all__ as mv2_all
04:37:25    File "/usr/local/lib/python3.8/site-packages/torchvision/models/mobilenetv2.py", line 8, in <module>
04:37:25      from ..ops.misc import ConvNormActivation
04:37:25    File "/usr/local/lib/python3.8/site-packages/torchvision/ops/__init__.py", line 12, in <module>
04:37:25      from .stochastic_depth import stochastic_depth, StochasticDepth
04:37:25    File "/usr/local/lib/python3.8/site-packages/torchvision/ops/stochastic_depth.py", line 2, in <module>
04:37:25      import torch.fx
04:37:25    File "/usr/local/lib/python3.8/site-packages/torch/fx/__init__.py", line 83, in <module>
04:37:25      from .graph_module import GraphModule
04:37:25    File "/usr/local/lib/python3.8/site-packages/torch/fx/graph_module.py", line 3, in <module>
04:37:25      import torch.overrides
04:37:25    File "/usr/local/lib/python3.8/site-packages/torch/overrides.py", line 32, in <module>
04:37:25      from torch._C import (
04:37:25  ImportError: cannot import name '_has_torch_function' from 'torch._C' (/usr/local/lib/python3.8/site-packages/torch/_C.cpython-38-x86_64-linux-gnu.so)
```

This happened due to [the latest PyTorch release](https://github.com/pytorch/pytorch/releases/tag/v1.10.0) where API was changed. 
One thing to notice is that `torch_cnn_mnist` workspace, which is the base for the failed native test, was completed successfully. 
It means that installing `torch` and `torchvision` in a separate CLI command works well, but native API uses the old version of torchvision.

This PR pins `torch` and `torchvision` to a fixed version in all workspaces.