### PR TITLE
write_logs parameter

### DIFF
--- a/docs/log_metric_callback.rst
+++ b/docs/log_metric_callback.rst
@@ -47,6 +47,7 @@ Command Line Interface
       best_state_path     : save/torch_cnn_mnist_best.pbuf
       last_state_path     : save/torch_cnn_mnist_last.pbuf
       rounds_to_train     : 10
+      write_logs          : true
       log_metric_callback :
         template : src.mnist_utils.callback_name
 

--- a/openfl-workspace/workspace/plan/defaults/aggregator.yaml
+++ b/openfl-workspace/workspace/plan/defaults/aggregator.yaml
@@ -1,4 +1,5 @@
 template : openfl.component.Aggregator
 settings :
     db_store_rounds   : 1
+    write_logs : false
     

--- a/openfl-workspace/workspace/plan/plans/default/plan.yaml
+++ b/openfl-workspace/workspace/plan/plans/default/plan.yaml
@@ -5,9 +5,9 @@ aggregator :
   defaults : plan/defaults/aggregator.yaml
   template : openfl.component.Aggregator
   settings :
-    init_state_path : save/keras_cnn_mnist_init.pbuf
-    best_state_path : save/keras_cnn_mnist_best.pbuf
-    last_state_path : save/keras_cnn_mnist_last.pbuf
+    init_state_path : save/init.pbuf
+    best_state_path : save/best.pbuf
+    last_state_path : save/last.pbuf
     rounds_to_train : 10
 
 collaborator :

--- a/openfl/component/aggregator/aggregator.py
+++ b/openfl/component/aggregator/aggregator.py
@@ -45,7 +45,7 @@ class Aggregator:
                  assigner,
 
                  rounds_to_train=256,
-                 log_metric_callback=None, # is it used somewhere?
+                 log_metric_callback=None,  # is it used somewhere?
                  single_col_cert_common_name=None,
                  compression_pipeline=None,
                  db_store_rounds=1,
@@ -82,7 +82,7 @@ class Aggregator:
             self.log_metric = write_metric
         self.logger = getLogger(__name__)
         self.best_model_score = None
-        self.log_dir = f'logs/{self.uuid}_{self.federation_uuid}' # <- is it used somewhere?
+        self.log_dir = f'logs/{self.uuid}_{self.federation_uuid}'  # <- is it used somewhere?
         self.metric_queue = queue.Queue()
 
         self.compression_pipeline = compression_pipeline or NoCompressionPipeline()
@@ -111,7 +111,6 @@ class Aggregator:
         self.collaborator_tasks_results = {}  # {TaskResultKey: list of TensorKeys}
 
         self.collaborator_task_weight = {}  # {TaskResultKey: data_size}
-
 
     def _load_initial_tensors(self):
         """

--- a/openfl/component/aggregator/aggregator.py
+++ b/openfl/component/aggregator/aggregator.py
@@ -45,7 +45,6 @@ class Aggregator:
                  assigner,
 
                  rounds_to_train=256,
-                 log_metric_callback=None,  # is it used somewhere?
                  single_col_cert_common_name=None,
                  compression_pipeline=None,
                  db_store_rounds=1,
@@ -82,7 +81,6 @@ class Aggregator:
             self.log_metric = write_metric
         self.logger = getLogger(__name__)
         self.best_model_score = None
-        self.log_dir = f'logs/{self.uuid}_{self.federation_uuid}'  # <- is it used somewhere?
         self.metric_queue = queue.Queue()
 
         self.compression_pipeline = compression_pipeline or NoCompressionPipeline()

--- a/openfl/component/aggregator/aggregator.py
+++ b/openfl/component/aggregator/aggregator.py
@@ -45,11 +45,11 @@ class Aggregator:
                  assigner,
 
                  rounds_to_train=256,
-                 log_metric_callback=None,
+                 log_metric_callback=None, # is it used somewhere?
                  single_col_cert_common_name=None,
                  compression_pipeline=None,
                  db_store_rounds=1,
-
+                 write_logs=False,
                  **kwargs):
         """Initialize."""
         self.round_number = 0
@@ -75,9 +75,18 @@ class Aggregator:
         # FIXME: I think next line generates an error on the second round
         # if it is set to 1 for the aggregator.
         self.db_store_rounds = db_store_rounds
+
+        # Gathered together logging-related objects
+        self.write_logs = write_logs
+        if self.write_logs:
+            self.log_metric = write_metric
+        self.logger = getLogger(__name__)
+        self.best_model_score = None
+        self.log_dir = f'logs/{self.uuid}_{self.federation_uuid}' # <- is it used somewhere?
+        self.metric_queue = queue.Queue()
+
         self.compression_pipeline = compression_pipeline or NoCompressionPipeline()
         self.tensor_codec = TensorCodec(self.compression_pipeline)
-        self.logger = getLogger(__name__)
 
         self.init_state_path = init_state_path
         self.best_state_path = best_state_path
@@ -85,9 +94,6 @@ class Aggregator:
 
         self.best_tensor_dict: dict = {}
         self.last_tensor_dict: dict = {}
-
-        self.metric_queue = queue.Queue()
-        self.best_model_score = None
 
         if kwargs.get('initial_tensor_dict', None) is not None:
             self._load_initial_tensors_from_dict(kwargs['initial_tensor_dict'])
@@ -99,17 +105,13 @@ class Aggregator:
             self.model: ModelProto = utils.load_proto(self.init_state_path)
             self._load_initial_tensors()  # keys are TensorKeys
 
-        self.log_dir = f'logs/{self.uuid}_{self.federation_uuid}'
-
         self.collaborator_tensor_results = {}  # {TensorKey: nparray}}
 
         # these enable getting all tensors for a task
-
         self.collaborator_tasks_results = {}  # {TaskResultKey: list of TensorKeys}
 
         self.collaborator_task_weight = {}  # {TaskResultKey: data_size}
 
-        self.log_metric = write_metric
 
     def _load_initial_tensors(self):
         """
@@ -511,8 +513,9 @@ class Aggregator:
                     'metric_name': tensor_key.tensor_name,
                     'metric_value': metric_value,
                     'round': round_number}
-                self.log_metric(tensor_key.tags[-1], task_name,
-                                tensor_key.tensor_name, nparray, round_number)
+                if self.write_logs:
+                    self.log_metric(tensor_key.tags[-1], task_name,
+                                    tensor_key.tensor_name, nparray, round_number)
                 self.logger.metric(f'Round {round_number}, '
                                    f'collaborator {tensor_key.tags[-1]} '
                                    f'{task_name} result '
@@ -800,8 +803,10 @@ class Aggregator:
                 else:
                     self.logger.metric(f'Round {round_number}, aggregator: {task_name} '
                                        f'{agg_tensor_name}:\t{agg_results:f}')
-                self.log_metric('Aggregator', task_name, tensor_key.tensor_name,
-                                agg_results, round_number)
+                if self.write_logs:
+                    self.log_metric('Aggregator', task_name,
+                                    tensor_key.tensor_name,
+                                    agg_results, round_number)
                 self.metric_queue.put(metric_dict)
                 # TODO Add all of the logic for saving the model based
                 #  on best accuracy, lowest loss, etc.


### PR DESCRIPTION
This PR introduces an additional parameter to `plan.yaml` for the Aggregator component: write_logs.
This flag indicates if logs should be written to disk on the Aggregator side.

There are two incentives to introduce this additional parameter:
1. In the Director-based workflow the Aggregator manager does not own logs and has no reason to store them locally, unless for persistence. Therefore, the parameter is set to false by default.
2. Running OpenFL in the Aggregator-based workflow under gramine SGX is now blocked by logging (as it relies on multiprocessing), thus it is beneficial to have a parameter to turn off logging when needed.

PR is tested and ready for review.