### PR TITLE
Fix 'gRPC is running on insecure channel with TLS' warnings spam

### DIFF
--- a/openfl/transport/grpc/client.py
+++ b/openfl/transport/grpc/client.py
@@ -164,7 +164,6 @@ class CollaboratorGRPCClient:
             An insecure gRPC channel object
 
         """
-
         return grpc.insecure_channel(uri, options=self.channel_options)
 
     def create_tls_channel(self, uri, root_certificate, disable_client_auth,

--- a/openfl/transport/grpc/client.py
+++ b/openfl/transport/grpc/client.py
@@ -110,7 +110,6 @@ class CollaboratorGRPCClient:
         self.root_certificate = root_certificate
         self.certificate = certificate
         self.private_key = private_key
-        self.notified_about_insecure = False
 
         self.channel_options = [
             ('grpc.max_metadata_size', 32 * 1024 * 1024),
@@ -121,6 +120,8 @@ class CollaboratorGRPCClient:
         self.logger = getLogger(__name__)
 
         if not self.tls:
+            self.logger.warn(
+                'gRPC is running on insecure channel with TLS disabled.')
             self.channel = self.create_insecure_channel(self.uri)
         else:
             self.channel = self.create_tls_channel(
@@ -163,10 +164,6 @@ class CollaboratorGRPCClient:
             An insecure gRPC channel object
 
         """
-        if not self.notified_about_insecure:
-            self.logger.warn(
-                'gRPC is running on insecure channel with TLS disabled.')
-            self.notified_about_insecure = True
 
         return grpc.insecure_channel(uri, options=self.channel_options)
 

--- a/openfl/transport/grpc/client.py
+++ b/openfl/transport/grpc/client.py
@@ -110,6 +110,7 @@ class CollaboratorGRPCClient:
         self.root_certificate = root_certificate
         self.certificate = certificate
         self.private_key = private_key
+        self.notified_about_insecure = False
 
         self.channel_options = [
             ('grpc.max_metadata_size', 32 * 1024 * 1024),
@@ -162,8 +163,10 @@ class CollaboratorGRPCClient:
             An insecure gRPC channel object
 
         """
-        self.logger.warn(
-            'gRPC is running on insecure channel with TLS disabled.')
+        if not self.notified_about_insecure:
+            self.logger.warn(
+                'gRPC is running on insecure channel with TLS disabled.')
+            self.notified_about_insecure = True
 
         return grpc.insecure_channel(uri, options=self.channel_options)
 


### PR DESCRIPTION
I've noticed that we have multiple warning messages  "gRPC is running on insecure channel with TLS". I suggest to fix it. 