### PR TITLE
Implementation of director-aggregator gRPC communication

### DIFF
--- a/openfl/component/aggregator/aggregator.py
+++ b/openfl/component/aggregator/aggregator.py
@@ -5,6 +5,7 @@
 import time
 import queue
 from logging import getLogger
+from typing import List
 
 from openfl.interface.aggregation_functions import WeightedAverage
 from openfl.component.straggler_handling_functions import CutoffTimeBasedStragglerHandling
@@ -572,6 +573,55 @@ class Aggregator:
         self.collaborator_tasks_results[task_key] = task_results
 
         self._end_of_task_check(task_name)
+
+    def get_experiment_description(self) -> dict:
+        """Get a experiment information by name for specific user."""
+        progress = self.round_number / self.rounds_to_train
+        model_statuses = self.model_download_statuses
+        tasks = [{
+            'name': task['function'],
+            'description': 'Task description Mock',
+        } for task in self.assigner.tasks.values()]
+        collaborators = [{
+            'name': name,
+            'status': 'pending_mock',
+            'progress': 0.0,
+            'round': 0,
+            'current_task': 'Current Task Mock',
+            'next_task': 'Next Task Mock'
+        } for name in self.authorized_cols]
+        result = {
+            'current_round': self.round_number,
+            'total_rounds': self.rounds_to_train,
+            'download_statuses': {
+                'models': model_statuses,
+                'logs': [{
+                    'name': 'aggregator',
+                    'status': 'ready'
+                }],
+            },
+            'collaborators': collaborators,
+            'tasks': tasks,
+            'progress': progress
+        }
+        return result
+
+    @property
+    def model_download_statuses(self) -> List[dict]:
+        """Return model download statuses representation."""
+        best_model_status = 'ready' if self.best_tensor_dict else 'pending'
+        last_model_status = 'ready' if self.last_tensor_dict else 'pending'
+        model_statuses = [{
+            'name': 'best',
+            'status': best_model_status,
+        }, {
+            'name': 'last',
+            'status': last_model_status,
+        }, {
+            'name': 'init',
+            'status': 'ready'
+        }]
+        return model_statuses
 
     def _process_named_tensor(self, named_tensor, collaborator_name):
         """

--- a/openfl/component/director/experiment.py
+++ b/openfl/component/director/experiment.py
@@ -49,6 +49,7 @@ class Experiment:
         self.sender = sender
         self.init_tensor_dict = init_tensor_dict
         self.plan_path = Path(plan_path)
+        self.plan = None
         self.users = set() if users is None else set(users)
         self.status = Status.PENDING
         self.aggregator = None
@@ -125,11 +126,11 @@ class Experiment:
             private_key: Union[Path, str] = None,
             certificate: Union[Path, str] = None,
     ) -> AggregatorGRPCServer:
-        plan = Plan.parse(plan_config_path=self.plan_path)
-        plan.authorized_cols = list(self.collaborators)
+        self.plan = Plan.parse(plan_config_path=self.plan_path)
+        self.plan.authorized_cols = list(self.collaborators)
 
         logger.info(f'🧿 Created an Aggregator Server for {self.name} experiment.')
-        aggregator_grpc_server = plan.interactive_api_get_server(
+        aggregator_grpc_server = self.plan.interactive_api_get_server(
             tensor_dict=self.init_tensor_dict,
             root_certificate=root_certificate,
             certificate=certificate,

--- a/openfl/federated/plan/plan.py
+++ b/openfl/federated/plan/plan.py
@@ -227,6 +227,8 @@ class Plan:
         self.hash_ = None
         self.name_ = None
         self.serializer_ = None
+        self.agg_addr = None
+        self.agg_port = None
 
     @property
     def hash(self):  # NOQA
@@ -236,6 +238,12 @@ class Plan:
                          extra={'markup': True})
 
         return self.hash_.hexdigest()
+
+    def generate_agg_port(self):
+        """Generate an aggregator port by plan hash."""
+        return int(
+            self.hash[:8], 16
+        ) % (60999 - 49152) + 49152
 
     def resolve(self):
         """Resolve the federation settings."""
@@ -247,11 +255,11 @@ class Plan:
 
         if self.config['network'][SETTINGS]['agg_addr'] == AUTO:
             self.config['network'][SETTINGS]['agg_addr'] = getfqdn_env()
+        self.agg_addr = self.config['network'][SETTINGS]['agg_addr']
 
         if self.config['network'][SETTINGS]['agg_port'] == AUTO:
-            self.config['network'][SETTINGS]['agg_port'] = int(
-                self.hash[:8], 16
-            ) % (60999 - 49152) + 49152
+            self.config['network'][SETTINGS]['agg_port'] = self.generate_agg_port()
+        self.agg_port = self.config['network'][SETTINGS]['agg_port']
 
     def get_assigner(self):
         """Get the plan task assigner."""

--- a/openfl/protocols/aggregator.proto
+++ b/openfl/protocols/aggregator.proto
@@ -74,9 +74,7 @@ message SendLocalTaskResultsResponse {
   MessageHeader header = 1;
 }
 
-// The same with director.proto
 message GetMetricStreamRequest {
-  string experiment_name = 1;
 }
 
 // The same with director.proto
@@ -104,9 +102,7 @@ message TrainedModelResponse {
 }
 
 // The same with director.proto
-message GetExperimentDescriptionRequest {
-  string name = 1;
-}
+message GetExperimentDescriptionRequest {}
 
 // The same with director.proto
 message GetExperimentDescriptionResponse {

--- a/openfl/transport/__init__.py
+++ b/openfl/transport/__init__.py
@@ -5,10 +5,12 @@
 
 from .grpc import AggregatorGRPCClient
 from .grpc import AggregatorGRPCServer
+from .grpc import AsyncAggregatorGRPCClient
 from .grpc import DirectorGRPCServer
 
 __all__ = [
     'AggregatorGRPCServer',
     'AggregatorGRPCClient',
+    'AsyncAggregatorGRPCClient',
     'DirectorGRPCServer',
 ]

--- a/openfl/transport/grpc/__init__.py
+++ b/openfl/transport/grpc/__init__.py
@@ -4,6 +4,7 @@
 """openfl.transport.grpc package."""
 
 from .aggregator_client import AggregatorGRPCClient
+from .aggregator_client import AsyncAggregatorGRPCClient
 from .aggregator_server import AggregatorGRPCServer
 from .director_server import DirectorGRPCServer
 
@@ -15,6 +16,7 @@ class ShardNotFoundError(Exception):
 __all__ = [
     'AggregatorGRPCServer',
     'AggregatorGRPCClient',
+    'AsyncAggregatorGRPCClient',
     'DirectorGRPCServer',
     'ShardNotFoundError',
 ]

--- a/openfl/transport/grpc/aggregator_client.py
+++ b/openfl/transport/grpc/aggregator_client.py
@@ -3,8 +3,9 @@
 
 """AggregatorGRPCClient module."""
 
+import asyncio
+import logging
 import time
-from logging import getLogger
 from typing import Optional
 from typing import Tuple
 
@@ -18,19 +19,23 @@ from openfl.utilities import check_equal
 
 from .grpc_channel_options import channel_options
 
+logger = logging.getLogger()
+
+CLIENT_RECONNECT_INTERVAL = 1  # in seconds
+CLIENT_CONNECT_TIMEOUT = 30  # in seconds
+
 
 class ConstantBackoff:
     """Constant Backoff policy."""
 
-    def __init__(self, reconnect_interval, logger, uri):
+    def __init__(self, reconnect_interval, uri):
         """Initialize Constant Backoff."""
         self.reconnect_interval = reconnect_interval
-        self.logger = logger
         self.uri = uri
 
     def sleep(self):
         """Sleep for specified interval."""
-        self.logger.info(f'Attempting to connect to aggregator at {self.uri}')
+        logger.info(f'Attempting to connect to aggregator at {self.uri}')
         time.sleep(self.reconnect_interval)
 
 
@@ -56,7 +61,7 @@ class RetryOnRpcErrorClientInterceptor(
             if isinstance(response, grpc.RpcError):
 
                 # If status code is not in retryable status codes
-                self.sleeping_policy.logger.info(f'Response code: {response.code()}')
+                logger.info(f'Response code: {response.code()}')
                 if (
                         self.status_for_retry
                         and response.code() not in self.status_for_retry
@@ -75,6 +80,83 @@ class RetryOnRpcErrorClientInterceptor(
             self, continuation, client_call_details, request_iterator
     ):
         """Wrap intercept call for stream->unary RPC."""
+        return self._intercept_call(continuation, client_call_details, request_iterator)
+
+
+class AsyncRetryOnRpcErrorClientInterceptorBase:
+    """Async retry gRPC connection on failure."""
+
+    def __init__(
+            self,
+            reconnect_interval=1,
+            connect_timeout=30,
+            status_for_retry: Optional[Tuple[grpc.StatusCode]] = None,
+    ):
+        """Initialize function for gRPC retry."""
+        self.reconnect_interval = reconnect_interval
+        self.connect_timeout = connect_timeout
+        self.status_for_retry = status_for_retry
+
+    async def handle_error_for_retry(self, error, started_time):
+        """Suppress an exception and sleep if error is in status_for_retry."""
+        logger.info(f'Response code: {error.code()}. Try to reconnect to the Aggregator.')
+        if self.status_for_retry and error.code() not in self.status_for_retry:
+            raise error
+        if (time.time() - started_time) > self.connect_timeout:
+            raise error
+        await asyncio.sleep(self.reconnect_interval)
+
+
+class AsyncRetryOnRpcErrorUnaryUnaryClientInterceptor(
+    grpc.aio.UnaryUnaryClientInterceptor, AsyncRetryOnRpcErrorClientInterceptorBase
+):
+    """Async retry gRPC connection on failure."""
+
+    async def _intercept_call(self, continuation, client_call_details, request_or_iterator):
+        """Intercept the async call to the gRPC server."""
+        started_time = time.time()
+        while True:
+            try:
+                async_response = await continuation(client_call_details, request_or_iterator)
+                response = await async_response
+            except grpc.aio.AioRpcError as error:
+                await self.handle_error_for_retry(error, started_time)
+            else:
+                return response
+
+    async def intercept_unary_unary(self, continuation, client_call_details, request):
+        """Wrap intercept call for unary->unary RPC."""
+        return await self._intercept_call(continuation, client_call_details, request)
+
+
+class AsyncRetryOnRpcErrorUnaryStreamClientInterceptor(
+    grpc.aio.UnaryStreamClientInterceptor, AsyncRetryOnRpcErrorClientInterceptorBase
+):
+    """Async retry gRPC connection on failure."""
+
+    async def _intercept_call(self, continuation, client_call_details, request_or_iterator):
+        """Intercept the async call to the gRPC server."""
+        started_time = time.time()
+        is_connected = False
+        while True:
+            try:
+                async_iter = await continuation(client_call_details, request_or_iterator)
+                async for response in async_iter:
+                    yield response
+                    is_connected = True
+            except grpc.aio.AioRpcError as error:
+                if (
+                        error.code() == grpc.StatusCode.UNAVAILABLE
+                        and error.details() == 'Socket closed'
+                ) or is_connected:
+                    logger.info(f'Rpc error: {error.code()}, details: {error.details()}.')
+                    return
+                await self.handle_error_for_retry(error, started_time)
+
+    async def intercept_unary_stream(
+            self, continuation, client_call_details, request_iterator
+    ):
+        """Wrap intercept call for unary->stream RPC."""
         return self._intercept_call(continuation, client_call_details, request_iterator)
 
 
@@ -107,8 +189,8 @@ def _resend_data_on_reconnection(func):
     return wrapper
 
 
-class AggregatorGRPCClient:
-    """Client to the aggregator over gRPC-TLS."""
+class BaseAggregatorGRPCClient:
+    """Base client to the aggregator over gRPC-TLS."""
 
     def __init__(self,
                  agg_addr,
@@ -129,11 +211,10 @@ class AggregatorGRPCClient:
         self.root_certificate = root_certificate
         self.certificate = certificate
         self.private_key = private_key
-
-        self.logger = getLogger(__name__)
+        self.kwargs = kwargs
 
         if not self.tls:
-            self.logger.warn(
+            logger.warn(
                 'gRPC is running on insecure channel with TLS disabled.')
             self.channel = self.create_insecure_channel(self.uri)
         else:
@@ -149,19 +230,12 @@ class AggregatorGRPCClient:
         self.aggregator_uuid = aggregator_uuid
         self.federation_uuid = federation_uuid
         self.single_col_cert_common_name = single_col_cert_common_name
+        self._create_stub(**kwargs)
 
-        # Adding an interceptor for RPC Errors
-        self.interceptors = (
-            RetryOnRpcErrorClientInterceptor(
-                sleeping_policy=ConstantBackoff(
-                    logger=self.logger,
-                    reconnect_interval=int(kwargs.get('client_reconnect_interval', 1)),
-                    uri=self.uri),
-                status_for_retry=(grpc.StatusCode.UNAVAILABLE,),
-            ),
-        )
+    def _create_stub(self, **kwargs):
+        """Create a server stub."""
         self.stub = aggregator_pb2_grpc.AggregatorStub(
-            grpc.intercept_channel(self.channel, *self.interceptors)
+            self.channel
         )
 
     def create_insecure_channel(self, uri):
@@ -179,6 +253,43 @@ class AggregatorGRPCClient:
         """
         return grpc.insecure_channel(uri, options=channel_options)
 
+    @staticmethod
+    def get_credentials(root_certificate, disable_client_auth,
+                        certificate, private_key):
+        """
+        Prepare credentials for an secure gRPC channel (i.e. TLS).
+
+        Args:
+            root_certificate: The Certificate Authority filename
+            disable_client_auth (boolean): True disabled client-side
+             authentication (not recommended, throws warning to user)
+            certificate: The client certficate filename from the collaborator
+             (signed by the certificate authority)
+
+        Returns:
+            A gRPC credentials object
+        """
+        with open(root_certificate, 'rb') as f:
+            root_certificate_b = f.read()
+
+        if disable_client_auth:
+            logger.warn('Client-side authentication is disabled.')
+            private_key_b = None
+            certificate_b = None
+        else:
+            with open(private_key, 'rb') as f:
+                private_key_b = f.read()
+            with open(certificate, 'rb') as f:
+                certificate_b = f.read()
+
+        credentials = grpc.ssl_channel_credentials(
+            root_certificates=root_certificate_b,
+            private_key=private_key_b,
+            certificate_chain=certificate_b,
+        )
+
+        return credentials
+
     def create_tls_channel(self, uri, root_certificate, disable_client_auth,
                            certificate, private_key):
         """
@@ -195,23 +306,11 @@ class AggregatorGRPCClient:
         Returns:
             An insecure gRPC channel object
         """
-        with open(root_certificate, 'rb') as f:
-            root_certificate_b = f.read()
-
-        if disable_client_auth:
-            self.logger.warn('Client-side authentication is disabled.')
-            private_key_b = None
-            certificate_b = None
-        else:
-            with open(private_key, 'rb') as f:
-                private_key_b = f.read()
-            with open(certificate, 'rb') as f:
-                certificate_b = f.read()
-
-        credentials = grpc.ssl_channel_credentials(
-            root_certificates=root_certificate_b,
-            private_key=private_key_b,
-            certificate_chain=certificate_b,
+        credentials = self.get_credentials(
+            root_certificate,
+            disable_client_auth,
+            certificate,
+            private_key
         )
 
         return grpc.secure_channel(
@@ -228,26 +327,26 @@ class AggregatorGRPCClient:
     def validate_response(self, reply, collaborator_name):
         """Validate the aggregator response."""
         # check that the message was intended to go to this collaborator
-        check_equal(reply.header.receiver, collaborator_name, self.logger)
-        check_equal(reply.header.sender, self.aggregator_uuid, self.logger)
+        check_equal(reply.header.receiver, collaborator_name, logger)
+        check_equal(reply.header.sender, self.aggregator_uuid, logger)
 
         # check that federation id matches
         check_equal(
             reply.header.federation_uuid,
             self.federation_uuid,
-            self.logger
+            logger
         )
 
         # check that there is aggrement on the single_col_cert_common_name
         check_equal(
             reply.header.single_col_cert_common_name,
             self.single_col_cert_common_name or '',
-            self.logger
+            logger
         )
 
     def disconnect(self):
         """Close the gRPC channel."""
-        self.logger.debug(f'Disconnecting from gRPC server at {self.uri}')
+        logger.debug(f'Disconnecting from gRPC server at {self.uri}')
         self.channel.close()
 
     def reconnect(self):
@@ -266,8 +365,31 @@ class AggregatorGRPCClient:
                 self.private_key
             )
 
-        self.logger.debug(f'Connecting to gRPC at {self.uri}')
+        logger.debug(f'Connecting to gRPC at {self.uri}')
+        self._create_stub()
 
+
+class AggregatorGRPCClient(BaseAggregatorGRPCClient):
+    """Client to the aggregator over gRPC-TLS."""
+
+    @property
+    def interceptors(self):
+        """Get interceptors."""
+        interceptors = (
+            RetryOnRpcErrorClientInterceptor(
+                sleeping_policy=ConstantBackoff(
+                    reconnect_interval=int(self.kwargs.get(
+                        'client_reconnect_interval', CLIENT_RECONNECT_INTERVAL
+                    )),
+                    uri=self.uri),
+                status_for_retry=(grpc.StatusCode.UNAVAILABLE,),
+            ),
+        )
+        return interceptors
+
+    def _create_stub(self, **kwargs):
+        """Create a server stub."""
+        # Adding an interceptor for RPC Errors
         self.stub = aggregator_pb2_grpc.AggregatorStub(
             grpc.intercept_channel(self.channel, *self.interceptors)
         )
@@ -320,21 +442,117 @@ class AggregatorGRPCClient:
 
         # convert (potentially) long list of tensors into stream
         stream = []
-        stream += utils.proto_to_datastream(request, self.logger)
+        stream += utils.proto_to_datastream(request, logger)
         response = self.stub.SendLocalTaskResults(iter(stream))
 
         # also do other validation, like on the round_number
         self.validate_response(response, collaborator_name)
 
-    def _get_trained_model(self, experiment_name, model_type):
+
+class AsyncAggregatorGRPCClient(BaseAggregatorGRPCClient):
+    """Async client to the aggregator over gRPC-TLS."""
+
+    @property
+    def interceptors(self):
+        """Get interceptors."""
+        interceptors = (
+            AsyncRetryOnRpcErrorUnaryUnaryClientInterceptor(
+                reconnect_interval=int(self.kwargs.get(
+                    'client_reconnect_interval', CLIENT_RECONNECT_INTERVAL
+                )),
+                connect_timeout=int(self.kwargs.get(
+                    'client_connect_timeout', CLIENT_CONNECT_TIMEOUT
+                )),
+                status_for_retry=(grpc.StatusCode.UNAVAILABLE,),
+            ),
+            AsyncRetryOnRpcErrorUnaryStreamClientInterceptor(
+                reconnect_interval=int(self.kwargs.get(
+                    'client_reconnect_interval', CLIENT_RECONNECT_INTERVAL
+                )),
+                connect_timeout=int(self.kwargs.get(
+                    'client_connect_timeout', CLIENT_CONNECT_TIMEOUT
+                )),
+                status_for_retry=(grpc.StatusCode.UNAVAILABLE,),
+            ),
+        )
+        return interceptors
+
+    def create_insecure_channel(self, uri):
+        """
+        Set an insecure gRPC channel (i.e. no TLS) if desired.
+
+        Warns user that this is not recommended.
+
+        Args:
+            uri: The uniform resource identifier fo the insecure channel
+
+        Returns:
+            An insecure gRPC channel object
+
+        """
+        return grpc.aio.insecure_channel(
+            uri,
+            options=channel_options,
+            interceptors=self.interceptors
+        )
+
+    def create_tls_channel(self, uri, root_certificate, disable_client_auth,
+                           certificate, private_key):
+        """
+        Set an secure gRPC channel (i.e. TLS).
+
+        Args:
+            uri: The uniform resource identifier fo the insecure channel
+            root_certificate: The Certificate Authority filename
+            disable_client_auth (boolean): True disabled client-side
+             authentication (not recommended, throws warning to user)
+            certificate: The client certficate filename from the collaborator
+             (signed by the certificate authority)
+
+        Returns:
+            An insecure gRPC channel object
+        """
+        credentials = self.get_credentials(
+            root_certificate,
+            disable_client_auth,
+            certificate,
+            private_key
+        )
+
+        return grpc.aio.secure_channel(
+            uri, credentials, options=channel_options, interceptors=self.interceptors)
+
+    async def get_trained_model(self, experiment_name, model_type):
         """Get trained model RPC."""
-        get_model_request = self.stub.GetTrainedModelRequest(
+        get_model_request = aggregator_pb2.GetTrainedModelRequest(
             experiment_name=experiment_name,
             model_type=model_type,
         )
-        model_proto_response = self.stub.GetTrainedModel(get_model_request)
+        model_proto_response = await self.stub.GetTrainedModel(get_model_request)
         tensor_dict, _ = utils.deconstruct_model_proto(
             model_proto_response.model_proto,
             NoCompressionPipeline(),
         )
         return tensor_dict
+
+    async def get_metric_stream(self):
+        """Get metrics stream."""
+        request = aggregator_pb2.GetMetricStreamRequest()
+        async for metric_message in self.stub.GetMetricStream(request):
+            logger.debug(f'Message: {metric_message}')
+            if not metric_message.metric_origin:
+                yield None
+                continue
+            yield {
+                'metric_origin': metric_message.metric_origin,
+                'task_name': metric_message.task_name,
+                'metric_name': metric_message.metric_name,
+                'metric_value': metric_message.metric_value,
+                'round': metric_message.round,
+            }
+
+    async def get_experiment_description(self):
+        """Get experiment info."""
+        request = aggregator_pb2.GetExperimentDescriptionRequest()
+        response = await self.stub.GetExperimentDescription(request)
+        return response.experiment

--- a/openfl/transport/grpc/aggregator_server.py
+++ b/openfl/transport/grpc/aggregator_server.py
@@ -4,6 +4,7 @@
 """AggregatorGRPCServer module."""
 
 import logging
+import queue
 from concurrent.futures import ThreadPoolExecutor
 from random import random
 from multiprocessing import cpu_count
@@ -13,11 +14,14 @@ from grpc import server
 from grpc import ssl_server_credentials
 from grpc import StatusCode
 
+from openfl.pipelines import NoCompressionPipeline
 from openfl.protocols import aggregator_pb2
 from openfl.protocols import aggregator_pb2_grpc
+from openfl.protocols import base_pb2
 from openfl.protocols import utils
 from openfl.utilities import check_equal
 from openfl.utilities import check_is_in
+from openfl.utilities.utils import getfqdn_env
 
 from .grpc_channel_options import channel_options
 
@@ -231,9 +235,114 @@ class AggregatorGRPCServer(aggregator_pb2_grpc.AggregatorServicer):
             header=self.get_header(collaborator_name)
         )
 
+    def validate_director_request(self, context):
+        """Validate if the request has got from the Director."""
+        if self.tls:
+            auth_subject = context.auth_context()['x509_common_name'][0].decode('utf-8')
+            if auth_subject != getfqdn_env():
+                raise Exception(f'Request has got from {auth_subject},'
+                                f'but the Director FQDN is {getfqdn_env()}.')
+
+    def GetMetricStream(self, request, context):  # NOQA:N802
+        """Get metric stream."""
+        self.validate_director_request(context)
+        while True:
+            try:
+                logger.debug('Try to get metric dict')
+                metric_dict = self.aggregator.metric_queue.get(timeout=1)
+            except queue.Empty:
+                if self.aggregator.all_quit_jobs_sent() and self.aggregator.metric_queue.empty():
+                    return
+                continue
+            logger.debug('Metric dict has got. Yield it')
+            yield aggregator_pb2.GetMetricStreamResponse(**metric_dict)
+
+    def GetTrainedModel(self, request, context):  # NOQA:N802
+        """RPC for retrieving trained models."""
+        logger.info('Request GetTrainedModel has got.')
+        self.validate_director_request(context)
+
+        if request.model_type == aggregator_pb2.GetTrainedModelRequest.BEST_MODEL:
+            model_type = 'best'
+        elif request.model_type == aggregator_pb2.GetTrainedModelRequest.LAST_MODEL:
+            model_type = 'last'
+        else:
+            logger.error('Incorrect model type')
+            return aggregator_pb2.TrainedModelResponse()
+
+        trained_model_dict = None
+        if self.aggregator.last_tensor_dict is None:
+            logger.error('Aggregator have no aggregated model to return')
+        elif model_type == 'best':
+            trained_model_dict = self.aggregator.best_tensor_dict
+        elif model_type == 'last':
+            trained_model_dict = self.aggregator.last_tensor_dict
+
+        if trained_model_dict is None:
+            return aggregator_pb2.TrainedModelResponse()
+
+        model_proto = utils.construct_model_proto(
+            trained_model_dict, 0, NoCompressionPipeline()
+        )
+
+        return aggregator_pb2.TrainedModelResponse(model_proto=model_proto)
+
+    def GetExperimentDescription(self, request, context):  # NOQA:N802
+        """Get an experiment description."""
+        logger.info('GetExperimentDescription request has got.')
+        self.validate_director_request(context)
+        experiment = self.aggregator.get_experiment_description()
+        models_statuses = [
+            base_pb2.DownloadStatus(
+                name=ms['name'],
+                status=ms['status']
+            )
+            for ms in experiment['download_statuses']['models']
+        ]
+        logs_statuses = [
+            base_pb2.DownloadStatus(
+                name=ls['name'],
+                status=ls['status']
+            )
+            for ls in experiment['download_statuses']['logs']
+        ]
+        download_statuses = base_pb2.DownloadStatuses(
+            models=models_statuses,
+            logs=logs_statuses,
+        )
+        collaborators = [
+            base_pb2.CollaboratorDescription(
+                name=col['name'],
+                status=col['status'],
+                progress=col['progress'],
+                round=col['round'],
+                current_task=col['current_task'],
+                next_task=col['next_task']
+            )
+            for col in experiment['collaborators']
+        ]
+        tasks = [
+            base_pb2.TaskDescription(
+                name=task['name'],
+                description=task['description']
+            )
+            for task in experiment['tasks']
+        ]
+
+        return aggregator_pb2.GetExperimentDescriptionResponse(
+            experiment=base_pb2.ExperimentDescription(
+                progress=experiment['progress'],
+                current_round=experiment['current_round'],
+                total_rounds=experiment['total_rounds'],
+                download_statuses=download_statuses,
+                collaborators=collaborators,
+                tasks=tasks,
+            ),
+        )
+
     def get_server(self):
         """Return gRPC server."""
-        self.server = server(ThreadPoolExecutor(max_workers=cpu_count()),
+        self.server = server(ThreadPoolExecutor(max_workers=cpu_count() + 1),
                              options=channel_options)
 
         aggregator_pb2_grpc.add_AggregatorServicer_to_server(self, self.server)


### PR DESCRIPTION
This is implementation of Director - Aggregator communication by gRPC in order to provide possibility of a separate launch. 
1 . There was implemented the next APIs: GetMetricStream, GetTrainedModel, GetExperimentDescription.
2. All request from user sent to the Director service. The Director service checks a caller, an experiment status and etc, and if it possible sends request to Aggregator service. User -> Federation -> director client -> Director service -> Director -> aggregator client -> Aggregator service -> Aggregator.
3. It was implemented an asynchronous aggregator client (AsyncAggregatorGRPCClient) for asynchronous Director based on the synchronous client.  
4. The async aggregator client makes several attempts to connect to the server in case of unavailability (each second during 30 seconds by default; synchronous aggregator client, that used by collaborators makes it last forever). It implemented using Interceptors. 
5. Aggregator's IP address and ports are taken from the plan (a port is generated by using the plan hash).
6. pytorch_kvasir_unet test was fixed.

There is a restriction: it is possible get an information from an aggregator only when it is alive. It is acceptable for GetMetricStream, but should be resolved for GetTrainedModel in the future (there several way to resolve, but they should be discussed). 