### PR TITLE
Fix hadolint issues in base Dockerfile

### DIFF
--- a/openfl-docker/Dockerfile.base
+++ b/openfl-docker/Dockerfile.base
@@ -26,8 +26,8 @@ RUN apt-get update && \
         grep -v -f base_packages.txt all_packages.txt | while read -r line; do \
             package=$line; \
             name=("${package//:/ }"); \
-            echo $name >> all_dependencies.txt; \
-            echo "$name" >> licenses.txt;\
+            echo "${name[0]}" >> all_dependencies.txt; \
+            echo "${name[0]}" >> licenses.txt;\
             cat /usr/share/doc/"${name[0]}"/copyright >> licenses.txt; \
             grep -lE 'GPL|MPL|EPL' /usr/share/doc/"${name[0]}"/copyright; \
             exit_status=$?; \


### PR DESCRIPTION
Dockerfile linter produces errors:
```
[2022-02-07T10:27:25.428Z] + hadolint --ignore SC1091 --ignore DL3002 --ignore DL3003 --ignore DL3006 --ignore DL3008 --ignore DL3013 --ignore DL3018 --ignore DL4001 openfl-docker/Dockerfile.base
[2022-02-07T10:27:26.002Z] openfl-docker/Dockerfile.base:15 SC2128 Expanding an array without an index only gives the first element.
[2022-02-07T10:27:26.002Z] openfl-docker/Dockerfile.base:15 SC2086 Double quote to prevent globbing and word splitting.
```

This PR resolves both warnings.