### PR TITLE
Fix envoy config in Histology tutorial

### DIFF
--- a/openfl-tutorials/interactive_api/PyTorch_Histology/director/director_config.yaml
+++ b/openfl-tutorials/interactive_api/PyTorch_Histology/director/director_config.yaml
@@ -1,5 +1,5 @@
 settings:
-  listen_addr: localhost
+  listen_host: localhost
   listen_port: 50051
   sample_shape: ['150', '150']
   target_shape: ['1']

--- a/openfl-tutorials/interactive_api/PyTorch_Histology/envoy/envoy_config.yaml
+++ b/openfl-tutorials/interactive_api/PyTorch_Histology/envoy/envoy_config.yaml
@@ -7,5 +7,4 @@ shard_descriptor:
   template: histology_shard_descriptor.HistologyShardDescriptor
   params:
     data_folder: histology_data
-    rank: 1
-    worldsize: 2
+    rank_worldsize: 1,2


### PR DESCRIPTION
Fixes `rank_worldsize` parameter to match `ShardDescriptor` signature.