### PR TITLE
Bump TensorFlow to 2.7

### DIFF
--- a/openfl-tutorials/Federated_FedProx_Keras_MNIST_Tutorial.ipynb
+++ b/openfl-tutorials/Federated_FedProx_Keras_MNIST_Tutorial.ipynb
@@ -16,8 +16,7 @@
    "outputs": [],
    "source": [
     "#Install Tensorflow and MNIST dataset if not installed\n",
-    "!pip install tensorflow==2.5.0\n",
-    "\n",
+    "!pip install tensorflow==2.7.0\n",
     "#Alternatively you could use the intel-tensorflow build\n",
     "# !pip install intel-tensorflow==2.3.0"
    ]

--- a/openfl-tutorials/Federated_Keras_MNIST_Tutorial.ipynb
+++ b/openfl-tutorials/Federated_Keras_MNIST_Tutorial.ipynb
@@ -16,7 +16,7 @@
    "outputs": [],
    "source": [
     "#Install Tensorflow and MNIST dataset if not installed\n",
-    "!pip install tensorflow==2.5.0\n",
+    "!pip install tensorflow==2.7.0\n",
     "\n",
     "#Alternatively you could use the intel-tensorflow build\n",
     "# !pip install intel-tensorflow==2.3.0"

--- a/openfl-tutorials/interactive_api/Tensorflow_Word_Prediction/workspace/requirements.txt
+++ b/openfl-tutorials/interactive_api/Tensorflow_Word_Prediction/workspace/requirements.txt
@@ -1,2 +1,2 @@
-tensorflow==2.5.1
+tensorflow==2.7.0
 numpy==1.19.5

--- a/openfl-workspace/fe_tf_adversarial_cifar/requirements.txt
+++ b/openfl-workspace/fe_tf_adversarial_cifar/requirements.txt
@@ -1,4 +1,4 @@
 torch==1.6
-tensorflow==2.5.1
+tensorflow==2.7.0
 fastestimator==1.1.1
 albumentations==0.5.2

--- a/openfl-workspace/fe_torch_adversarial_cifar/requirements.txt
+++ b/openfl-workspace/fe_torch_adversarial_cifar/requirements.txt
@@ -1,4 +1,4 @@
 torch==1.6
-tensorflow==2.5.1
+tensorflow==2.7.0
 fastestimator==1.1.1
 albumentations==0.5.2

--- a/openfl-workspace/keras_cnn_mnist/requirements.txt
+++ b/openfl-workspace/keras_cnn_mnist/requirements.txt
@@ -1,1 +1,1 @@
-tensorflow==2.5.1
+tensorflow==2.7.0

--- a/openfl-workspace/keras_cnn_with_compression/requirements.txt
+++ b/openfl-workspace/keras_cnn_with_compression/requirements.txt
@@ -1,1 +1,1 @@
-tensorflow==2.5.0
+tensorflow==2.7.0

--- a/openfl-workspace/keras_nlp/requirements.txt
+++ b/openfl-workspace/keras_nlp/requirements.txt
@@ -1,1 +1,1 @@
-tensorflow==2.5.0
+tensorflow==2.7.0

--- a/openfl-workspace/tf_2dunet/requirements.txt
+++ b/openfl-workspace/tf_2dunet/requirements.txt
@@ -1,2 +1,2 @@
 nibabel
-tensorflow==2.5.1
+tensorflow==2.7.0

--- a/openfl-workspace/tf_cnn_histology/requirements.txt
+++ b/openfl-workspace/tf_cnn_histology/requirements.txt
@@ -1,3 +1,3 @@
 pillow
-tensorflow==2.5.1
+tensorflow==2.7.0
 tensorflow-datasets


### PR DESCRIPTION
Latest nightly builds started failing with errors:
```
...
13:29:50  ERROR: Cannot install black==21.12b0 and typing-extensions==3.7.4.3 because these package versions have conflicting dependencies.
13:29:50  
13:29:50  
13:29:50  The conflict is caused by:
13:29:50      The user requested typing-extensions==3.7.4.3
13:29:50      black 21.12b0 depends on typing-extensions>=3.10.0.0
13:29:50  
13:29:50  To fix this you could try to:
13:29:50  1. loosen the range of package versions you've specified
13:29:50  2. remove package versions to allow pip attempt to solve the dependency conflict
13:29:50  
13:29:50  
13:29:50  ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies
...
```
[Sample build job output](http://213.221.44.203/job/Federated-Learning/job/nightly/399/execution/node/60/log/)
Latest `ipython` release started depending on `black` package. Latest version of `black` depends on `typing-extensions>=3.10.0.0` but TensorFlow 2.5 that we are pinning to depends strictly on `typing-extensions~=3.7.4`.
To overcome the issue it was decided  to move to TensorFlow 2.7 in order to unlock `typing-extensions` version.

Tested TensorFlow workspaces:
 - [x] keras_cnn_mnist
 - [x] keras_cnn_with_compression
 - [x] keras_nlp
 - [x] tf_2dunet
 - [x] tf_cnn_histology
 - [x] fe_tf_adversarial_cifar
 - [x] fe_torch_adversarial_cifar
 - [x] Tensorflow_Word_Prediction (interactive API)
 - [x] Federated_Keras_MNIST_Tutorial.ipynb
 - [x] Federated_FedProx_Keras_MNIST_Tutorial.ipynb