### PR TITLE
Remove Python 2 compatible object inheritance

### DIFF
--- a/openfl-tutorials/interactive_api/PyTorch_Market_Re-ID/workspace/tools.py
+++ b/openfl-tutorials/interactive_api/PyTorch_Market_Re-ID/workspace/tools.py
@@ -15,7 +15,7 @@ from torch.utils.data.sampler import Sampler
 logger = getLogger(__name__)
 
 
-class AverageMeter(object):
+class AverageMeter:
     """
     Computes and stores the average and current value.
 

--- a/openfl-tutorials/interactive_api/PyTorch_Market_Re-ID/workspace/transforms.py
+++ b/openfl-tutorials/interactive_api/PyTorch_Market_Re-ID/workspace/transforms.py
@@ -9,7 +9,7 @@ import random
 from PIL import Image
 
 
-class ResizeRandomCropping(object):
+class ResizeRandomCropping:
     """
     With a probability, first increase image size to (1 + 1/8), and then perform random crop.
 
@@ -49,7 +49,7 @@ class ResizeRandomCropping(object):
         return cropped_img
 
 
-class RandomErasing(object):
+class RandomErasing:
     """
     Randomly selects a rectangle region in an image and erases its pixels.
 

--- a/openfl/federated/data/loader.py
+++ b/openfl/federated/data/loader.py
@@ -4,7 +4,7 @@
 """DataLoader module."""
 
 
-class DataLoader(object):
+class DataLoader:
     """Federated Learning Data Loader Class."""
 
     def __init__(self, **kwargs):

--- a/openfl/federated/plan/plan.py
+++ b/openfl/federated/plan/plan.py
@@ -25,7 +25,7 @@ DEFAULTS = 'defaults'
 AUTO = 'auto'
 
 
-class Plan(object):
+class Plan:
     """Federated Learning plan."""
 
     logger = getLogger(__name__)

--- a/openfl/federated/task/runner.py
+++ b/openfl/federated/task/runner.py
@@ -14,7 +14,7 @@ port your own models.
 from logging import getLogger
 
 
-class TaskRunner(object):
+class TaskRunner:
     """Federated Learning Task Runner Class."""
 
     def __init__(self, data_loader, tensor_dict_split_fn_kwargs: dict = None, **kwargs):

--- a/openfl/federated/task/task_runner.py
+++ b/openfl/federated/task/task_runner.py
@@ -10,7 +10,7 @@ from openfl.utilities import split_tensor_dict_for_holdouts
 from openfl.utilities import TensorKey
 
 
-class CoreTaskRunner(object):
+class CoreTaskRunner:
     """Federated Learning Task Runner Class."""
 
     def _prepare_tensorkeys_for_agggregation(self, metric_dict, validation_flag,

--- a/openfl/protocols/director_pb2_grpc.py
+++ b/openfl/protocols/director_pb2_grpc.py
@@ -5,7 +5,7 @@ import grpc
 from . import director_pb2 as director__pb2
 
 
-class FederationDirectorStub(object):
+class FederationDirectorStub:
     """Missing associated documentation comment in .proto file."""
 
     def __init__(self, channel):
@@ -76,7 +76,7 @@ class FederationDirectorStub(object):
                 )
 
 
-class FederationDirectorServicer(object):
+class FederationDirectorServicer:
     """Missing associated documentation comment in .proto file."""
 
     def AcknowledgeShard(self, request, context):
@@ -225,7 +225,7 @@ def add_FederationDirectorServicer_to_server(servicer, server):
 
 
  # This class is part of an EXPERIMENTAL API.
-class FederationDirector(object):
+class FederationDirector:
     """Missing associated documentation comment in .proto file."""
 
     @staticmethod

--- a/openfl/protocols/federation_pb2_grpc.py
+++ b/openfl/protocols/federation_pb2_grpc.py
@@ -5,7 +5,7 @@ import grpc
 from . import federation_pb2 as federation__pb2
 
 
-class AggregatorStub(object):
+class AggregatorStub:
     """Missing associated documentation comment in .proto file."""
 
     def __init__(self, channel):
@@ -31,7 +31,7 @@ class AggregatorStub(object):
                 )
 
 
-class AggregatorServicer(object):
+class AggregatorServicer:
     """Missing associated documentation comment in .proto file."""
 
     def GetTasks(self, request, context):
@@ -77,7 +77,7 @@ def add_AggregatorServicer_to_server(servicer, server):
 
 
  # This class is part of an EXPERIMENTAL API.
-class Aggregator(object):
+class Aggregator:
     """Missing associated documentation comment in .proto file."""
 
     @staticmethod


### PR DESCRIPTION
Replace structures like `class ABC(object):` to simple `class ABC:` since they seem to be useless because we support only Python 3.x (no Python2 compatibility)