### PR TITLE
Set values to default and additional checks if they are unfilled

### DIFF
--- a/openfl/component/director/director.py
+++ b/openfl/component/director/director.py
@@ -60,7 +60,7 @@ class Director:
             'is_online': True,
             'is_experiment_running': False,
             'valid_duration': 2 * hc_period,
-            'last_updated': time.time()
+            'last_updated': time.time(),
         }
         is_accepted = True
         return is_accepted

--- a/openfl/component/director/director.py
+++ b/openfl/component/director/director.py
@@ -201,8 +201,8 @@ class Director:
         logger.info(f'Shard registry: {self._shard_registry}')
         for envoy_info in self._shard_registry.values():
             envoy_info['is_online'] = (
-                time.time() <
-                envoy_info.get('last_updated', 0) + envoy_info.get('valid_duration', 0)
+                time.time() < envoy_info.get('last_updated', 0)
+                + envoy_info.get('valid_duration', 0)
             )
             envoy_name = envoy_info['shard_info']['node_info']['name']
             envoy_info['experiment_name'] = self.col_exp[envoy_name]

--- a/openfl/component/envoy/envoy.py
+++ b/openfl/component/envoy/envoy.py
@@ -93,27 +93,32 @@ class Envoy:
         while True:
             # Need a separate method 'Get self state' or smth
             cuda_devices_info = None
-            if self.cuda_device_monitor is not None:
-                cuda_devices_info = []
-                cuda_driver_version = self.cuda_device_monitor.get_driver_version()
-                cuda_version = self.cuda_device_monitor.get_cuda_version()
-                for device_id in self.cuda_devices:
-                    memory_total = self.cuda_device_monitor.get_device_memory_total(device_id)
-                    memory_utilized = self.cuda_device_monitor.get_device_memory_utilized(
-                        device_id
-                    )
-                    device_utilization = self.cuda_device_monitor.get_device_utilization(device_id)
-                    device_name = self.cuda_device_monitor.get_device_name(device_id)
-                    cuda_devices_info.append({
-                        'index': device_id,
-                        'memory_total': memory_total,
-                        'memory_utilized': memory_utilized,
-                        'device_utilization': device_utilization,
-                        'cuda_driver_version': cuda_driver_version,
-                        'cuda_version': cuda_version,
-                        'name': device_name,
-                    })
-
+            try:  # TODO: investigate problem, it's a quick workaround
+                if self.cuda_device_monitor is not None:
+                    cuda_devices_info = []
+                    cuda_driver_version = self.cuda_device_monitor.get_driver_version()
+                    try:
+                        cuda_version = self.cuda_device_monitor.get_cuda_version()
+                    except Exception as exc:
+                        logger.exception(exc)
+                    for device_id in self.cuda_devices:
+                        memory_total = self.cuda_device_monitor.get_device_memory_total(device_id)
+                        memory_utilized = self.cuda_device_monitor.get_device_memory_utilized(
+                            device_id
+                        )
+                        device_utilization = self.cuda_device_monitor.get_device_utilization(device_id)
+                        device_name = self.cuda_device_monitor.get_device_name(device_id)
+                        cuda_devices_info.append({
+                            'index': device_id,
+                            'memory_total': memory_total,
+                            'memory_utilized': memory_utilized,
+                            'device_utilization': device_utilization,
+                            'cuda_driver_version': cuda_driver_version,
+                            'cuda_version': cuda_version,
+                            'name': device_name,
+                        })
+            except Exception as exc:
+                logger.exception(exc)
             timeout = self.director_client.send_health_check(
                 envoy_name=self.name,
                 is_experiment_running=self.is_experiment_running,

--- a/openfl/component/envoy/envoy.py
+++ b/openfl/component/envoy/envoy.py
@@ -123,7 +123,8 @@ class Envoy:
                         'name': device_name,
                     })
         except Exception as exc:
-            logger.exception(f'Failed to get cuda device info: {exc}. Check your cuda device monitor plugin.')
+            logger.exception(f'Failed to get cuda device info: {exc}. '
+                             f'Check your cuda device monitor plugin.')
         return cuda_devices_info
 
     def _run_collaborator(self, plan='plan/plan.yaml'):


### PR DESCRIPTION
Envoys send EnvoyHealthCheck after ShardInfo, and there is a short period between them. The director filled part of values (last_updated, valid_duration) in shard_info after EnvoyHealthCheck getting and didn't check if they are not set  in GetEnvoys API.
last_updated and valid_duration values are now filled in by default on envoy registration.
Additional checks that last_updated and valid_duration are not set were added in GetEnvoy API.