### PR TITLE
Add dispatching by system and architecture while downloading step CLI

### DIFF
--- a/openfl/component/ca/ca.py
+++ b/openfl/component/ca/ca.py
@@ -73,6 +73,9 @@ def download_step_bin(url, grep_name, architecture, prefix='.', confirmation=Tru
         if (grep_name in a['name'] and architecture in a['name']
             and 'application/gzip' in a['content_type'])
     ]
+    if len(archive_urls) == 0:
+        raise Exception('Applicable CA binaries from github were not found '
+                        f'(name: {grep_name}, architecture: {architecture})')
     archive_url = archive_urls[-1]
     archive_url = archive_url.replace('https', 'http')
     name = archive_url.split('/')[-1]

--- a/openfl/component/ca/ca.py
+++ b/openfl/component/ca/ca.py
@@ -34,15 +34,15 @@ def get_system_and_architecture():
     system = uname_res.system.lower()
 
     architecture_aliases = {
-        ('x86_64', ): 'amd64',
-        ('armv6l', ): 'armv6',
-        ('armv7l', ): 'armv7',
-        ('aarch64', ): 'arm64'
+        'x86_64': 'amd64',
+        'armv6l': 'armv6',
+        'armv7l': 'armv7',
+        'aarch64': 'arm64'
     }
-    architecture = uname_res.machine
-    for aliases in architecture_aliases:
-        if architecture in aliases:
-            architecture = architecture_aliases[aliases]
+    architecture = uname_res.machine.lower()
+    for alias in architecture_aliases:
+        if architecture == alias:
+            architecture = architecture_aliases[alias]
             break
 
     return system, architecture

--- a/openfl/component/ca/ca.py
+++ b/openfl/component/ca/ca.py
@@ -36,6 +36,7 @@ def get_system_and_architecture():
     architecture_aliases = {
         ('x86_64', ): 'amd64',
         ('armv6l', ): 'armv6',
+        ('armv7l', ): 'armv7',
         ('aarch64', ): 'arm64'
     }
     architecture = uname_res.machine

--- a/openfl/component/ca/ca.py
+++ b/openfl/component/ca/ca.py
@@ -186,10 +186,11 @@ def install(ca_path, ca_url, password):
 
     if not (step_path and step_ca_path and step_path.exists() and step_ca_path.exists()):
         confirm('CA binaries from github will be downloaded now', default=True, abort=True)
+        system, arch = get_system_and_architecture()
         url = 'http://api.github.com/repos/smallstep/certificates/releases/latest'
-        download_step_bin(url, 'step-ca_linux', 'amd', prefix=ca_path, confirmation=False)
+        download_step_bin(url, f'step-ca_{system}', arch, prefix=ca_path, confirmation=False)
         url = 'http://api.github.com/repos/smallstep/cli/releases/latest'
-        download_step_bin(url, 'step_linux', 'amd', prefix=ca_path, confirmation=False)
+        download_step_bin(url, f'step_{system}', arch, prefix=ca_path, confirmation=False)
     step_config_dir = ca_path / CA_STEP_CONFIG_DIR
     if (not step_config_dir.exists()
             or confirm('CA exists, do you want to recreate it?', default=True)):


### PR DESCRIPTION
While working with certificates, openfl downloads only linux-x86_64 version of step CLI. This PR targets to add more supported systems and architectures for downloading.

Changes were tested on linux-x86_64 and linux-arm64.