### PR TITLE
Only validation experiment

### DIFF
--- a/openfl/interface/interactive_api/experiment.py
+++ b/openfl/interface/interactive_api/experiment.py
@@ -92,9 +92,7 @@ class FLExperiment:
 
         else:
             self.task_runner_stub.rebuild_model(tensor_dict, validation=True, device='cpu')
-            if not called_from_get_best_model:
-                # get_last_model was called
-                self.current_model_type = 'last'
+            self.current_model_type = 'best' if called_from_get_best_model else 'last'
 
         return self.task_runner_stub.model
 

--- a/openfl/interface/interactive_api/experiment.py
+++ b/openfl/interface/interactive_api/experiment.py
@@ -20,6 +20,15 @@ from openfl.utilities import split_tensor_dict_for_holdouts
 from openfl.utilities.utils import is_package_versioned
 
 
+class ModelStatus:
+    """Model's statuses."""
+
+    INITIAL = 'initial'
+    BEST = 'best'
+    LAST = 'last'
+    RESTORED = 'restored'
+
+
 class FLExperiment:
     """Central class for FL experiment orchestration."""
 
@@ -43,10 +52,6 @@ class FLExperiment:
 
         self.experiment_accepted = False
 
-        self.current_model_type = 'initial'  # used for warning_msg variable in self._rebuild_model
-        self.train_task_exist = False
-        self.validation_task_exist = False
-
         self.logger = getLogger(__name__)
         setup_logging()
 
@@ -65,7 +70,7 @@ class FLExperiment:
         tensor_dict = self.federation.dir_client.get_best_model(
             experiment_name=self.experiment_name)
 
-        return self._rebuild_model(tensor_dict, called_from_get_best_model=True)
+        return self._rebuild_model(tensor_dict, model_status=ModelStatus.BEST)
 
     def get_last_model(self):
         """Retrieve the aggregated model after the last round."""
@@ -73,9 +78,9 @@ class FLExperiment:
         tensor_dict = self.federation.dir_client.get_last_model(
             experiment_name=self.experiment_name)
 
-        return self._rebuild_model(tensor_dict)
+        return self._rebuild_model(tensor_dict, model_status=ModelStatus.LAST)
 
-    def _rebuild_model(self, tensor_dict, called_from_get_best_model=False):
+    def _rebuild_model(self, tensor_dict, model_status=ModelStatus.BEST):
         """Use tensor dict to update model weights."""
         if len(tensor_dict) == 0:
             warning_msg = ('No tensors received from director\n'
@@ -83,16 +88,16 @@ class FLExperiment:
                            '\t1. Aggregated model is not ready\n'
                            '\t2. Experiment data removed from director')
 
-            if called_from_get_best_model and not self.validation_task_exist:
+            if model_status == ModelStatus.BEST and not self.validation_task_exist:
                 warning_msg += '\n\t3. No validation tasks are provided'
 
-            warning_msg += f'\nReturn {self.current_model_type} model'
+            warning_msg += f'\nReturn {self.current_model_status} model'
 
             self.logger.warning(warning_msg)
 
         else:
             self.task_runner_stub.rebuild_model(tensor_dict, validation=True, device='cpu')
-            self.current_model_type = 'best' if called_from_get_best_model else 'last'
+            self.current_model_status = model_status
 
         return self.task_runner_stub.model
 
@@ -184,7 +189,7 @@ class FLExperiment:
     def restore_experiment_state(self, model_provider):
         """Restore accepted experimnet object."""
         self.task_runner_stub = self.plan.get_core_task_runner(model_provider=model_provider)
-        self.current_model_type = 'restored experiment state'
+        self.current_model_status = ModelStatus.RESTORED
         self.experiment_accepted = True
 
     @staticmethod
@@ -235,6 +240,7 @@ class FLExperiment:
     def _get_initial_tensor_dict(self, model_provider):
         """Extract initial weights from the model."""
         self.task_runner_stub = self.plan.get_core_task_runner(model_provider=model_provider)
+        self.current_model_status = ModelStatus.INITIAL
         tensor_dict, _ = split_tensor_dict_for_holdouts(
             self.logger,
             self.task_runner_stub.get_tensor_dict(False),
@@ -266,6 +272,10 @@ class FLExperiment:
         # brining in fault tolerance changes
 
         # Check tasks type
+        # NOTE We have an implicit division of tasks into two types: training and validation.
+        # It depends on the presence of an optimizer parameter
+        self.train_task_exist = False
+        self.validation_task_exist = False
         for name in task_keeper.task_registry:
             if task_keeper.task_contract[name]['optimizer'] is not None:
                 self.train_task_exist = True
@@ -275,9 +285,8 @@ class FLExperiment:
         if not self.train_task_exist:
             # Since we have only validation task, we do not have to train it multiple times
             if rounds_to_train != 1:
-                rounds_to_train = 1
-            self.logger.info('Variable rounds_to_train was changed to 1, '
-                             'because only validation task(s) were given')
+                raise Exception('Variable rounds_to_train must be equal 1, '
+                                'because only validation task(s) were given')
 
         shard_registry = self.federation.get_shard_registry()
         plan.authorized_cols = [
@@ -311,12 +320,11 @@ class FLExperiment:
                                               'kwargs': task_keeper.task_settings[name]}
             else:
                 # This is a validation type task (not altering the model state)
+                validation_task_types = [('aggregated_model_', 'global')]
                 if self.train_task_exist:
-                    adapt_validation_task_dcit = zip(['localy_tuned_model_', 'aggregated_model_'],
-                                                     ['local', 'global'])
-                else:
-                    adapt_validation_task_dcit = zip(['aggregated_model_'], ['global'])
-                for name_prefix, apply_kwarg in adapt_validation_task_dcit:
+                    validation_task_types.insert(0, ('localy_tuned_model_', 'local'))
+
+                for name_prefix, apply_kwarg in validation_task_types:
                     # We add two entries for this task: for local and global models
                     task_kwargs = deepcopy(task_keeper.task_settings[name])
                     task_kwargs.update({'apply': apply_kwarg})

--- a/openfl/interface/interactive_api/experiment.py
+++ b/openfl/interface/interactive_api/experiment.py
@@ -283,10 +283,10 @@ class FLExperiment:
                 self.validation_task_exist = True
 
         if not self.train_task_exist:
-            # Since we have only validation task, we do not have to train it multiple times
+            # Since we have only validation tasks, we do not have to train it multiple times
             if rounds_to_train != 1:
                 raise Exception('Variable rounds_to_train must be equal 1, '
-                                'because only validation task(s) were given')
+                                'because only validation tasks were given')
 
         shard_registry = self.federation.get_shard_registry()
         plan.authorized_cols = [


### PR DESCRIPTION
This PR was opened according to https://github.com/intel/openfl/issues/236 and https://github.com/intel/openfl/issues/191
* If only validation task was given, we do not split it into two ones. For now we leave only `aggregated_model_validate` task and change `rounds_to_train` variable to 1
* Fixed message output when `get_best_model` or `get_last_model` method was called to provide more info about returned model

Fixes #236 #191