### PR TITLE
Gramine + OpenFL

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include openfl-workspace *
 recursive-include openfl-docker *
+recursive-include openfl-gramine *
 recursive-include openfl-tutorials *

--- a/openfl-gramine/Dockerfile.gramine
+++ b/openfl-gramine/Dockerfile.gramine
@@ -7,7 +7,7 @@ FROM ${BASE_IMAGE}
 #     pip install openfl
 
 # for now install from source (branch with logs_writer turned off)
-RUN git clone https://github.com/igor-davidyuk/openfl.git --branch gramine
+RUN git clone https://github.com/igor-davidyuk/openfl.git --branch gramine-rebased
 WORKDIR /openfl
 RUN --mount=type=cache,target=/root/.cache/ \
     pip install --upgrade pip && \

--- a/openfl-gramine/Dockerfile.gramine
+++ b/openfl-gramine/Dockerfile.gramine
@@ -1,0 +1,38 @@
+ARG BASE_IMAGE=python:3.8
+FROM ${BASE_IMAGE}
+
+# install openfl
+# RUN --mount=type=cache,target=/root/.cache/ \
+#     pip install --upgrade pip && \
+#     pip install openfl
+
+# for now install from source (branch with logs_writer turned off)
+RUN git clone https://github.com/igor-davidyuk/openfl.git --branch gramine
+WORKDIR /openfl
+RUN --mount=type=cache,target=/root/.cache/ \
+    pip install --upgrade pip && \
+    pip install .
+WORKDIR /
+
+# install gramine
+RUN curl -fsSLo /usr/share/keyrings/gramine-keyring.gpg https://packages.gramineproject.io/gramine-keyring.gpg && \
+    echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/gramine-keyring.gpg] https://packages.gramineproject.io/ stable main' | \
+    tee /etc/apt/sources.list.d/gramine.list
+RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+    gramine libprotobuf-c-dev
+    # there is an issue for libprotobuf-c in gramine repo, install from apt for now
+
+# graminelibos is under this dir
+ENV PYTHONPATH=/usr/local/lib/python3.8/site-packages/:/usr/lib/python3/dist-packages/:
+
+# install linux headers
+# WORKDIR /tmp/
+# RUN wget -c https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.11/amd64/linux-headers-5.11.0-051100_5.11.0-051100.202102142330_all.deb
+# RUN dpkg -i *.deb
+# RUN mv /usr/src/linux-headers-5.11.0-051100/ /usr/src/linux-headers-5.11.0-051100rc5-generic/
+# WORKDIR /
+
+# ENV LC_ALL=C.UTF-8
+# ENV LANG=C.UTF-8

--- a/openfl-gramine/Dockerfile.graminized.workspace
+++ b/openfl-gramine/Dockerfile.graminized.workspace
@@ -1,9 +1,5 @@
 ARG BASE_IMAGE=gramine_openfl
-FROM ${BASE_IMAGE}
-
-
-# RUN --mount=type=cache,target=/root/.cache/ \
-#     pip install torch==1.7.1+cpu torchvision==0.8.2+cpu -f https://download.pytorch.org/whl/cpu/torch_stable.html
+FROM ${BASE_IMAGE} as builder
 
 ARG WORKSPACE_ARCHIVE
 ADD ${WORKSPACE_ARCHIVE} /workspace.zip
@@ -13,11 +9,25 @@ RUN --mount=type=cache,target=/root/.cache/ \
 WORKDIR /workspace
 
 # TODO: Find a way to remove the hardcoded paths
-RUN cp /usr/local/lib/python3.8/site-packages/openfl-gramine/template . && \
+RUN cp /usr/local/lib/python3.8/site-packages/openfl-gramine/openfl.manifest.template . && \
     cp /usr/local/lib/python3.8/site-packages/openfl-gramine/Makefile .
 
+ARG SGX_BUILD=1
 RUN --mount=type=secret,id=signer-key,dst=/key.pem \
-    make clean && make SGX=1 SGX_SIGNER_KEY=/key.pem
+    make clean && make SGX=${SGX} SGX_SIGNER_KEY=/key.pem
 
-ENTRYPOINT [ "gramine-sgx", "./openfl", "/usr/local/bin/fx"]
-CMD ["aggregator", "start"]
+ARG GRAMINE_EXE=gramine-sgx
+ENV GRAMINE_EXE=GRAMINE_EXE
+ENTRYPOINT [ ${GRAMINE_EXE}, "./openfl", "/usr/local/bin/fx"]
+
+# FROM builder as runner-sgx-1
+# ENTRYPOINT [ "gramine-sgx", "./openfl", "/usr/local/bin/fx"]
+
+
+# FROM builder as runner-sgx-0
+# ENTRYPOINT [ "gramine-direct", "./openfl", "/usr/local/bin/fx"]
+
+
+# ARG SGX_RUN=1
+# FROM runner-sgx-${SGX_RUN}
+# CMD ["aggregator", "start"]

--- a/openfl-gramine/Dockerfile.graminized.workspace
+++ b/openfl-gramine/Dockerfile.graminized.workspace
@@ -10,24 +10,16 @@ WORKDIR /workspace
 
 # TODO: Find a way to remove the hardcoded paths
 RUN cp /usr/local/lib/python3.8/site-packages/openfl-gramine/openfl.manifest.template . && \
-    cp /usr/local/lib/python3.8/site-packages/openfl-gramine/Makefile .
+    cp /usr/local/lib/python3.8/site-packages/openfl-gramine/Makefile . && \
+    cp /usr/local/lib/python3.8/site-packages/openfl-gramine/start_process.sh .
 
 ARG SGX_BUILD=1
 RUN --mount=type=secret,id=signer-key,dst=/key.pem \
     make clean && make SGX=${SGX_BUILD} SGX_SIGNER_KEY=/key.pem
 
-ARG GRAMINE_EXE=gramine-sgx
-ENV GRAMINE=GRAMINE_EXE
-ENTRYPOINT [ $GRAMINE, "./openfl", "/usr/local/bin/fx"]
-
-# FROM builder as runner-sgx-1
-# ENTRYPOINT [ "gramine-sgx", "./openfl", "/usr/local/bin/fx"]
-
-
-# FROM builder as runner-sgx-0
-# ENTRYPOINT [ "gramine-direct", "./openfl", "/usr/local/bin/fx"]
-
-
-# ARG SGX_RUN=1
-# FROM runner-sgx-${SGX_RUN}
+# ARG GRAMINE_EXE=gramine-sgx
+# ENV GRAMINE=$GRAMINE_EXE
+# RUN echo $GRAMINE
 # CMD ["aggregator", "start"]
+ENV GRAMINE_EXECUTABLE=gramine-sgx
+ENTRYPOINT ["/bin/bash", "start_process.sh"]

--- a/openfl-gramine/Dockerfile.graminized.workspace
+++ b/openfl-gramine/Dockerfile.graminized.workspace
@@ -17,8 +17,8 @@ RUN --mount=type=secret,id=signer-key,dst=/key.pem \
     make clean && make SGX=${SGX} SGX_SIGNER_KEY=/key.pem
 
 ARG GRAMINE_EXE=gramine-sgx
-ENV GRAMINE_EXE=GRAMINE_EXE
-ENTRYPOINT [ ${GRAMINE_EXE}, "./openfl", "/usr/local/bin/fx"]
+ENV GRAMINE=GRAMINE_EXE
+ENTRYPOINT [ $GRAMINE, "./openfl", "/usr/local/bin/fx"]
 
 # FROM builder as runner-sgx-1
 # ENTRYPOINT [ "gramine-sgx", "./openfl", "/usr/local/bin/fx"]

--- a/openfl-gramine/Dockerfile.graminized.workspace
+++ b/openfl-gramine/Dockerfile.graminized.workspace
@@ -14,7 +14,7 @@ RUN cp /usr/local/lib/python3.8/site-packages/openfl-gramine/openfl.manifest.tem
 
 ARG SGX_BUILD=1
 RUN --mount=type=secret,id=signer-key,dst=/key.pem \
-    make clean && make SGX=${SGX} SGX_SIGNER_KEY=/key.pem
+    make clean && make SGX=${SGX_BUILD} SGX_SIGNER_KEY=/key.pem
 
 ARG GRAMINE_EXE=gramine-sgx
 ENV GRAMINE=GRAMINE_EXE

--- a/openfl-gramine/Dockerfile.graminized.workspace
+++ b/openfl-gramine/Dockerfile.graminized.workspace
@@ -1,0 +1,23 @@
+ARG BASE_IMAGE=gramine_openfl
+FROM ${BASE_IMAGE}
+
+
+# RUN --mount=type=cache,target=/root/.cache/ \
+#     pip install torch==1.7.1+cpu torchvision==0.8.2+cpu -f https://download.pytorch.org/whl/cpu/torch_stable.html
+
+ARG WORKSPACE_ARCHIVE
+ADD ${WORKSPACE_ARCHIVE} /workspace.zip
+RUN --mount=type=cache,target=/root/.cache/ \
+    fx workspace import --archive /workspace.zip
+
+WORKDIR /workspace
+
+# TODO: Find a way to remove the hardcoded paths
+RUN cp /usr/local/lib/python3.8/site-packages/openfl-gramine/template . && \
+    cp /usr/local/lib/python3.8/site-packages/openfl-gramine/Makefile .
+
+RUN --mount=type=secret,id=signer-key,dst=/key.pem \
+    make clean && make SGX=1 SGX_SIGNER_KEY=/key.pem
+
+ENTRYPOINT [ "gramine-sgx", "./openfl", "/usr/local/bin/fx"]
+CMD ["aggregator", "start"]

--- a/openfl-gramine/Dockerfile.graminized.workspace
+++ b/openfl-gramine/Dockerfile.graminized.workspace
@@ -17,9 +17,6 @@ ARG SGX_BUILD=1
 RUN --mount=type=secret,id=signer-key,dst=/key.pem \
     make clean && make SGX=${SGX_BUILD} SGX_SIGNER_KEY=/key.pem
 
-# ARG GRAMINE_EXE=gramine-sgx
-# ENV GRAMINE=$GRAMINE_EXE
-# RUN echo $GRAMINE
-# CMD ["aggregator", "start"]
 ENV GRAMINE_EXECUTABLE=gramine-sgx
 ENTRYPOINT ["/bin/bash", "start_process.sh"]
+CMD [ "aggregator", "start"]

--- a/openfl-gramine/MANUAL.md
+++ b/openfl-gramine/MANUAL.md
@@ -1,19 +1,19 @@
 # OpenFL + Gramine
 This manual will help you run OpenFL with Aggregator-based workflow inside SGX enclave with Gramine.
 ## TO-DO:
-- [X] import manifest and makefile from dist-package openfl 
-- [X] pass wheel repository to pip (for cpu versions of pytorch for example)
+- [X] import manifest and makefile from OpenFL dist-package 
+- [X] pass wheel repository to pip (for CPU versions of PyTorch for example)
 - get rid of command line args (insecure)
 ## Known issues:
 - Kvasir experiment: aggregation takes really long, debug log-level does not show the reason
-- We need workspace zip to import it and create certs. We need to know number of collaborators prior to zipping the workspace. SOLUTOIN: mount cols.yaml and data.yaml
+- We need workspace zip to import it and create certs. We need to know the number of collaborators prior to zipping the workspace. SOLUTOIN: mount cols.yaml and data.yaml
 - During plan initialization we need data to initialize the model. so at least one collaborator should be in data.yaml and its data should be available. cols.yaml may be empty at first
 During cert sign request generation cols.yaml on collaborators remain empty, data.yaml is extended if needed. On aggregator, cols.yaml are updated during signing procedure, data.yaml remains unmodified
 - `error: Disallowing access to file '/usr/local/lib/python3.8/__pycache__/signal.cpython-38.pyc.3423950304'; file is not protected, trusted or allowed.`
 ## Prerquisites
 Building machine:
 - OpenFL
-- Docker should be installed, user included into Docker group
+- Docker should be installed, user included in Docker group
 
 Machines that will run an Aggregator and Collaborator containers should have the following:
 - SGX enebled in BIOS
@@ -23,7 +23,7 @@ Machines that will run an Aggregator and Collaborator containers should have the
 This is a short list, see more in Gramine docs.
 
 ## Workflow
-The user will mainly interact with OpenFL CLI, docker CLI and other commandline tools. But the user is also expected to modify plan.yaml file and Python code under workspace/src folder to set up an FL Experiment.
+The user will mainly interact with OpenFL CLI, docker CLI, and other command-line tools. But the user is also expected to modify plan.yaml file and Python code under workspace/src folder to set up an FL Experiment.
 ### On the building machine (Data Scientist's node):
 1. As usual, **create a workspace**: 
 ```
@@ -32,38 +32,38 @@ cd WORKSPACE_NAME
 ```
 Modify the code and the plan.yaml, set up your training procedure. </br>
 Pay attention to the following: 
-- make sure data loading code reads data from ./data folder inside the workspace
-- if you download data (developement scenario) make sure your code first checks if data exists, as connecting to the internet from an enclave may be problematic.
+- make sure the data loading code reads data from ./data folder inside the workspace
+- if you download data (development scenario) make sure your code first checks if data exists, as connecting to the internet from an enclave may be problematic.
 - make sure you do not use any CUDA driver-dependent packages
 
 2. **Initialize the experiment plan** </br> 
-Find out the FQDN of the aggregator machine and use for plan initialization.
+Find out the FQDN of the aggregator machine and use it for plan initialization.
 ```
 fx plan initialize -a ${FQDN}
 ```
 To find out FQDN (Unix-like OS) try `hostname --all-fqdns | awk '{print $1}'` command.
 
-3. (Optional) **Generate a signing key** on building machine if you do not have one.</br>
+3. (Optional) **Generate a signing key** on the building machine if you do not have one.</br>
 It will be used to calculate hashes of trusted files. If you plan to test the application without SGX (gramine-direct) you also do not need a signer key.
 ```
 openssl genrsa -3 -out KEY_LOCATION/key.pem 3072
 ```
-This key will not be packed to the final Docker image.
+This key will not be packed into the final Docker image.
 
 4. **Build the Experiment Docker image**
 
 ```
 fx workspace graminize -s KEY_LOCATION/key.pem --sgx-target/--no-sgx-target
 ```
-This command will build and save a Docker image with you Experiment. The saved image will contain all the required files to start a process in an enclave.</br>
-If `--no-sgx-target` option passed to the command, the image will run processes under gramine-direct, in this case it is not necessary to pass signing key.
+This command will build and save a Docker image with your Experiment. The saved image will contain all the required files to start a process in an enclave.</br>
+If `--no-sgx-target` option is passed to the command, the image will run processes under gramine-direct, in this case, it is not necessary to pass the signing key.
 
 
 ### Image distribution:
-Data scientist now must transfer the Docker image to the aggregator and collaborator machines. Aggregator will also need initial model weights.
+Data scientist (builder) now must transfer the Docker image to the aggregator and collaborator machines. The Aggregator will also need initial model weights.
 
 5. **Transfer files** to the aggregator an collaborator machines.
-If there is a connaction between machines, you may use `scp`. In other case use the transfer channel that suits your situation.</br>
+If there is a connection between machines, you may use `scp`. In other cases use the transfer channel that suits your situation.</br>
 Send files to the aggregator machine:
 ```
 scp BUILDING_MACHINE:WORKSPACE_PATH/WORKSPACE_NAME.tar.gz AGGREGATOR_MACHINE:SOME_PATH
@@ -82,10 +82,10 @@ docker load < WORKSPACE_NAME.tar.gz
 ```
 
 7. **Prepare certificates**
-Certificates exchange is a big separate topic. To run an experiment following OpenFL Aggregator-based workflow, user must follow the established procedure, please refer to [the docs](https://openfl.readthedocs.io/en/latest/running_the_federation.html#bare-metal-approach).
-Following the above-mentioned procedure, running machines will acquire certificates. Moreover, as the result of this procedure, the aggregator machine will also obtain a `cols.yaml` file (required to start an experiment) with registered collaborators names, and the collaborator machines will obtain `data.yaml` files.
+Certificates exchange is a big separate topic. To run an experiment following OpenFL Aggregator-based workflow, a user must follow the established procedure, please refer to [the docs](https://openfl.readthedocs.io/en/latest/running_the_federation.html#bare-metal-approach).
+Following the above-mentioned procedure, running machines will acquire certificates. Moreover, as the result of this procedure, the aggregator machine will also obtain a `cols.yaml` file (required to start an experiment) with registered collaborators' names, and the collaborator machines will obtain `data.yaml` files.
 
-We recoment replicate the OpenFL workspace folder structure on all the machines and follow the usual certifying procedure. Finally, on the aggregator node you should have the following folder structure:
+We recommend replicating the OpenFL workspace folder structure on all the machines and following the usual certifying procedure. Finally, on the aggregator node you should have the following folder structure:
 ```
 workspace/
 --save/WORKSPACE_NAME_init.pbuf
@@ -124,8 +124,8 @@ docker run -it --rm --device=/dev/sgx_enclave --volume=/var/run/aesmd/aesm.socke
 ${WORKSPACE_NAME} aggregator start
 ```
 
-If the image was built with
-No SGX (gramine-direct):
+**No SGX run (`gramine-direct`)**:
+If the image was built with `fx workspace graminize --no-sgx-target` you may run an experiment under gramine without SGX. Note how we do not mount `sgx_enclave` device and pass a `--security-opt` instead that allows syscalls required by `gramine-direct`
 
 ```
 export WORKSPACE_NAME=your_workspace_name
@@ -145,6 +145,20 @@ export WORKSPACE_NAME=your_workspace_name
 export WORKSPACE_PATH=path_to_workspace
 export COL_NAME=col_name
 docker run -it --rm --device=/dev/sgx_enclave --volume=/var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket \
+--network=host \
+--volume=${WORKSPACE_PATH}/cert:/workspace/cert \
+--volume=${WORKSPACE_PATH}/plan/data.yaml:/workspace/plan/data.yaml \
+--volume=${WORKSPACE_PATH}/data:/workspace/data \
+${EXP_NAME} collaborator start -n ${COL_NAME}
+```
+
+**No SGX run (`gramine-direct`)**:
+If the image was built with `fx workspace graminize --no-sgx-target` you may run an experiment under gramine without SGX.
+```
+export WORKSPACE_NAME=your_workspace_name
+export WORKSPACE_PATH=path_to_workspace
+export COL_NAME=col_name
+docker run -it --rm --security-opt seccomp=unconfined \
 --network=host \
 --volume=${WORKSPACE_PATH}/cert:/workspace/cert \
 --volume=${WORKSPACE_PATH}/plan/data.yaml:/workspace/plan/data.yaml \

--- a/openfl-gramine/MANUAL.md
+++ b/openfl-gramine/MANUAL.md
@@ -13,6 +13,7 @@ This manual will help you run OpenFL with Aggregator-based workflow inside SGX e
 - During plan initialization we need data to initialize the model. so at least one collaborator should be in data.yaml and its data should be available. cols.yaml may be empty at first
 During cert sign request generation cols.yaml on collaborators remain empty, data.yaml is extended if needed. On aggregator, cols.yaml are updated during signing procedure, data.yaml remains unmodified
 - `error: Disallowing access to file '/usr/local/lib/python3.8/__pycache__/signal.cpython-38.pyc.3423950304'; file is not protected, trusted or allowed.`
+
 ## Prerquisites
 Building machine:
 - OpenFL
@@ -53,6 +54,7 @@ For example, on Unix-like OS try the following command:
 ```
 hostname --all-fqdns | awk '{print $1}'
 ```
+(In case this FQDN does not work for your federation, try putting the machine IP instead)
 Then pass the result as `AGG_FQDN` parameter to:
 ```
 fx plan initialize -a $AGG_FQDN

--- a/openfl-gramine/MANUAL.md
+++ b/openfl-gramine/MANUAL.md
@@ -3,7 +3,10 @@ This manual will help you run OpenFL with Aggregator-based workflow inside SGX e
 ## TO-DO:
 - [X] import manifest and makefile from OpenFL dist-package 
 - [X] pass wheel repository to pip (for CPU versions of PyTorch for example)
-- get rid of command line args (insecure)
+- [ ] get rid of command line args (insecure)
+- [ ] introduce `fx workspace create --prefix WORKSPACE_NAME` command without --template option to the OpenFL CLI, that will create just an empty workspace with the right folder structure.
+- [ ] introduce `fx *actor* start --from image`
+
 ## Known issues:
 - Kvasir experiment: aggregation takes really long, debug log-level does not show the reason
 - We need workspace zip to import it and create certs. We need to know the number of collaborators prior to zipping the workspace. SOLUTOIN: mount cols.yaml and data.yaml
@@ -120,7 +123,7 @@ workspace/
 
 To speed up the certification process for one-node test runs, it makes sense to utilize the [OpenFL integration test script](https://github.com/intel/openfl/blob/develop/tests/github/test_hello_federation.sh) (comment out last 9 lines) that will create required folders and certify an aggregator and two collaborators.
 
-### **Run the Federation in an enclave**
+### **Run the Federation in enclaves**
 #### On the Aggregator machine run:
 ```
 export WORKSPACE_NAME=your_workspace_name

--- a/openfl-gramine/MANUAL.md
+++ b/openfl-gramine/MANUAL.md
@@ -27,8 +27,11 @@ The user will mainly interact with OpenFL CLI, docker CLI, and other command-lin
 ### On the building machine (Data Scientist's node):
 1. As usual, **create a workspace**: 
 ```
-fx workspace create --prefix WORKSPACE_NAME --template TEMPLATE_NAME
-cd WORKSPACE_NAME
+export WORKSPACE_NAME=my_sgx_federation_workspace
+export TEMPLATE_NAME=torch_cnn_histology
+
+fx workspace create --prefix $WORKSPACE_NAME --template $TEMPLATE_NAME
+cd $WORKSPACE_NAME
 ```
 Modify the code and the plan.yaml, set up your training procedure. </br>
 Pay attention to the following: 
@@ -38,22 +41,28 @@ Pay attention to the following:
 
 2. **Initialize the experiment plan** </br> 
 Find out the FQDN of the aggregator machine and use it for plan initialization.
+For example, on Unix-like OS try the following command:
 ```
-fx plan initialize -a ${FQDN}
+hostname --all-fqdns | awk '{print $1}'
 ```
-To find out FQDN (Unix-like OS) try `hostname --all-fqdns | awk '{print $1}'` command.
+Then pass the result as `AGG_FQDN` parameter to:
+```
+fx plan initialize -a $AGG_FQDN
+```
 
 3. (Optional) **Generate a signing key** on the building machine if you do not have one.</br>
 It will be used to calculate hashes of trusted files. If you plan to test the application without SGX (gramine-direct) you also do not need a signer key.
 ```
-openssl genrsa -3 -out KEY_LOCATION/key.pem 3072
+export KEY_LOCATION=.
+
+openssl genrsa -3 -out $KEY_LOCATION/key.pem 3072
 ```
 This key will not be packed into the final Docker image.
 
 4. **Build the Experiment Docker image**
 
 ```
-fx workspace graminize -s KEY_LOCATION/key.pem --sgx-target/--no-sgx-target
+fx workspace graminize -s $KEY_LOCATION/key.pem --sgx-target/--no-sgx-target
 ```
 This command will build and save a Docker image with your Experiment. The saved image will contain all the required files to start a process in an enclave.</br>
 If `--no-sgx-target` option is passed to the command, the image will run processes under gramine-direct, in this case, it is not necessary to pass the signing key.

--- a/openfl-gramine/MANUAL.md
+++ b/openfl-gramine/MANUAL.md
@@ -42,6 +42,11 @@ Pay attention to the following:
 - if you download data (development scenario) make sure your code first checks if data exists, as connecting to the internet from an enclave may be problematic.
 - make sure you do not use any CUDA driver-dependent packages
 
+Default workspaces (templates) in OpenFL differ in their data downloading procedures. Workspaces with data loading flow that do not require changes to run with Gramine include:
+- torch_unet_kvasir
+- torch_cnn_histology
+- keras_nlp
+
 2. **Initialize the experiment plan** </br> 
 Find out the FQDN of the aggregator machine and use it for plan initialization.
 For example, on Unix-like OS try the following command:

--- a/openfl-gramine/MANUAL.md
+++ b/openfl-gramine/MANUAL.md
@@ -14,7 +14,7 @@ This manual will help you run OpenFL with Aggregator-based workflow inside SGX e
 During cert sign request generation cols.yaml on collaborators remain empty, data.yaml is extended if needed. On aggregator, cols.yaml are updated during signing procedure, data.yaml remains unmodified
 - `error: Disallowing access to file '/usr/local/lib/python3.8/__pycache__/signal.cpython-38.pyc.3423950304'; file is not protected, trusted or allowed.`
 
-## Prerquisites
+## Prerequisites
 Building machine:
 - OpenFL
 - Docker should be installed, user included in Docker group

--- a/openfl-gramine/MANUAL.md
+++ b/openfl-gramine/MANUAL.md
@@ -131,7 +131,7 @@ workspace/
     --col_name.key
 ```
 
-To speed up the certification process for one-node test runs, it makes sense to utilize the [OpenFL integration test script](https://github.com/intel/openfl/blob/develop/tests/github/test_hello_federation.sh) (comment out last 9 lines) that will create required folders and certify an aggregator and two collaborators.
+To speed up the certification process for one-node test runs, it makes sense to utilize the OpenFL integration test script [make this a link after merge]  openfl/tests/github/test_graminize.sh, that will create required folders and certify an aggregator and two collaborators.
 
 ### **Run the Federation in enclaves**
 #### On the Aggregator machine run:

--- a/openfl-gramine/MANUAL.md
+++ b/openfl-gramine/MANUAL.md
@@ -165,8 +165,8 @@ The user may run an experiment under gramine without SGX. Note how we do not mou
 ```
 export WORKSPACE_NAME=your_workspace_name
 export WORKSPACE_PATH=path_to_workspace
-docker run -it --rm --security-opt seccomp=unconfined \
---network=host -e GRAMINE_EXECUTABLE=gramine-direct \
+docker run -it --rm --security-opt seccomp=unconfined -e GRAMINE_EXECUTABLE=gramine-direct \
+--network=host \
 --volume=${WORKSPACE_PATH}/cert:/workspace/cert \
 --volume=${WORKSPACE_PATH}/logs:/workspace/logs \
 --volume=${WORKSPACE_PATH}/plan/cols.yaml:/workspace/plan/cols.yaml \
@@ -180,8 +180,8 @@ ${WORKSPACE_NAME} aggregator start
 export WORKSPACE_NAME=your_workspace_name
 export WORKSPACE_PATH=path_to_workspace
 export COL_NAME=col_name
-docker run -it --rm --security-opt seccomp=unconfined \
---network=host -e GRAMINE_EXECUTABLE=gramine-direct \
+docker run -it --rm --security-opt seccomp=unconfined -e GRAMINE_EXECUTABLE=gramine-direct \
+--network=host \
 --volume=${WORKSPACE_PATH}/cert:/workspace/cert \
 --volume=${WORKSPACE_PATH}/plan/data.yaml:/workspace/plan/data.yaml \
 --volume=${WORKSPACE_PATH}/data:/workspace/data \

--- a/openfl-gramine/MANUAL.md
+++ b/openfl-gramine/MANUAL.md
@@ -86,6 +86,9 @@ Send the image archive to collaborator machines:
 ```
 scp BUILDING_MACHINE:WORKSPACE_PATH/WORKSPACE_NAME.tar.gz COLLABORATOR_MACHINE:SOME_PATH
 ```
+
+Please, keep in mind, if you run a test Federation, with data downloaded from the internet, you should also transfer/download data to collaborator machines.
+
 ### On the running machines (Aggregator and Collaborator nodes):
 6. **Load the image.**
 Execute the following command on all running machines:

--- a/openfl-gramine/MANUAL.md
+++ b/openfl-gramine/MANUAL.md
@@ -144,7 +144,7 @@ docker run -it --rm --device=/dev/sgx_enclave --volume=/var/run/aesmd/aesm.socke
 --volume=${WORKSPACE_PATH}/cert:/workspace/cert \
 --volume=${WORKSPACE_PATH}/plan/data.yaml:/workspace/plan/data.yaml \
 --volume=${WORKSPACE_PATH}/data:/workspace/data \
-${EXP_NAME} collaborator start -n ${COL_NAME}
+${WORKSPACE_NAME} collaborator start -n ${COL_NAME}
 ```
 
 ### **No SGX run (`gramine-direct`)**:
@@ -174,5 +174,5 @@ docker run -it --rm --security-opt seccomp=unconfined \
 --volume=${WORKSPACE_PATH}/cert:/workspace/cert \
 --volume=${WORKSPACE_PATH}/plan/data.yaml:/workspace/plan/data.yaml \
 --volume=${WORKSPACE_PATH}/data:/workspace/data \
-${EXP_NAME} collaborator start -n ${COL_NAME}
+${WORKSPACE_NAME} collaborator start -n ${COL_NAME}
 ```

--- a/openfl-gramine/MANUAL.md
+++ b/openfl-gramine/MANUAL.md
@@ -1,0 +1,115 @@
+# OpenFL + Gramine
+This manual will help you run OpenFL with Aggregator-based workflow under Gramine SGX.
+## TO-DO:
+- import manifest and makefile from dist-package openfl 
+- pass wheel repository to pip (for cpu versions of pytorch for example)
+- get rid of command line args (insecure)
+## Known issues:
+- Kvasir experiment: aggregation takes really long, debug log-level does not show the reason
+- We need workspace zip to import it and create certs. We need to know number of collaborators prior to zipping the workspace. SOLUTOIN: mount cols.yaml and data.yaml
+- During plan initialization we need data to initialize the model. so at least one collaborator should be in data.yaml and its data should be available. cols.yaml may be empty at first
+During cert sign request generation cols.yaml on collaborators remain empty, data.yaml is extended if needed. On aggregator, cols.yaml are updated during signing procedure, data.yaml remains unmodified
+- `error: Disallowing access to file '/usr/local/lib/python3.8/__pycache__/signal.cpython-38.pyc.3423950304'; file is not protected, trusted or allowed.`
+## Prerquisites
+Building machine:
+- OpenFL
+
+Machines that will run an Aggregator and Collaborator containers should have the following:
+- SGX enebled in BIOS
+- Ubuntu with Linux kernel 5.11+
+- ? SGX drivers, it is built in kernel: `/dev/sgx_enclave`
+- [aesmd service](https://github.com/intel/linux-sgx) (`/var/run/aesmd/aesm.socket`)
+This is a short list, see more in Gramine docs.
+
+## Workflow
+1. Build the base image with openfl installed from pip and gramine from apt:
+```
+DOCKER_BUILDKIT=1 docker build -t gramine_openfl -f openfl-gramine/Dockerfile.gramine .
+```
+
+2. Create a workspace. Modify code and the plan.yaml.
+- make sure data loading code reads data from ./data folder inside the workspace
+- make sure you do not use any CUDA driver-dependent packages
+- Find out the FQDN of the aggregator machine and use during plan initialization
+
+3. Do `fx plan initialize -a ${FQDN}`
+
+4. Do `fx workspace export`
+
+4.5 cd one folder up
+
+5. Generate a signer key on building machine to hash trusted files
+```
+openssl genrsa -3 -out ./key.pem 3072
+```
+6. Build dockerized workspace and gramine app
+```
+EXP_NAME=kvasir
+FEDERATION=fed_work12345alpha81671
+DOCKER_BUILDKIT=1
+docker build -t ${EXP_NAME} \
+--build-arg WORKSPACE_ARCHIVE=${FEDERATION}/${FEDERATION}.zip \
+--secret id=signer-key,src=./key.pem \
+-f ./openfl-gramine/Dockerfile.graminized.workspace . 
+```
+
+7. Transfer the image to the aggregator an collaborator machines
+```
+EXP_NAME=kvasir
+docker save ${EXP_NAME} | gzip > ${EXP_NAME}.tar.gz
+```
+
+transfer file:
+```
+scp idavidyu@nnlicv674.inn.intel.com:/home/idavidyu/openfl/kvasir.tar.gz .
+```
+
+on the running machines:
+```
+EXP_NAME=kvasir
+docker load < ${EXP_NAME}.tar.gz
+```
+8. Transfer initial model weights from save/ directory to aggregator machine.
+
+9. Register collaborators. Signing requests process is coupled with modifying cols.yaml on the aggregator machine and data.yaml files in collaborator machines
+In the end of this step you should have signed certificates on all the machines, cols.yaml file on aggregator 
+and data.yaml files on collaborators.
+
+10. Run aggregator
+```
+EXP_NAME=kvasir
+FEDERATION_PATH=/home/idavidyu/openfl-rebased-gramine/openfl/fed_work12345alpha81671
+docker run -it --rm --device=/dev/sgx_enclave --volume=/var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket \
+--network=host \
+--volume=${FEDERATION_PATH}/cert:/workspace/cert \
+--volume=${FEDERATION_PATH}/logs:/workspace/logs \
+--volume=${FEDERATION_PATH}/plan/cols.yaml:/workspace/plan/cols.yaml \
+--mount type=bind,src=${FEDERATION_PATH}/save,dst=/workspace/save,readonly=0 \
+${EXP_NAME} aggregator start
+```
+
+No SGX (gramine-direct):
+
+```
+EXP_NAME=kvasir
+FEDERATION=fed_work12345alpha81671
+docker run -it --rm --security-opt seccomp=unconfined \
+--network=host \
+--volume=/home/idavidyu/openfl/${FEDERATION}/cert:/workspace/cert \
+--volume=/home/idavidyu/openfl/${FEDERATION}/logs:/workspace/logs \
+--mount type=bind,src=/home/idavidyu/openfl/${FEDERATION}/save,dst=/workspace/save,readonly=0 \
+${EXP_NAME} aggregator start
+```
+11. Run collaborator
+```
+EXP_NAME=kvasir
+FEDERATION=fed_work12345alpha81671
+COL_NAME=two
+COL_NAME=one
+docker run -it --rm --device=/dev/sgx_enclave --volume=/var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket \
+--network=host \
+--volume=/home/idavidyu/openfl-rebased-gramine/openfl/${FEDERATION}/${COL_NAME}/${FEDERATION}/cert:/workspace/cert \
+--volume=/home/idavidyu/openfl-rebased-gramine/openfl/${FEDERATION}/${COL_NAME}/${FEDERATION}/plan/data.yaml:/workspace/plan/data.yaml \
+--volume=/home/idavidyu/openfl-rebased-gramine/openfl/${FEDERATION}/data:/workspace/data \
+${EXP_NAME} collaborator start -n ${COL_NAME}
+```

--- a/openfl-gramine/MANUAL.md
+++ b/openfl-gramine/MANUAL.md
@@ -4,12 +4,12 @@ This manual will help you run OpenFL with Aggregator-based workflow inside SGX e
 - [X] import manifest and makefile from OpenFL dist-package 
 - [X] pass wheel repository to pip (for CPU versions of PyTorch for example)
 - [ ] get rid of command line args (insecure)
-- [ ] introduce `fx workspace create --prefix WORKSPACE_NAME` command without --template option to the OpenFL CLI, that will create just an empty workspace with the right folder structure.
+- [ ] introduce `fx workspace create --prefix WORKSPACE_NAME` command without --template option to the OpenFL CLI, which will create just an empty workspace with the right folder structure.
 - [ ] introduce `fx *actor* start --from image`
 
 ## Known issues:
 - Kvasir experiment: aggregation takes really long, debug log-level does not show the reason
-- We need workspace zip to import it and create certs. We need to know the number of collaborators prior to zipping the workspace. SOLUTOIN: mount cols.yaml and data.yaml
+- We need workspace zip to import it and create certs. We need to know the number of collaborators prior to zipping the workspace. SOLUTION: mount cols.yaml and data.yaml
 - During plan initialization we need data to initialize the model. so at least one collaborator should be in data.yaml and its data should be available. cols.yaml may be empty at first
 During cert sign request generation cols.yaml on collaborators remain empty, data.yaml is extended if needed. On aggregator, cols.yaml are updated during signing procedure, data.yaml remains unmodified
 - `error: Disallowing access to file '/usr/local/lib/python3.8/__pycache__/signal.cpython-38.pyc.3423950304'; file is not protected, trusted or allowed.`
@@ -74,7 +74,7 @@ If a signing key is not provided, the application will be built without SGX supp
 ### Image distribution:
 Data scientist (builder) now must transfer the Docker image to the aggregator and collaborator machines. The Aggregator will also need initial model weights.
 
-5. **Transfer files** to the aggregator an collaborator machines.
+5. **Transfer files** to the aggregator and collaborator machines.
 If there is a connection between machines, you may use `scp`. In other cases use the transfer channel that suits your situation.</br>
 Send files to the aggregator machine:
 ```

--- a/openfl-gramine/MANUAL.md
+++ b/openfl-gramine/MANUAL.md
@@ -85,19 +85,34 @@ docker load < WORKSPACE_NAME.tar.gz
 Certificates exchange is a big separate topic. To run an experiment following OpenFL Aggregator-based workflow, user must follow the established procedure, please refer to [the docs](https://openfl.readthedocs.io/en/latest/running_the_federation.html#bare-metal-approach).
 Following the above-mentioned procedure, running machines will acquire certificates. Moreover, as the result of this procedure, the aggregator machine will also obtain a `cols.yaml` file (required to start an experiment) with registered collaborators names, and the collaborator machines will obtain `data.yaml` files.
 
-We recoment replicate the OpenFL workspace folder structure on all the machines and follow the usual certifying procedure. Finally, on aggregator you should have the following folder structure:
+We recoment replicate the OpenFL workspace folder structure on all the machines and follow the usual certifying procedure. Finally, on the aggregator node you should have the following folder structure:
 ```
 workspace/
 --save/WORKSPACE_NAME_init.pbuf
 --logs/
 --plan/cols.yaml
---cert
+--cert/
+  --client/*col.crt
+  --server/
+    --agg_FQDN.crt
+    --agg_FQDN.key
+```
+
+On collaborator nodes:
+```
+workspace/
+--data/*dataset*
+--plan/data.yaml
+--cert/
+  --client/
+    --col_name.crt
+    --col_name.key
 ```
 
 10. Run aggregator
 ```
-EXP_NAME=kvasir
-FEDERATION_PATH=/home/idavidyu/openfl-rebased-gramine/openfl/fed_work12345alpha81671
+EXP_NAME=federation
+FEDERATION_PATH=/home/idavidyu/openfl/federation
 docker run -it --rm --device=/dev/sgx_enclave --volume=/var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket \
 --network=host \
 --volume=${FEDERATION_PATH}/cert:/workspace/cert \
@@ -110,13 +125,14 @@ ${EXP_NAME} aggregator start
 No SGX (gramine-direct):
 
 ```
-EXP_NAME=kvasir
-FEDERATION=fed_work12345alpha81671
+EXP_NAME=federation
+FEDERATION_PATH=/home/idavidyu/openfl/fed_work12345alpha81671
 docker run -it --rm --security-opt seccomp=unconfined \
 --network=host \
---volume=/home/idavidyu/openfl/${FEDERATION}/cert:/workspace/cert \
---volume=/home/idavidyu/openfl/${FEDERATION}/logs:/workspace/logs \
---mount type=bind,src=/home/idavidyu/openfl/${FEDERATION}/save,dst=/workspace/save,readonly=0 \
+--volume=${FEDERATION_PATH}/cert:/workspace/cert \
+--volume=${FEDERATION_PATH}/logs:/workspace/logs \
+--volume=${FEDERATION_PATH}/plan/cols.yaml:/workspace/plan/cols.yaml \
+--mount type=bind,src=${FEDERATION_PATH}/save,dst=/workspace/save,readonly=0 \
 ${EXP_NAME} aggregator start
 ```
 11. Run collaborator

--- a/openfl-gramine/Makefile
+++ b/openfl-gramine/Makefile
@@ -1,6 +1,6 @@
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
-# This is a signer key on a BUILDING machine
+# This is a signer key on the BUILDING machine
 SGX_SIGNER_KEY ?= /key.pem
 
 ifeq ($(DEBUG),1)
@@ -16,6 +16,7 @@ all: openfl.manifest.sgx openfl.sig openfl.token
 endif
 
 openfl.manifest: openfl.manifest.template
+	@echo "Making openfl.manifest file"
 	gramine-manifest \
 		-Dlog_level=$(GRAMINE_LOG_LEVEL) \
 		-Darch_libdir=$(ARCH_LIBDIR) \
@@ -25,6 +26,7 @@ openfl.manifest: openfl.manifest.template
 		$< >$@
 
 openfl.manifest.sgx: openfl.manifest
+	@echo "Making openfl.manifest.sgx file"
 	@test -s $(SGX_SIGNER_KEY) || \
 	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	gramine-sgx-sign \
@@ -35,6 +37,7 @@ openfl.manifest.sgx: openfl.manifest
 openfl.sig: openfl.manifest.sgx
 
 openfl.token: openfl.sig
+	@echo "Making openfl.sig file"
 	gramine-sgx-get-token --output $@ --sig $<
 
 

--- a/openfl-gramine/Makefile
+++ b/openfl-gramine/Makefile
@@ -1,0 +1,47 @@
+ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
+
+# This is a signer key on a BUILDING machine
+SGX_SIGNER_KEY ?= /key.pem
+
+ifeq ($(DEBUG),1)
+GRAMINE_LOG_LEVEL = debug
+else
+GRAMINE_LOG_LEVEL = error
+endif
+
+.PHONY: all
+all: openfl.manifest
+ifeq ($(SGX),1)
+all: openfl.manifest.sgx openfl.sig openfl.token
+endif
+
+openfl.manifest: openfl.manifest.template
+	gramine-manifest \
+		-Dlog_level=$(GRAMINE_LOG_LEVEL) \
+		-Darch_libdir=$(ARCH_LIBDIR) \
+		-Dno_proxy=$(no_proxy) \
+		-Dhttp_proxy=$(http_proxy) \
+		-Dhttps_proxy=$(https_proxy) \
+		$< >$@
+
+openfl.manifest.sgx: openfl.manifest
+	@test -s $(SGX_SIGNER_KEY) || \
+	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
+	gramine-sgx-sign \
+		--key $(SGX_SIGNER_KEY) \
+		--manifest $< \
+		--output $@
+
+openfl.sig: openfl.manifest.sgx
+
+openfl.token: openfl.sig
+	gramine-sgx-get-token --output $@ --sig $<
+
+
+.PHONY: clean
+clean:
+	$(RM) *.manifest *.manifest.sgx *.token *.sig OUTPUT* *.PID TEST_STDOUT TEST_STDERR
+	$(RM) -r scripts/__pycache__
+
+.PHONY: distclean
+distclean: clean

--- a/openfl-gramine/openfl.manifest.template
+++ b/openfl-gramine/openfl.manifest.template
@@ -30,10 +30,6 @@ fs.mount.usr.type = "chroot"
 fs.mount.usr.path = "/usr"
 fs.mount.usr.uri = "file:/usr"
 
-fs.mount.tmp.type = "chroot"
-fs.mount.tmp.path = "/tmp"
-fs.mount.tmp.uri = "file:/tmp"
-
 fs.mount.etc.type = "chroot"
 fs.mount.etc.path = "/etc"
 fs.mount.etc.uri = "file:/etc"

--- a/openfl-gramine/openfl.manifest.template
+++ b/openfl-gramine/openfl.manifest.template
@@ -69,6 +69,7 @@ sgx.trusted_files = [
 ]
 
 sgx.allowed_files = [
+  "file:/tmp"
   "file:/etc",
   "file:/workspace/save",
   "file:/workspace/logs",

--- a/openfl-gramine/openfl.manifest.template
+++ b/openfl-gramine/openfl.manifest.template
@@ -52,7 +52,7 @@ sgx.debug = false
 sgx.nonpie_binary = true
 sgx.enclave_size = "16G"
 sys.stack.size = "4M"
-sgx.thread_num = 128
+sgx.thread_num = 256
 #sys.brk.max_size = "1M"
 
 sgx.trusted_files = [

--- a/openfl-gramine/openfl.manifest.template
+++ b/openfl-gramine/openfl.manifest.template
@@ -52,7 +52,7 @@ sgx.debug = false
 sgx.nonpie_binary = true
 sgx.enclave_size = "16G"
 sys.stack.size = "4M"
-sgx.thread_num = 64
+sgx.thread_num = 128
 #sys.brk.max_size = "1M"
 
 sgx.trusted_files = [

--- a/openfl-gramine/openfl.manifest.template
+++ b/openfl-gramine/openfl.manifest.template
@@ -52,7 +52,7 @@ sgx.debug = false
 sgx.nonpie_binary = true
 sgx.enclave_size = "16G"
 sys.stack.size = "4M"
-sgx.thread_num = 256
+sgx.thread_num = 512
 #sys.brk.max_size = "1M"
 
 sgx.trusted_files = [

--- a/openfl-gramine/openfl.manifest.template
+++ b/openfl-gramine/openfl.manifest.template
@@ -1,0 +1,79 @@
+loader.preload = "file:{{ gramine.libos }}"
+libos.entrypoint = "/usr/local/bin/python3.8"
+loader.log_level = "{{ log_level }}"
+
+loader.env.LD_LIBRARY_PATH = "{{ python.stdlib }}/lib:/lib:{{ arch_libdir }}:/usr/lib:/usr/{{ arch_libdir }}"
+loader.env.no_proxy = "{{ no_proxy }}"
+loader.env.https_proxy = "{{ https_proxy }}"
+loader.env.http_proxy = "{{ http_proxy }}"
+loader.env.SSL_CERT_DIR = "/etc/ssl/certs"
+
+loader.insecure__use_cmdline_argv = true
+
+sys.enable_sigterm_injection = true
+
+fs.start_dir="/workspace"
+
+
+# .URI - path on host
+# .PATH - pointer inside gramine
+
+fs.mount.lib.type = "chroot"
+fs.mount.lib.path = "/lib"
+fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
+
+fs.mount.lib2.type = "chroot"
+fs.mount.lib2.path = "{{ arch_libdir }}"
+fs.mount.lib2.uri = "file:{{ arch_libdir }}"
+
+fs.mount.usr.type = "chroot"
+fs.mount.usr.path = "/usr"
+fs.mount.usr.uri = "file:/usr"
+
+fs.mount.tmp.type = "chroot"
+fs.mount.tmp.path = "/tmp"
+fs.mount.tmp.uri = "file:/tmp"
+
+fs.mount.etc.type = "chroot"
+fs.mount.etc.path = "/etc"
+fs.mount.etc.uri = "file:/etc"
+
+fs.mount.workspace.type = "chroot"
+fs.mount.workspace.path = "/workspace"
+fs.mount.workspace.uri = "file:/workspace"
+
+sgx.preheat_enclave = false
+
+# Detected a huge manifest, preallocating 64MB of internal memory.
+# error: Too small `loader.pal_internal_mem_size`, need at least 64MB because the manifest is large
+loader.pal_internal_mem_size = "256M"
+
+sgx.debug = false
+sgx.nonpie_binary = true
+sgx.enclave_size = "16G"
+sys.stack.size = "4M"
+sgx.thread_num = 64
+#sys.brk.max_size = "1M"
+
+sgx.trusted_files = [
+  "file:/usr/local/bin/python3.8",
+  "file:{{ gramine.runtimedir() }}/",
+  "file:{{ arch_libdir }}/",
+  "file:/usr/{{ arch_libdir }}/",
+  "file:/usr/local/lib/python3.8/",
+  "file:/usr/local/lib/libpython3.8.so.1.0",
+  "file:/usr/lib/python3/dist-packages/",
+  "file:/workspace/src/",
+  "file:/workspace/plan/plan.yaml",
+  "file:/usr/local/bin/fx",
+]
+
+sgx.allowed_files = [
+  "file:/etc",
+  "file:/workspace/save",
+  "file:/workspace/logs",
+  "file:/workspace/cert",
+  "file:/workspace/data",
+  "file:/workspace/plan/cols.yaml",
+  "file:/workspace/plan/data.yaml",
+]

--- a/openfl-gramine/openfl.manifest.template
+++ b/openfl-gramine/openfl.manifest.template
@@ -69,7 +69,7 @@ sgx.trusted_files = [
 ]
 
 sgx.allowed_files = [
-  "file:/tmp"
+  "file:/tmp",
   "file:/etc",
   "file:/workspace/save",
   "file:/workspace/logs",

--- a/openfl-gramine/start_process.sh
+++ b/openfl-gramine/start_process.sh
@@ -1,3 +1,3 @@
 fx_command=$@;
 
-$GRAMINE_EXECUTABLE ./openfl $fx_command
+$GRAMINE_EXECUTABLE ./openfl /usr/local/bin/fx $fx_command

--- a/openfl-gramine/start_process.sh
+++ b/openfl-gramine/start_process.sh
@@ -1,0 +1,3 @@
+fx_command=$@;
+
+$GRAMINE_EXECUTABLE ./openfl $fx_command

--- a/openfl-workspace/keras_nlp_gramine_ready/.workspace
+++ b/openfl-workspace/keras_nlp_gramine_ready/.workspace
@@ -1,0 +1,2 @@
+current_plan_name: default
+

--- a/openfl-workspace/keras_nlp_gramine_ready/plan/cols.yaml
+++ b/openfl-workspace/keras_nlp_gramine_ready/plan/cols.yaml
@@ -1,0 +1,5 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# Licensed subject to the terms of the separately executed evaluation license agreement between Intel Corporation and you.
+
+collaborators:
+  

--- a/openfl-workspace/keras_nlp_gramine_ready/plan/data.yaml
+++ b/openfl-workspace/keras_nlp_gramine_ready/plan/data.yaml
@@ -1,0 +1,7 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# Licensed subject to the terms of the separately executed evaluation license agreement between Intel Corporation and you.
+
+# collaborator_name,data_directory_path
+one,1
+
+  

--- a/openfl-workspace/keras_nlp_gramine_ready/plan/plan.yaml
+++ b/openfl-workspace/keras_nlp_gramine_ready/plan/plan.yaml
@@ -1,0 +1,47 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# Licensed subject to the terms of the separately executed evaluation license agreement between Intel Corporation and you.
+
+aggregator :
+  defaults : plan/defaults/aggregator.yaml
+  template : openfl.component.Aggregator
+  settings :
+    init_state_path : save/keras_nlp_init.pbuf
+    best_state_path : save/keras_nlp_best.pbuf
+    last_state_path : save/keras_nlp_last.pbuf
+    rounds_to_train : 10
+
+collaborator :
+  defaults : plan/defaults/collaborator.yaml
+  template : openfl.component.Collaborator
+  settings :
+    epochs_per_round : 10
+    polling_interval : 4
+    delta_updates    : false
+    opt_treatment    : RESET
+
+data_loader :
+  defaults : plan/defaults/data_loader.yaml
+  template : src.nlp_dataloader.NLPDataLoader
+  settings :
+    collaborator_count : 2
+    batch_size         : 64
+    split_ratio: 0.2
+    num_samples: 10000
+
+task_runner :
+  defaults : plan/defaults/task_runner.yaml
+  template : src.nlp_taskrunner.KerasNLP
+  settings :
+    latent_dim : 256
+
+network :
+  defaults : plan/defaults/network.yaml
+
+assigner :
+  defaults : plan/defaults/assigner.yaml
+
+tasks :
+  defaults : plan/defaults/tasks_keras.yaml
+
+compression_pipeline :
+  defaults : plan/defaults/compression_pipeline.yaml

--- a/openfl-workspace/keras_nlp_gramine_ready/requirements.txt
+++ b/openfl-workspace/keras_nlp_gramine_ready/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow-cpu==2.7.0

--- a/openfl-workspace/keras_nlp_gramine_ready/src/__init__.py
+++ b/openfl-workspace/keras_nlp_gramine_ready/src/__init__.py
@@ -1,0 +1,1 @@
+"""openfl nlp keras template."""

--- a/openfl-workspace/keras_nlp_gramine_ready/src/dataloader_utils.py
+++ b/openfl-workspace/keras_nlp_gramine_ready/src/dataloader_utils.py
@@ -1,0 +1,220 @@
+"""Copyright (C) 2020-2021 Intel Corporation.
+
+Licensed subject to the terms of the separately executed evaluation
+license agreement between Intel Corporation and you.
+"""
+from logging import getLogger
+from os import getcwd
+from os import path
+from os import remove
+from zipfile import ZipFile
+
+import numpy as np
+import requests
+
+logger = getLogger(__name__)
+
+
+def download_data_():
+    """Download data.
+
+    Returns:
+      string: relative path to data file
+    """
+    pkg = 'fra-eng.zip'   # Language file: change this to change the language
+    data_dir = 'data'
+    url = 'http://www.manythings.org/anki/' + pkg
+    filename = pkg.split('-')[0] + '.txt'
+
+    workspace_dir = getcwd()
+    default_path = path.join(workspace_dir, data_dir)
+    pkgpath = path.join(default_path, pkg)       # path to downloaded zipfile
+    filepath = path.join(default_path, filename)  # path to extracted file
+
+    if path.isfile(filepath):
+        return path.join(data_dir, filename)
+    try:
+        response = requests.get(url, headers={'User-Agent': 'openfl'})
+        if response.status_code == 200:
+            with open(pkgpath, 'wb') as f:
+                f.write(response.content)
+        else:
+            print(f'Error while downloading {pkg} from {url}: Aborting!')
+            exit()
+    except Exception:
+        print(f'Error while downloading {pkg} from {url}: Aborting!')
+        exit()
+
+    try:
+        with ZipFile(pkgpath, 'r') as z:
+            z.extract(filename, default_path)
+    except Exception:
+        print(f'Error while extracting {pkgpath}: Aborting!')
+        exit()
+
+    if path.isfile(filepath):
+        remove(pkgpath)
+        return path.join(data_dir, filename)
+    else:
+        return ''
+
+
+def import_raw_data_(data_path='', num_samples=0):
+    """Import data.
+
+    Returns:
+      dict: variable details
+      numpy.ndarray: encoder input data
+      numpy.ndarray: decoder input data
+      numpy.ndarray: decoder labels
+    """
+    # Vectorize the data.
+    input_texts = []
+    target_texts = []
+    input_characters = set()
+    target_characters = set()
+    with open(data_path, 'r', encoding='utf-8') as f:
+        lines = f.read().split('\n')
+    for line in lines[: min(num_samples, len(lines) - 1)]:
+        input_text, target_text, _ = line.split('\t')
+        # We use 'tab' as the 'start sequence' character
+        # for the targets, and '\n' as 'end sequence' character.
+        target_text = '\t' + target_text + '\n'
+        input_texts.append(input_text)
+        target_texts.append(target_text)
+        for char in input_text:
+            if char not in input_characters:
+                input_characters.add(char)
+        for char in target_text:
+            if char not in target_characters:
+                target_characters.add(char)
+
+    input_characters = sorted(input_characters)
+    target_characters = sorted(target_characters)
+    num_encoder_tokens = len(input_characters)
+    num_decoder_tokens = len(target_characters)
+    max_encoder_seq_length = max([len(txt) for txt in input_texts])
+    max_decoder_seq_length = max([len(txt) for txt in target_texts])
+
+    details = {'num_samples': len(input_texts),
+               'num_encoder_tokens': num_encoder_tokens,
+               'num_decoder_tokens': num_decoder_tokens,
+               'max_encoder_seq_length': max_encoder_seq_length,
+               'max_decoder_seq_length': max_decoder_seq_length}
+
+    input_token_index = {char: i for i, char in enumerate(input_characters)}
+    target_token_index = {char: i for i, char in enumerate(target_characters)}
+
+    encoder_input_data = np.zeros(
+        (len(input_texts), max_encoder_seq_length, num_encoder_tokens), dtype='float32')
+
+    decoder_input_data = np.zeros(
+        (len(input_texts), max_decoder_seq_length, num_decoder_tokens), dtype='float32')
+
+    decoder_target_data = np.zeros(
+        (len(input_texts), max_decoder_seq_length, num_decoder_tokens), dtype='float32')
+
+    for i, (input_text, target_text) in enumerate(zip(input_texts, target_texts)):
+        for t, char in enumerate(input_text):
+            encoder_input_data[i, t, input_token_index[char]] = 1.0
+        encoder_input_data[i, t + 1:, input_token_index[' ']] = 1.0
+        for t, char in enumerate(target_text):
+            # decoder_target_data is ahead of decoder_input_data by one timestep
+            decoder_input_data[i, t, target_token_index[char]] = 1.0
+            if t > 0:
+                # decoder_target_data will be ahead by one timestep
+                # and will not include the start character.
+                decoder_target_data[i, t - 1, target_token_index[char]] = 1.0
+        decoder_input_data[i, t + 1:, target_token_index[' ']] = 1.0
+        decoder_target_data[i, t:, target_token_index[' ']] = 1.0
+
+    logger.info(f'[DL]-import_raw_data: Number of samples = {len(input_texts)}')
+    logger.info(f'[DL]-import_raw_data: Number of unique input tokens = {num_encoder_tokens}')
+    logger.info(f'[DL]-import_raw_data: '
+                f'Number of unique decoder tokens = {num_decoder_tokens}')
+
+    logger.info(f'[DL]-import_raw_data: '
+                f'Max sequence length for inputs = {max_encoder_seq_length}')
+
+    logger.info(f'[DL]-import_raw_data: '
+                f'Max sequence length for outputs = {max_decoder_seq_length}')
+
+    logger.info(f'[DL]-import_raw_data: encoder_input_data = {encoder_input_data.shape}')
+    logger.info(f'[DL]-import_raw_data: decoder_input_data = {decoder_input_data.shape}')
+    logger.info(f'[DL]-import_raw_data: decoder_target_data = {decoder_target_data.shape}')
+
+    return details, encoder_input_data, decoder_input_data, decoder_target_data
+
+
+def get_datasets_(encoder_input_data, decoder_input_data,
+                  decoder_target_data, num_samples, split_ratio):
+    """Create train/val.
+
+    Returns:
+      dict: Results, containing the train-valid split of the dataset (split_ratio = 0.2)
+    """
+    import random
+
+    random.seed(42)
+    train_indexes = random.sample(range(num_samples), int(num_samples * (1 - split_ratio)))
+    valid_indexes = np.delete(range(num_samples), train_indexes)
+
+    # Dataset creation (2 inputs <encoder,decoder>, 1 output <decoder_target>)
+    encoder_train_input = encoder_input_data[train_indexes, :, :]
+    decoder_train_input = decoder_input_data[train_indexes, :, :]
+    decoder_train_labels = decoder_target_data[train_indexes, :, :]
+
+    encoder_valid_input = encoder_input_data[valid_indexes, :, :]
+    decoder_valid_input = decoder_input_data[valid_indexes, :, :]
+    decoder_valid_labels = decoder_target_data[valid_indexes, :, :]
+
+    results = {'encoder_train_input': encoder_train_input,
+               'decoder_train_input': decoder_train_input,
+               'decoder_train_labels': decoder_train_labels,
+               'encoder_valid_input': encoder_valid_input,
+               'decoder_valid_input': decoder_valid_input,
+               'decoder_valid_labels': decoder_valid_labels}
+
+    logger.info(f'[DL]get_datasets: encoder_train_input = {encoder_train_input.shape}')
+    logger.info(f'[DL]get_datasets: decoder_train_labels= {decoder_train_labels.shape}')
+
+    return results
+
+
+def load_shard(collaborator_count, shard_num, data_path, num_samples, split_ratio):
+    """Load data-shards.
+
+    Returns:
+      Tuple: ( numpy.ndarray: X_train_encoder,
+               numpy.ndarray: X_train_decoder,
+               numpy.ndarray: y_train)
+      Tuple: ( numpy.ndarray: X_valid_encoder,
+               numpy.ndarray: X_valid_decoder,
+               numpy.ndarray: y_valid)
+      Dict: details, from DataLoader_utils.get_datasets
+    """
+    details, encoder_input_data, decoder_input_data, decoder_target_data = import_raw_data_(
+        data_path,
+        num_samples
+    )
+
+    train_val_dataset = get_datasets_(encoder_input_data, decoder_input_data,
+                                      decoder_target_data, num_samples, split_ratio)
+    # Get the data shards
+    shard_num = int(shard_num)
+    X_train_encoder = train_val_dataset['encoder_train_input'][shard_num::collaborator_count]
+    X_train_decoder = train_val_dataset['decoder_train_input'][shard_num::collaborator_count]
+    y_train = train_val_dataset['decoder_train_labels'][shard_num::collaborator_count]
+
+    X_valid_encoder = train_val_dataset['encoder_valid_input'][shard_num::collaborator_count]
+    X_valid_decoder = train_val_dataset['decoder_valid_input'][shard_num::collaborator_count]
+    y_valid = train_val_dataset['decoder_valid_labels'][shard_num::collaborator_count]
+
+    logger.info(f'[DL]load_shard: X_train_encoder = {X_train_encoder.shape}')
+    logger.info(f'[DL]load_shard: y_train = {y_train.shape}')
+
+    return (
+        (X_train_encoder, X_train_decoder, y_train),
+        (X_valid_encoder, X_valid_decoder, y_valid),
+        details
+    )

--- a/openfl-workspace/keras_nlp_gramine_ready/src/nlp_dataloader.py
+++ b/openfl-workspace/keras_nlp_gramine_ready/src/nlp_dataloader.py
@@ -1,0 +1,132 @@
+"""Copyright (C) 2020-2021 Intel Corporation.
+
+Licensed subject to the terms of the separately executed evaluation
+license agreement between Intel Corporation and you.
+"""
+from logging import getLogger
+
+import numpy as np
+import src.dataloader_utils as dlu
+
+from openfl.federated import KerasDataLoader
+
+logger = getLogger(__name__)
+
+
+class NLPDataLoader(KerasDataLoader):
+    """NLP Dataloader template."""
+
+    def __init__(self, collaborator_count, split_ratio,
+                 num_samples, data_path, batch_size, **kwargs):
+        """Instantiate the data object.
+
+        Args:
+            data_path: The file path to the data Returns:
+            batch_size: The batch size of the data loader tuple: shape of an example feature array
+            **kwargs: Additional arguments, passed to super init and load_mnist_shard
+
+        Returns:
+           none
+        """
+        self.shard_num = data_path
+        self.data_path = dlu.download_data_()
+
+        self.batch_size = batch_size
+
+        train, valid, details = dlu.load_shard(collaborator_count, self.shard_num,
+                                               self.data_path, num_samples, split_ratio)
+
+        self.num_samples = details['num_samples']
+        self.num_encoder_tokens = details['num_encoder_tokens']
+        self.num_decoder_tokens = details['num_decoder_tokens']
+        self.max_encoder_seq_length = details['max_encoder_seq_length']
+        self.max_decoder_seq_length = details['max_decoder_seq_length']
+
+        self.X_train = [train[0], train[1]]
+        self.y_train = train[2]
+        self.X_valid = [valid[0], valid[1]]
+        self.y_valid = valid[2]
+
+    def get_feature_shape(self):
+        """Get the shape of an example feature array."""
+        return self.X_train[0].shape
+
+    def get_train_loader(self, batch_size=None):
+        """
+        Get training data loader.
+
+        Returns
+        -------
+        loader object
+        """
+        return self._get_batch_generator(X1=self.X_train[0], X2=self.X_train[1],
+                                         y=self.y_train, batch_size=batch_size)
+
+    def get_valid_loader(self, batch_size=None):
+        """
+        Get validation data loader.
+
+        Returns:
+            loader object
+        """
+        return self._get_batch_generator(X1=self.X_valid[0], X2=self.X_valid[1],
+                                         y=self.y_valid, batch_size=batch_size)
+
+    def get_train_data_size(self):
+        """
+        Get total number of training samples.
+
+        Returns:
+            int: number of training samples
+        """
+        return self.X_train[0].shape[0]
+
+    def get_valid_data_size(self):
+        """
+        Get total number of validation samples.
+
+        Returns:
+            int: number of validation samples
+        """
+        return self.X_valid[0].shape[0]
+
+    @staticmethod
+    def _batch_generator(X1, X2, y, idxs, batch_size, num_batches):
+        """
+        Generate batch of data.
+
+        Args:
+            X: input data
+            y: label data
+            idxs: The index of the dataset
+            batch_size: The batch size for the data loader
+            num_batches: The number of batches
+        Yields:
+            tuple: input data, label data
+        """
+        for i in range(num_batches):
+            a = i * batch_size
+            b = a + batch_size
+            yield [X1[idxs[a:b]], X2[idxs[a:b]]], y[idxs[a:b]]
+
+    def _get_batch_generator(self, X1, X2, y, batch_size):
+        """
+        Return the dataset generator.
+
+        Args:
+            X1: input data  (encoder)
+            X2: input data  (decoder)
+            y: label data
+            batch_size: The batch size for the data loader
+        """
+        if batch_size is None:
+            batch_size = self.batch_size
+        # shuffle data indices
+        idxs = np.random.permutation(np.arange(X1.shape[0]))
+        # compute the number of batches
+        num_batches = int(np.ceil(X1.shape[0] / batch_size))
+        # build the generator and return it
+        # TODO: due to _batch_generator(X1, ...) has first param X1, all params here will be moved,
+        #       X1 -> X2, X2 -> y, y -> idxs, idxs -> batch_size, batch_size -> num_batches,
+        #       and num_batches -> should be unexpected in this function
+        return self._batch_generator(X1, X2, y, idxs, batch_size, num_batches)

--- a/openfl-workspace/keras_nlp_gramine_ready/src/nlp_taskrunner.py
+++ b/openfl-workspace/keras_nlp_gramine_ready/src/nlp_taskrunner.py
@@ -1,0 +1,72 @@
+"""Copyright (C) 2020-2021 Intel Corporation.
+
+Licensed subject to the terms of the separately executed evaluation
+license agreement between Intel Corporation and you.
+"""
+from tensorflow import keras
+
+from openfl.federated import KerasTaskRunner
+
+
+def build_model(latent_dim, num_encoder_tokens, num_decoder_tokens, **kwargs):
+    """
+    Define the model architecture.
+
+    Args:
+        input_shape (numpy.ndarray): The shape of the data
+        num_classes (int): The number of classes of the dataset
+    Returns:
+        tensorflow.python.keras.engine.sequential.Sequential: The model defined in Keras
+    """
+    encoder_inputs = keras.Input(shape=(None, num_encoder_tokens))
+    encoder = keras.layers.LSTM(latent_dim, return_state=True)
+    encoder_outputs, state_h, state_c = encoder(encoder_inputs)
+
+    # We discard `encoder_outputs` and only keep the states.
+    encoder_states = [state_h, state_c]
+
+    # Set up the decoder, using `encoder_states` as initial state.
+    decoder_inputs = keras.Input(shape=(None, num_decoder_tokens))
+
+    # We set up our decoder to return full output sequences,
+    # and to return internal states as well. We don't use the
+    # return states in the training model, but we will use them in inference.
+    decoder_lstm = keras.layers.LSTM(latent_dim, return_sequences=True, return_state=True)
+    decoder_outputs, _, _ = decoder_lstm(decoder_inputs, initial_state=encoder_states)
+    decoder_dense = keras.layers.Dense(num_decoder_tokens, activation='softmax')
+    decoder_outputs = decoder_dense(decoder_outputs)
+
+    # Define the model that will turn
+    # `encoder_input_data` & `decoder_input_data` into `decoder_target_data`
+    model = keras.Model([encoder_inputs, decoder_inputs], decoder_outputs)
+
+    model.compile(
+        optimizer='rmsprop', loss='categorical_crossentropy', metrics=['accuracy']
+    )
+
+    return model
+
+
+class KerasNLP(KerasTaskRunner):
+    """A basic convolutional neural network model."""
+
+    def __init__(self, latent_dim, **kwargs):
+        """
+        Init taskrunner.
+
+        Args:
+            **kwargs: Additional parameters to pass to the function
+        """
+        super().__init__(**kwargs)
+
+        self.model = build_model(latent_dim,
+                                 self.data_loader.num_encoder_tokens,
+                                 self.data_loader.num_decoder_tokens,
+                                 **kwargs)
+
+        self.initialize_tensorkeys_for_functions()
+
+        self.model.summary(print_fn=self.logger.info)
+
+        if self.data_loader is not None:
+            self.logger.info(f'Train Set Size : {self.get_train_data_size()}')

--- a/openfl-workspace/torch_cnn_histology/src/histology_utils.py
+++ b/openfl-workspace/torch_cnn_histology/src/histology_utils.py
@@ -6,7 +6,7 @@
 from collections.abc import Iterable
 from logging import getLogger
 from os import makedirs
-from os import path
+from pathlib import Path
 from urllib.request import urlretrieve
 from zipfile import ZipFile
 
@@ -31,21 +31,20 @@ class HistologyDataset(ImageFolder):
     FOLDER_NAME = 'Kather_texture_2016_image_tiles_5000'
     ZIP_SHA384 = ('7d86abe1d04e68b77c055820c2a4c582a1d25d2983e38ab724e'
                   'ac75affce8b7cb2cbf5ba68848dcfd9d84005d87d6790')
-    DEFAULT_PATH = path.join(path.expanduser('~'), '.openfl', 'data')
+    DEFAULT_PATH = Path.cwd().absolute() / 'data'
 
-    def __init__(self, root: str = DEFAULT_PATH, **kwargs) -> None:
+    def __init__(self, root: Path = DEFAULT_PATH, **kwargs) -> None:
         """Initialize."""
         makedirs(root, exist_ok=True)
-        filepath = path.join(root, HistologyDataset.FILENAME)
-        if not path.exists(filepath):
+        filepath = root / HistologyDataset.FILENAME
+        if not filepath.is_file():
             self.pbar = tqdm(total=None)
             urlretrieve(HistologyDataset.URL, filepath, self.report_hook)  # nosec
             validate_file_hash(filepath, HistologyDataset.ZIP_SHA384)
             with ZipFile(filepath, 'r') as f:
                 f.extractall(root)
 
-        super(HistologyDataset, self).__init__(
-            path.join(root, HistologyDataset.FOLDER_NAME), **kwargs)
+        super(HistologyDataset, self).__init__(root / HistologyDataset.FOLDER_NAME, **kwargs)
 
     def report_hook(self, count, block_size, total_size):
         """Update progressbar."""

--- a/openfl-workspace/torch_cnn_histology_gramine_ready/plan/cols.yaml
+++ b/openfl-workspace/torch_cnn_histology_gramine_ready/plan/cols.yaml
@@ -1,0 +1,4 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# Licensed subject to the terms of the separately executed evaluation license agreement between Intel Corporation and you.
+
+collaborators:

--- a/openfl-workspace/torch_cnn_histology_gramine_ready/plan/data.yaml
+++ b/openfl-workspace/torch_cnn_histology_gramine_ready/plan/data.yaml
@@ -1,0 +1,5 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# Licensed subject to the terms of the separately executed evaluation license agreement between Intel Corporation and you.
+
+one,1
+two,2

--- a/openfl-workspace/torch_cnn_histology_gramine_ready/plan/plan.yaml
+++ b/openfl-workspace/torch_cnn_histology_gramine_ready/plan/plan.yaml
@@ -1,0 +1,41 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# Licensed subject to the terms of the separately executed evaluation license agreement between Intel Corporation and you.
+
+aggregator :
+  defaults : plan/defaults/aggregator.yaml
+  template : openfl.component.Aggregator
+  settings :
+    init_state_path : save/torch_cnn_histology_init.pbuf
+    best_state_path : save/torch_cnn_histology_best.pbuf
+    last_state_path : save/torch_cnn_histology_last.pbuf
+    rounds_to_train : 20
+
+collaborator :
+  defaults : plan/defaults/collaborator.yaml
+  template : openfl.component.Collaborator
+  settings :
+    delta_updates    : false
+    opt_treatment    : RESET
+
+data_loader :
+  template : src.pthistology_inmemory.PyTorchHistologyInMemory
+  settings :
+    collaborator_count : 2
+    data_group_name    : histology
+    batch_size         : 32
+
+task_runner:
+  defaults : plan/defaults/task_runner.yaml
+  template: src.pt_cnn.PyTorchCNN
+
+network:
+  defaults: plan/defaults/network.yaml
+
+tasks:
+  defaults: plan/defaults/tasks_torch.yaml
+
+assigner:
+  defaults: plan/defaults/assigner.yaml
+
+compression_pipeline :
+  defaults : plan/defaults/compression_pipeline.yaml

--- a/openfl-workspace/torch_cnn_histology_gramine_ready/requirements.txt
+++ b/openfl-workspace/torch_cnn_histology_gramine_ready/requirements.txt
@@ -1,0 +1,3 @@
+-f https://download.pytorch.org/whl/cpu/torch_stable.html
+torch==1.6.0+cpu
+torchvision==0.7.0+cpu

--- a/openfl-workspace/torch_cnn_histology_gramine_ready/src/__init__.py
+++ b/openfl-workspace/torch_cnn_histology_gramine_ready/src/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""You may copy this file as the starting point of your own model."""

--- a/openfl-workspace/torch_cnn_histology_gramine_ready/src/histology_utils.py
+++ b/openfl-workspace/torch_cnn_histology_gramine_ready/src/histology_utils.py
@@ -1,0 +1,154 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""You may copy this file as the starting point of your own model."""
+
+from collections.abc import Iterable
+from logging import getLogger
+from os import makedirs
+from pathlib import Path
+from urllib.request import urlretrieve
+from zipfile import ZipFile
+
+import numpy as np
+import torch
+from torch.utils.data import random_split
+from torchvision.datasets import ImageFolder
+from torchvision.transforms import ToTensor
+from tqdm import tqdm
+
+from openfl.utilities import validate_file_hash
+
+logger = getLogger(__name__)
+
+
+class HistologyDataset(ImageFolder):
+    """Colorectal Histology Dataset."""
+
+    URL = ('https://zenodo.org/record/53169/files/Kather_'
+           'texture_2016_image_tiles_5000.zip?download=1')
+    FILENAME = 'Kather_texture_2016_image_tiles_5000.zip'
+    FOLDER_NAME = 'Kather_texture_2016_image_tiles_5000'
+    ZIP_SHA384 = ('7d86abe1d04e68b77c055820c2a4c582a1d25d2983e38ab724e'
+                  'ac75affce8b7cb2cbf5ba68848dcfd9d84005d87d6790')
+    DEFAULT_PATH = Path.cwd().absolute() / 'data'
+
+    def __init__(self, root: Path = DEFAULT_PATH, **kwargs) -> None:
+        """Initialize."""
+        makedirs(root, exist_ok=True)
+        filepath = root / HistologyDataset.FILENAME
+        if not filepath.is_file():
+            self.pbar = tqdm(total=None)
+            urlretrieve(HistologyDataset.URL, filepath, self.report_hook)  # nosec
+            validate_file_hash(filepath, HistologyDataset.ZIP_SHA384)
+            with ZipFile(filepath, 'r') as f:
+                f.extractall(root)
+
+        super(HistologyDataset, self).__init__(root / HistologyDataset.FOLDER_NAME, **kwargs)
+
+    def report_hook(self, count, block_size, total_size):
+        """Update progressbar."""
+        if self.pbar.total is None and total_size:
+            self.pbar.total = total_size
+        progress_bytes = count * block_size
+        self.pbar.update(progress_bytes - self.pbar.n)
+
+    def __getitem__(self, index):
+        """Allow getting items by slice index."""
+        if isinstance(index, Iterable):
+            return [super(HistologyDataset, self).__getitem__(i) for i in index]
+        else:
+            return super(HistologyDataset, self).__getitem__(index)
+
+
+def one_hot(labels, classes):
+    """
+    One Hot encode a vector.
+
+    Args:
+        labels (list):  List of labels to onehot encode
+        classes (int): Total number of categorical classes
+
+    Returns:
+        np.array: Matrix of one-hot encoded labels
+    """
+    return np.eye(classes)[labels]
+
+
+def _load_raw_datashards(shard_num, collaborator_count, train_split_ratio=0.8):
+    """
+    Load the raw data by shard.
+
+    Returns tuples of the dataset shard divided into training and validation.
+
+    Args:
+        shard_num (int): The shard number to use
+        collaborator_count (int): The number of collaborators in the federation
+
+    Returns:
+        2 tuples: (image, label) of the training, validation dataset
+    """
+    dataset = HistologyDataset(transform=ToTensor())
+    n_train = int(train_split_ratio * len(dataset))
+    n_valid = len(dataset) - n_train
+    ds_train, ds_val = random_split(
+        dataset, lengths=[n_train, n_valid], generator=torch.manual_seed(0))
+
+    # create the shards
+    X_train, y_train = list(zip(*ds_train[shard_num::collaborator_count]))
+    X_train, y_train = np.stack(X_train), np.array(y_train)
+
+    X_valid, y_valid = list(zip(*ds_val[shard_num::collaborator_count]))
+    X_valid, y_valid = np.stack(X_valid), np.array(y_valid)
+
+    return (X_train, y_train), (X_valid, y_valid)
+
+
+def load_histology_shard(shard_num, collaborator_count,
+                         categorical=False, channels_last=False, **kwargs):
+    """
+    Load the Histology dataset.
+
+    Args:
+        shard_num (int): The shard to use from the dataset
+        collaborator_count (int): The number of collaborators in the federation
+        categorical (bool): True = convert the labels to one-hot encoded
+         vectors (Default = True)
+        channels_last (bool): True = The input images have the channels
+         last (Default = True)
+        **kwargs: Additional parameters to pass to the function
+
+    Returns:
+        list: The input shape
+        int: The number of classes
+        numpy.ndarray: The training data
+        numpy.ndarray: The training labels
+        numpy.ndarray: The validation data
+        numpy.ndarray: The validation labels
+    """
+    img_rows, img_cols = 150, 150
+    num_classes = 8
+
+    (X_train, y_train), (X_valid, y_valid) = _load_raw_datashards(
+        shard_num, collaborator_count)
+
+    if channels_last:
+        X_train = X_train.reshape(X_train.shape[0], img_rows, img_cols, 3)
+        X_valid = X_valid.reshape(X_valid.shape[0], img_rows, img_cols, 3)
+        input_shape = (img_rows, img_cols, 3)
+    else:
+        X_train = X_train.reshape(X_train.shape[0], 3, img_rows, img_cols)
+        X_valid = X_valid.reshape(X_valid.shape[0], 3, img_rows, img_cols)
+        input_shape = (3, img_rows, img_cols)
+
+    logger.info(f'Histology > X_train Shape : {X_train.shape}')
+    logger.info(f'Histology > y_train Shape : {y_train.shape}')
+    logger.info(f'Histology > Train Samples : {X_train.shape[0]}')
+    logger.info(f'Histology > Valid Samples : {X_valid.shape[0]}')
+
+    if categorical:
+        # convert class vectors to binary class matrices
+        y_train = one_hot(y_train, num_classes)
+        y_valid = one_hot(y_valid, num_classes)
+
+    return input_shape, num_classes, X_train, y_train, X_valid, y_valid

--- a/openfl-workspace/torch_cnn_histology_gramine_ready/src/pt_cnn.py
+++ b/openfl-workspace/torch_cnn_histology_gramine_ready/src/pt_cnn.py
@@ -1,0 +1,165 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""You may copy this file as the starting point of your own model."""
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim as optim
+import tqdm
+
+from openfl.federated import PyTorchTaskRunner
+from openfl.utilities import TensorKey
+
+
+def cross_entropy(output, target):
+    """Calculate Cross-entropy loss."""
+    return F.cross_entropy(input=output, target=target)
+
+
+class PyTorchCNN(PyTorchTaskRunner):
+    """Simple CNN for classification."""
+
+    def __init__(self, **kwargs):
+        """Initialize.
+
+        Args:
+            **kwargs: Additional arguments to pass to the function
+        """
+        super().__init__(loss_fn=cross_entropy, **kwargs)
+
+        torch.manual_seed(0)
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+
+        self.num_classes = self.data_loader.num_classes
+        self.init_network(device=self.device, **kwargs)
+        self._init_optimizer(lr=kwargs.get('lr'))
+        self.initialize_tensorkeys_for_functions()
+
+    def _init_optimizer(self, lr):
+        """Initialize the optimizer."""
+        self.optimizer = optim.Adam(self.parameters(), lr=float(lr or 1e-3))
+
+    def init_network(self,
+                     device,
+                     print_model=True,
+                     **kwargs):
+        """Create the network (model).
+
+        Args:
+            device: The hardware device to use for training
+            print_model (bool): Print the model topology (Default=True)
+            **kwargs: Additional arguments to pass to the function
+
+        """
+        channel = self.data_loader.get_feature_shape()[
+            0]  # (channel, dim1, dim2)
+        conv_kwargs = {'kernel_size': 3, 'stride': 1, 'padding': 1}
+        self.conv1 = nn.Conv2d(channel, 16, **conv_kwargs)
+        self.conv2 = nn.Conv2d(16, 32, **conv_kwargs)
+        self.conv3 = nn.Conv2d(32, 64, **conv_kwargs)
+        self.conv4 = nn.Conv2d(64, 128, **conv_kwargs)
+        self.conv5 = nn.Conv2d(128 + 32, 256, **conv_kwargs)
+        self.conv6 = nn.Conv2d(256, 512, **conv_kwargs)
+        self.conv7 = nn.Conv2d(512 + 128 + 32, 256, **conv_kwargs)
+        self.conv8 = nn.Conv2d(256, 512, **conv_kwargs)
+        self.fc1 = nn.Linear(1184 * 9 * 9, 128)
+        self.fc2 = nn.Linear(128, 8)
+        if print_model:
+            print(self)
+        self.to(device)
+
+    def forward(self, x):
+        """Forward pass of the model.
+
+        Args:
+            x: Data input to the model for the forward pass
+        """
+        x = F.relu(self.conv1(x))
+        x = F.relu(self.conv2(x))
+        maxpool = F.max_pool2d(x, 2, 2)
+
+        x = F.relu(self.conv3(maxpool))
+        x = F.relu(self.conv4(x))
+        concat = torch.cat([maxpool, x], dim=1)
+        maxpool = F.max_pool2d(concat, 2, 2)
+
+        x = F.relu(self.conv5(maxpool))
+        x = F.relu(self.conv6(x))
+        concat = torch.cat([maxpool, x], dim=1)
+        maxpool = F.max_pool2d(concat, 2, 2)
+
+        x = F.relu(self.conv7(maxpool))
+        x = F.relu(self.conv8(x))
+        concat = torch.cat([maxpool, x], dim=1)
+        maxpool = F.max_pool2d(concat, 2, 2)
+
+        x = maxpool.flatten(start_dim=1)
+        x = F.dropout(self.fc1(x), p=0.5)
+        x = self.fc2(x)
+        return x
+
+    def validate(self, col_name, round_num, input_tensor_dict,
+                 use_tqdm=False, **kwargs):
+        """Validate.
+
+        Run validation of the model on the local data.
+
+        Args:
+            col_name:            Name of the collaborator
+            round_num:           What round is it
+            input_tensor_dict:   Required input tensors (for model)
+            use_tqdm (bool):     Use tqdm to print a progress
+                                 bar (Default=True)
+
+        Returns:
+            global_output_dict:  Tensors to send back to the aggregator
+            local_output_dict:   Tensors to maintain in the local TensorDB
+
+        """
+        self.rebuild_model(round_num, input_tensor_dict, validation=True)
+        self.eval()
+        val_score = 0
+        total_samples = 0
+
+        loader = self.data_loader.get_valid_loader()
+        if use_tqdm:
+            loader = tqdm.tqdm(loader, desc='validate')
+
+        with torch.no_grad():
+            for data, target in loader:
+                samples = target.shape[0]
+                total_samples += samples
+                data, target = (torch.tensor(data).to(self.device),
+                                torch.tensor(target).to(self.device))
+                output = self(data)
+                # get the index of the max log-probability
+                pred = output.argmax(dim=1)
+                val_score += pred.eq(target).sum().cpu().numpy()
+
+        origin = col_name
+        suffix = 'validate'
+        if kwargs['apply'] == 'local':
+            suffix += '_local'
+        else:
+            suffix += '_agg'
+        tags = ('metric', suffix)
+        # TODO figure out a better way to pass in metric for
+        #  this pytorch validate function
+        output_tensor_dict = {
+            TensorKey('acc', origin, round_num, True, tags):
+                np.array(val_score / total_samples)
+        }
+
+        # empty list represents metrics that should only be stored locally
+        return output_tensor_dict, {}
+
+    def reset_opt_vars(self):
+        """Reset optimizer variables.
+
+        Resets the optimizer state variables.
+
+        """
+        self._init_optimizer(lr=self.optimizer.defaults.get('lr'))

--- a/openfl-workspace/torch_cnn_histology_gramine_ready/src/pthistology_inmemory.py
+++ b/openfl-workspace/torch_cnn_histology_gramine_ready/src/pthistology_inmemory.py
@@ -1,0 +1,32 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""You may copy this file as the starting point of your own model."""
+
+from openfl.federated import PyTorchDataLoader
+from .histology_utils import load_histology_shard
+
+
+class PyTorchHistologyInMemory(PyTorchDataLoader):
+    """PyTorch data loader for Histology dataset."""
+
+    def __init__(self, data_path, batch_size, **kwargs):
+        """Instantiate the data object.
+
+        Args:
+            data_path: The file path to the data
+            batch_size: The batch size of the data loader
+            **kwargs: Additional arguments, passed to super init
+             and load_mnist_shard
+        """
+        super().__init__(batch_size, random_seed=0, **kwargs)
+
+        _, num_classes, X_train, y_train, X_valid, y_valid = load_histology_shard(
+            shard_num=int(data_path), **kwargs)
+
+        self.X_train = X_train
+        self.y_train = y_train
+        self.X_valid = X_valid
+        self.y_valid = y_valid
+
+        self.num_classes = num_classes

--- a/openfl-workspace/torch_unet_kvasir/src/data_loader.py
+++ b/openfl-workspace/torch_unet_kvasir/src/data_loader.py
@@ -5,6 +5,7 @@
 
 import zipfile
 from os import listdir
+from pathlib import Path
 
 import numpy as np
 import PIL
@@ -93,14 +94,17 @@ def load_kvasir_dataset():
     """Load and unzip kvasir dataset."""
     zip_sha384 = ('e30d18a772c6520476e55b610a4db457237f151e'
                   '19182849d54b49ae24699881c1e18e0961f77642be900450ef8b22e7')
-    data_url = 'https://datasets.simula.no/hyper-kvasir/hyper-kvasir-segmented-images.zip'
+    data_url = ('https://datasets.simula.no/downloads/'
+                'hyper-kvasir/hyper-kvasir-segmented-images.zip')
     filename = 'kvasir.zip'
-    download_url(data_url, '.', filename=filename)
-    validate_file_hash(filename, zip_sha384)
-
-    with zipfile.ZipFile(filename, 'r') as zip_ref:
-        for member in tqdm(iterable=zip_ref.infolist(), desc='Unzipping dataset'):
-            zip_ref.extract(member, './data')
+    data_folder_path = Path.cwd().absolute() / 'data'
+    kvasir_archive_path = data_folder_path / filename
+    if not kvasir_archive_path.is_file():
+        download_url(data_url, data_folder_path, filename=filename)
+        validate_file_hash(kvasir_archive_path, zip_sha384)
+        with zipfile.ZipFile(kvasir_archive_path, 'r') as zip_ref:
+            for member in tqdm(iterable=zip_ref.infolist(), desc='Unzipping dataset'):
+                zip_ref.extract(member, './data')
 
 
 class PyTorchKvasirDataLoader(PyTorchDataLoader):

--- a/openfl-workspace/torch_unet_kvasir_gramine_ready/.workspace
+++ b/openfl-workspace/torch_unet_kvasir_gramine_ready/.workspace
@@ -1,0 +1,2 @@
+current_plan_name: default
+

--- a/openfl-workspace/torch_unet_kvasir_gramine_ready/plan/cols.yaml
+++ b/openfl-workspace/torch_unet_kvasir_gramine_ready/plan/cols.yaml
@@ -1,0 +1,4 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# Licensed subject to the terms of the separately executed evaluation license agreement between Intel Corporation and you.
+
+collaborators:

--- a/openfl-workspace/torch_unet_kvasir_gramine_ready/plan/data.yaml
+++ b/openfl-workspace/torch_unet_kvasir_gramine_ready/plan/data.yaml
@@ -1,0 +1,10 @@
+## Copyright (C) 2020-2021 Intel Corporation
+# Licensed subject to the terms of the separately executed evaluation license agreement between Intel Corporation and you.
+
+# all keys under 'collaborators' corresponds to a specific colaborator name the corresponding dictionary has data_name, data_path pairs.
+# Note that in the kvasir case we split general dataset by shards, and the data_path is used to pass an integer that helps the data object
+# construct the shard of the kvasir dataset to be use for this collaborator.
+
+# collaborator_name ,data_directory_path
+one,1
+two,2

--- a/openfl-workspace/torch_unet_kvasir_gramine_ready/plan/defaults
+++ b/openfl-workspace/torch_unet_kvasir_gramine_ready/plan/defaults
@@ -1,0 +1,2 @@
+../../workspace/plan/defaults
+

--- a/openfl-workspace/torch_unet_kvasir_gramine_ready/plan/plan.yaml
+++ b/openfl-workspace/torch_unet_kvasir_gramine_ready/plan/plan.yaml
@@ -1,0 +1,60 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# Licensed subject to the terms of the separately executed evaluation license agreement between Intel Corporation and you.
+
+aggregator :
+  defaults : plan/defaults/aggregator.yaml
+  template : openfl.component.Aggregator
+  settings :
+    init_state_path : save/torch_unet_kvasir_init.pbuf
+    best_state_path : save/torch_unet_kvasir_best.pbuf
+    last_state_path : save/torch_unet_kvasir_last.pbuf
+    rounds_to_train : 40
+
+collaborator :
+  defaults : plan/defaults/collaborator.yaml
+  template : openfl.component.Collaborator
+  settings :
+    epochs_per_round : 1.0
+    polling_interval : 4
+    delta_updates    : false
+    opt_treatment    : RESET
+
+data_loader :
+  defaults : plan/defaults/data_loader.yaml
+  template : src.data_loader.PyTorchKvasirDataLoader
+  settings :
+    collaborator_count : 2
+    data_group_name    : kvasir
+    batch_size         : 4
+
+task_runner :
+  defaults : plan/defaults/task_runner.yaml
+  template : src.fed_unet_runner.PyTorchFederatedUnet
+  settings :
+    n_channels : 3
+    n_classes  : 1
+
+network :
+  defaults : plan/defaults/network.yaml
+
+assigner :
+  defaults : plan/defaults/assigner.yaml
+
+tasks :
+  defaults : plan/defaults/tasks_torch.yaml
+  aggregated_model_validation:
+    function  : validate
+    kwargs    :
+      apply   : global
+      metrics :
+      - dice_coef
+  
+  locally_tuned_model_validation:
+    function  : validate
+    kwargs    :
+      apply   : local
+      metrics :
+      - dice_coef
+
+compression_pipeline :
+  defaults : plan/defaults/compression_pipeline.yaml

--- a/openfl-workspace/torch_unet_kvasir_gramine_ready/requirements.txt
+++ b/openfl-workspace/torch_unet_kvasir_gramine_ready/requirements.txt
@@ -1,0 +1,4 @@
+-f https://download.pytorch.org/whl/cpu/torch_stable.html
+torch==1.7.1+cpu
+torchvision==0.8.2+cpu
+scikit-image==0.17.2

--- a/openfl-workspace/torch_unet_kvasir_gramine_ready/src/__init__.py
+++ b/openfl-workspace/torch_unet_kvasir_gramine_ready/src/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""You may copy this file as the starting point of your own model."""

--- a/openfl-workspace/torch_unet_kvasir_gramine_ready/src/data_loader.py
+++ b/openfl-workspace/torch_unet_kvasir_gramine_ready/src/data_loader.py
@@ -1,0 +1,149 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""You may copy this file as the starting point of your own model."""
+
+import zipfile
+from os import listdir
+from pathlib import Path
+
+import numpy as np
+import PIL
+from skimage import io
+from torch.utils.data import DataLoader
+from torch.utils.data import Dataset
+from torchvision import transforms as tsf
+from torchvision.datasets.utils import download_url
+from tqdm import tqdm
+
+from openfl.federated import PyTorchDataLoader
+from openfl.utilities import validate_file_hash
+
+
+def read_data(image_path, mask_path):
+    """Read image and mask from disk.
+
+    Args:
+        image_path: Path to image
+        mask_path:  Path to mask
+
+    Returns:
+        Numpy image and mask
+
+    """
+    img = io.imread(image_path)
+    assert(img.shape[2] == 3)
+    mask = io.imread(mask_path)
+    return (img, mask[:, :, 0].astype(np.uint8))
+
+
+class KvasirDataset(Dataset):
+    """Kvasir dataset. Splits data by shards for each collaborator."""
+
+    def __init__(self, is_validation, shard_num, collaborator_count, **kwargs):
+        """Initialize dataset.
+
+        Args:
+            is_validation: Validation dataset or not
+            shard_num: Number of collaborator for which the data is splited
+            collaborator_count: Total number of collaborators
+
+        """
+        self.images_path = './data/segmented-images/images/'
+        self.masks_path = './data/segmented-images/masks/'
+        self.images_names = [
+            img_name
+            for img_name in sorted(listdir(self.images_path))
+            if len(img_name) > 3 and img_name[-3:] == 'jpg'
+        ]
+
+        self.images_names = self.images_names[shard_num:: collaborator_count]
+        self.is_validation = is_validation
+        assert(len(self.images_names) > 8)
+        validation_size = len(self.images_names) // 8
+
+        if is_validation:
+            self.images_names = self.images_names[-validation_size:]
+        else:
+            self.images_names = self.images_names[: -validation_size]
+
+        self.img_trans = tsf.Compose([
+            tsf.ToPILImage(),
+            tsf.Resize((332, 332)),
+            tsf.ToTensor(),
+            tsf.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5])])
+        self.mask_trans = tsf.Compose([
+            tsf.ToPILImage(),
+            tsf.Resize((332, 332), interpolation=PIL.Image.NEAREST),
+            tsf.ToTensor()])
+
+    def __getitem__(self, index):
+        """Get items by slice index."""
+        name = self.images_names[index]
+        img, mask = read_data(self.images_path + name, self.masks_path + name)
+        img = self.img_trans(img)
+        mask = self.mask_trans(mask)
+        return img, mask
+
+    def __len__(self):
+        """Length of spltted data."""
+        return len(self.images_names)
+
+
+def load_kvasir_dataset():
+    """Load and unzip kvasir dataset."""
+    zip_sha384 = ('e30d18a772c6520476e55b610a4db457237f151e'
+                  '19182849d54b49ae24699881c1e18e0961f77642be900450ef8b22e7')
+    data_url = ('https://datasets.simula.no/downloads/'
+                'hyper-kvasir/hyper-kvasir-segmented-images.zip')
+    filename = 'kvasir.zip'
+    data_folder_path = Path.cwd().absolute() / 'data'
+    kvasir_archive_path = data_folder_path / filename
+    if not kvasir_archive_path.is_file():
+        download_url(data_url, data_folder_path, filename=filename)
+        validate_file_hash(kvasir_archive_path, zip_sha384)
+        with zipfile.ZipFile(kvasir_archive_path, 'r') as zip_ref:
+            for member in tqdm(iterable=zip_ref.infolist(), desc='Unzipping dataset'):
+                zip_ref.extract(member, './data')
+
+
+class PyTorchKvasirDataLoader(PyTorchDataLoader):
+    """PyTorch data loader for Kvasir dataset."""
+
+    def __init__(self, data_path, batch_size, **kwargs):
+        """Instantiate the data object.
+
+        Args:
+            data_path: The file path to the data
+            batch_size: The batch size of the data loader
+            **kwargs: Additional arguments, passed to super
+             init and load_mnist_shard
+        """
+        super().__init__(batch_size, **kwargs)
+
+        load_kvasir_dataset()
+        self.valid_dataset = KvasirDataset(True, shard_num=int(data_path), **kwargs)
+        self.train_dataset = KvasirDataset(False, shard_num=int(data_path), **kwargs)
+        self.train_loader = self.get_train_loader()
+        self.val_loader = self.get_valid_loader()
+        self.batch_size = batch_size
+
+    def get_valid_loader(self, num_batches=None):
+        """Return validation dataloader."""
+        return DataLoader(self.valid_dataset, batch_size=self.batch_size)
+
+    def get_train_loader(self, num_batches=None):
+        """Return train dataloader."""
+        return DataLoader(self.train_dataset, batch_size=self.batch_size, shuffle=True)
+
+    def get_train_data_size(self):
+        """Return size of train dataset."""
+        return len(self.train_dataset)
+
+    def get_valid_data_size(self):
+        """Return size of validation dataset."""
+        return len(self.valid_dataset)
+
+    def get_feature_shape(self):
+        """Return data shape."""
+        return self.valid_dataset[0][0].shape

--- a/openfl-workspace/torch_unet_kvasir_gramine_ready/src/fed_unet_runner.py
+++ b/openfl-workspace/torch_unet_kvasir_gramine_ready/src/fed_unet_runner.py
@@ -1,0 +1,148 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""You may copy this file as the starting point of your own model."""
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.optim as optim
+import tqdm
+
+from openfl.federated import PyTorchTaskRunner
+from openfl.utilities import TensorKey
+from .pt_unet_parts import DoubleConv
+from .pt_unet_parts import Down
+from .pt_unet_parts import soft_dice_coef
+from .pt_unet_parts import soft_dice_loss
+from .pt_unet_parts import Up
+
+
+class PyTorchFederatedUnet(PyTorchTaskRunner):
+    """Simple Unet for segmentation."""
+
+    def __init__(self, device='cpu', **kwargs):
+        """Initialize.
+
+        Args:
+            device: The hardware device to use for training (Default = "cpu")
+            **kwargs: Additional arguments to pass to the function
+
+        """
+        super().__init__(device=device, **kwargs)
+        self.init_network(device=self.device, **kwargs)
+        self._init_optimizer()
+        self.loss_fn = soft_dice_loss
+        self.initialize_tensorkeys_for_functions()
+
+    def _init_optimizer(self):
+        """Initialize the optimizer."""
+        self.optimizer = optim.Adam(self.parameters(), lr=1e-3)
+
+    def init_network(self,
+                     device,
+                     n_channels,
+                     n_classes,
+                     print_model=True,
+                     **kwargs):
+        """Create the network (model).
+
+        Args:
+            device: The hardware device to use for training
+            n_channels: Number of input image channels
+            n_classes: Number of output classes (1 for segmentation)
+            print_model: Print the model topology (Default=True)
+            **kwargs: Additional arguments to pass to the function
+
+        """
+        self.n_channels = n_channels
+        self.n_classes = n_classes
+        self.inc = DoubleConv(self.n_channels, 64)
+        self.down1 = Down(64, 128)
+        self.down2 = Down(128, 256)
+        self.down3 = Down(256, 512)
+        self.down4 = Down(512, 1024)
+        self.up1 = Up(1024, 512)
+        self.up2 = Up(512, 256)
+        self.up3 = Up(256, 128)
+        self.up4 = Up(128, 64)
+        self.outc = nn.Conv2d(64, self.n_classes, 1)
+        if print_model:
+            print(self)
+        self.to(device)
+
+    def forward(self, x):
+        """Forward pass of the model.
+
+        Args:
+            x: Data input to the model for the forward pass
+        """
+        x1 = self.inc(x)
+        x2 = self.down1(x1)
+        x3 = self.down2(x2)
+        x4 = self.down3(x3)
+        x5 = self.down4(x4)
+        x = self.up1(x5, x4)
+        x = self.up2(x, x3)
+        x = self.up3(x, x2)
+        x = self.up4(x, x1)
+        x = self.outc(x)
+        x = torch.sigmoid(x)
+        return x
+
+    def validate(self, col_name, round_num, input_tensor_dict, use_tqdm=True, **kwargs):
+        """Run validation of the model on the local data.
+
+        Args:
+            col_name:            Name of the collaborator
+            round_num:           What round is it
+            input_tensor_dict:   Required input tensors (for model)
+            use_tqdm:     Use tqdm to print a progress bar (Default=True)
+
+        Returns:
+            global_output_dict:  Tensors to send back to the aggregator
+            local_output_dict:   Tensors to maintain in the local TensorDB
+        """
+        self.rebuild_model(round_num, input_tensor_dict, validation=True)
+        self.eval()
+        self.to(self.device)
+        val_score = 0
+        total_samples = 0
+
+        loader = self.data_loader.get_valid_loader()
+        if use_tqdm:
+            loader = tqdm.tqdm(loader, desc='validate')
+
+        with torch.no_grad():
+            for data, target in loader:
+                samples = target.shape[0]
+                total_samples += samples
+                data, target = torch.tensor(data).to(self.device), torch.tensor(
+                    target).to(self.device)
+                output = self(data)
+                # get the index of the max log-probability
+                val = soft_dice_coef(output, target)
+                val_score += val.sum().cpu().numpy()
+
+        origin = col_name
+        suffix = 'validate'
+        if kwargs['apply'] == 'local':
+            suffix += '_local'
+        else:
+            suffix += '_agg'
+        tags = ('metric', suffix)
+        # TODO figure out a better way to pass in metric for this pytorch
+        #  validate function
+        output_tensor_dict = {
+            TensorKey('dice_coef', origin, round_num, True, tags):
+                np.array(val_score / total_samples)
+        }
+
+        return output_tensor_dict, {}
+
+    def reset_opt_vars(self):
+        """Reset optimizer variables.
+
+        Resets the optimizer state variables.
+
+        """
+        self._init_optimizer()

--- a/openfl-workspace/torch_unet_kvasir_gramine_ready/src/pt_unet_parts.py
+++ b/openfl-workspace/torch_unet_kvasir_gramine_ready/src/pt_unet_parts.py
@@ -1,0 +1,111 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""You may copy this file as the starting point of your own model."""
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+def soft_dice_loss(output, target):
+    """Dice loss function."""
+    num = target.size(0)
+    m1 = output.view(num, -1)
+    m2 = target.view(num, -1)
+    intersection = (m1 * m2)
+    score = 2. * (intersection.sum(1) + 1) / (m1.sum(1) + m2.sum(1) + 1)
+    score = 1 - score.sum() / num
+    return score
+
+
+def soft_dice_coef(output, target):
+    """Dice coef metric function."""
+    num = target.size(0)
+    m1 = output.view(num, -1)
+    m2 = target.view(num, -1)
+    intersection = (m1 * m2)
+    score = 2. * (intersection.sum(1) + 1) / (m1.sum(1) + m2.sum(1) + 1)
+    return score.sum()
+
+
+class DoubleConv(nn.Module):
+    """Convolutions with BN and activation."""
+
+    def __init__(self, in_ch, out_ch):
+        """Initialize.
+
+        Args:
+            in_ch: number of input channels
+            out_ch: number of output channels
+
+        """
+        super(DoubleConv, self).__init__()
+        self.in_ch = in_ch
+        self.out_ch = out_ch
+        self.conv = nn.Sequential(
+            nn.Conv2d(in_ch, out_ch, 3, padding=1),
+            nn.BatchNorm2d(out_ch),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(out_ch, out_ch, 3, padding=1),
+            nn.BatchNorm2d(out_ch),
+            nn.ReLU(inplace=True)
+        )
+
+    def forward(self, x):
+        """Run forward."""
+        x = self.conv(x)
+        return x
+
+
+class Down(nn.Module):
+    """UNet downscaling. MaxPool with double convolution."""
+
+    def __init__(self, in_ch, out_ch):
+        """Initialize.
+
+        Args:
+            in_ch: number of input channels
+            out_ch: number of output channels
+
+        """
+        super(Down, self).__init__()
+        self.mpconv = nn.Sequential(
+            nn.MaxPool2d(2),
+            DoubleConv(in_ch, out_ch)
+        )
+
+    def forward(self, x):
+        """Run forward."""
+        x = self.mpconv(x)
+        return x
+
+
+class Up(nn.Module):
+    """UNet upscaling."""
+
+    def __init__(self, in_ch, out_ch):
+        """Initialize.
+
+        Args:
+            in_ch: number of input channels
+            out_ch: number of output channels
+
+        """
+        super(Up, self).__init__()
+        self.in_ch = in_ch
+        self.out_ch = out_ch
+        self.up = nn.ConvTranspose2d(in_ch, in_ch // 2, 2, stride=2)
+        self.conv = DoubleConv(in_ch, out_ch)
+
+    def forward(self, x1, x2):
+        """Run forward."""
+        x1 = self.up(x1)
+        diff_y = x2.size()[2] - x1.size()[2]
+        diff_x = x2.size()[3] - x1.size()[3]
+
+        x1 = F.pad(x1, (diff_x // 2, diff_x - diff_x // 2,
+                        diff_y // 2, diff_y - diff_y // 2))
+
+        x = torch.cat([x2, x1], dim=1)
+        x = self.conv(x)
+        return x

--- a/openfl/interface/workspace.py
+++ b/openfl/interface/workspace.py
@@ -497,11 +497,12 @@ def graminize_(context, sgx_target, signing_key, pip_install_options: Tuple[str]
     grainized_ws_dockerfile = SITEPACKS / 'openfl-gramine' / 'Dockerfile.graminized.workspace'
 
     echo('\n 🐋 Building graminized workspace image...')
+    signing_key = f'--secret id=signer-key,src={signing_key} ' if SGX_BUILD else ''
     graminized_build_command = f'docker build -t {workspace_name} ' + \
         '--build-arg BASE_IMAGE=gramine_openfl ' + \
         f'--build-arg WORKSPACE_ARCHIVE={workspace_archive.relative_to(workspace_path)} ' + \
         f'--build-arg SGX_BUILD={SGX_BUILD} --build-arg SGX_EXE={SGX_EXE} ' + \
-        f'--secret id=signer-key,src={signing_key} ' if SGX_BUILD else '' + \
+        signing_key + \
         f'-f {grainized_ws_dockerfile} {workspace_path}'
     open_pipe(graminized_build_command)
     echo('\n ✔️ DONE: Building graminized workspace image')

--- a/openfl/interface/workspace.py
+++ b/openfl/interface/workspace.py
@@ -440,8 +440,11 @@ def dockerize_(context, base_image, save):
         help='Options for remote pip install. '
              'You may pass several options in quotation marks alongside with arguments, '
              'e.g. -o "--find-links source.site"')
+@option('--save/--no-save', required=False,
+        default=True, type=bool,
+        help='Dump the Docker image to an archive')
 @pass_context
-def graminize_(context, signing_key, pip_install_options: Tuple[str]) -> None:
+def graminize_(context, signing_key: Path, pip_install_options: Tuple[str], save: bool) -> None:
     """
     Build gramine app inside a docker image.
 
@@ -504,10 +507,11 @@ def graminize_(context, signing_key, pip_install_options: Tuple[str]) -> None:
     open_pipe(graminized_build_command)
     echo('\n ✔️ DONE: Building graminized workspace image')
 
-    echo('\n 💾 Saving the graminized workspace image...')
-    save_image_command = f'docker save {workspace_name} | gzip > {workspace_name}.tar.gz'
-    open_pipe(save_image_command)
-    echo(f'\n ✔️ The image saved to file: {workspace_name}.tar.gz')
+    if save:
+        echo('\n 💾 Saving the graminized workspace image...')
+        save_image_command = f'docker save {workspace_name} | gzip > {workspace_name}.tar.gz'
+        open_pipe(save_image_command)
+        echo(f'\n ✔️ The image saved to file: {workspace_name}.tar.gz')
 
 
 def apply_template_plan(prefix, template):

--- a/openfl/interface/workspace.py
+++ b/openfl/interface/workspace.py
@@ -475,13 +475,13 @@ def graminize_(context, sgx_target, signing_key, pip_install_options: Tuple[str]
 
     # We can build for gramine-sgx and run with gramine-direct,
     # but not vice versa.
-    SGX_BUILD = 1 if signing_key.is_file() else 0
-    SGX_EXE = 'gramine-sgx' if sgx_target else 'gramine-direct'
-    if sgx_target and not SGX_BUILD:
+    sgx_build = 1 if signing_key.is_file() else 0
+    sgx_exe = 'gramine-sgx' if sgx_target else 'gramine-direct'
+    if sgx_target and not sgx_build:
         echo('\n ❌ Can not prepare SGX-ready application without a signing key.')
         raise Exception('Provide a signing key or pass "--no-sgx-target"')
 
-    os.environ["DOCKER_BUILDKIT"] = '1'
+    os.environ['DOCKER_BUILDKIT'] = '1'
 
     echo('\n 🐋 Building base gramine-openfl image...')
     base_dockerfile = SITEPACKS / 'openfl-gramine' / 'Dockerfile.gramine'
@@ -497,13 +497,14 @@ def graminize_(context, sgx_target, signing_key, pip_install_options: Tuple[str]
     grainized_ws_dockerfile = SITEPACKS / 'openfl-gramine' / 'Dockerfile.graminized.workspace'
 
     echo('\n 🐋 Building graminized workspace image...')
-    signing_key = f'--secret id=signer-key,src={signing_key} ' if SGX_BUILD else ''
-    graminized_build_command = f'docker build -t {workspace_name} ' + \
-        '--build-arg BASE_IMAGE=gramine_openfl ' + \
-        f'--build-arg WORKSPACE_ARCHIVE={workspace_archive.relative_to(workspace_path)} ' + \
-        f'--build-arg SGX_BUILD={SGX_BUILD} --build-arg SGX_EXE={SGX_EXE} ' + \
-        signing_key + \
-        f'-f {grainized_ws_dockerfile} {workspace_path}'
+    signing_key = f'--secret id=signer-key,src={signing_key} ' if sgx_build else ''
+    graminized_build_command = (
+        f'docker build -t {workspace_name} '
+        '--build-arg BASE_IMAGE=gramine_openfl '
+        f'--build-arg WORKSPACE_ARCHIVE={workspace_archive.relative_to(workspace_path)} '
+        f'--build-arg SGX_BUILD={sgx_build} --build-arg SGX_EXE={sgx_exe} '
+        f'{signing_key}'
+        f'-f {grainized_ws_dockerfile} {workspace_path}')
     open_pipe(graminized_build_command)
     echo('\n ✔️ DONE: Building graminized workspace image')
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         'openfl.plugins.processing_units_monitor',
         'openfl-workspace',
         'openfl-docker',
+        'openfl-gramine',
         'openfl-tutorials',
         'openfl.component.aggregation_functions'
     ],

--- a/tests/github/test_graminize.sh
+++ b/tests/github/test_graminize.sh
@@ -3,7 +3,7 @@ set -e
 # =========== SET SGX_RUN variable to 0 or 1 ============
 
 SGX_RUN=${1:-1}
-TEMPLATE=${2:-'keras_nlp_gramine_ready'}  # ['torch_cnn_histology_gramine_ready', 'torch_unet_kvasir_gramine_ready']
+TEMPLATE=${2:-'torch_unet_kvasir_gramine_ready'}  # ['torch_cnn_histology_gramine_ready', 'keras_nlp_gramine_ready']
 FED_WORKSPACE=${3:-'fed_gramine'}   # This can be whatever unique directory name you want
 COL1=${4:-'one'}  # This can be any unique label (lowercase)
 COL2=${5:-'two'} # This can be any unique label (lowercase)

--- a/tests/github/test_graminize.sh
+++ b/tests/github/test_graminize.sh
@@ -63,7 +63,7 @@ fi
 
 openssl genrsa -3 -out ${FED_DIRECTORY}/key.pem 3072
 # Build graminized app image
-fx workspace graminize -s ${FED_DIRECTORY}/key.pem
+fx workspace graminize -s ${FED_DIRECTORY}/key.pem --no-save
 
 # CERTIFICATION PART------------------------------
 # ================================================

--- a/tests/github/test_graminize.sh
+++ b/tests/github/test_graminize.sh
@@ -1,0 +1,160 @@
+set -e
+# Test the pipeline
+# =========== SET SGX_RUN variable to 0 or 1 ============
+
+SGX_RUN=${1:-1}
+TEMPLATE=${2:-'torch_unet_kvasir_gramine_ready'}  # ['torch_cnn_histology_gramine_ready', 'keras_nlp_gramine_ready']
+FED_WORKSPACE=${3:-'fed_gramine'}   # This can be whatever unique directory name you want
+COL1=${4:-'one'}  # This can be any unique label (lowercase)
+COL2=${5:-'two'} # This can be any unique label (lowercase)
+
+FQDN=${6:-$(hostname --all-fqdns | awk '{print $1}')}
+
+COL1_DATA_PATH=1
+COL2_DATA_PATH=2
+
+help() {
+    echo "Usage: test_hello_federation.sh TEMPLATE FED_WORKSPACE COL1 COL2 [OPTIONS]"
+    echo
+    echo "Options:"
+    echo "--rounds-to-train     rounds to train"
+    echo "--col1-data-path      data path for collaborator 1"
+    echo "--col2-data-path      data path for collaborator 2"
+    echo "-h, --help            display this help and exit"
+}
+
+# Getting additional options
+ADD_OPTS=$(getopt -o "h" -l "rounds-to-train:,col1-data-path:,
+col2-data-path:,help" -n test_hello_federation.sh -- "$@")
+eval set -- "$ADD_OPTS"
+while (($#)); do
+    case "${1:-}" in
+    (--rounds-to-train) ROUNDS_TO_TRAIN="$2" ; shift 2 ;;
+    (--col1-data-path) COL1_DATA_PATH="$2" ; shift 2 ;;
+    (--col2-data-path) COL2_DATA_PATH="$2" ; shift 2 ;;
+    (-h|--help) help ; exit 0 ;;
+
+    (--)        shift ; break ;;
+    (*)         echo "Invalid option: ${1:-}"; exit 1 ;;
+    esac
+done
+
+
+# START
+# =====
+# Make sure you are in a Python virtual environment with the FL package installed.
+
+# Create FL workspace
+rm -rf ${FED_WORKSPACE}
+fx workspace create --prefix ${FED_WORKSPACE} --template ${TEMPLATE}
+cd ${FED_WORKSPACE}
+FED_DIRECTORY=`pwd`  # Get the absolute directory path for the workspace
+
+# Initialize FL plan
+fx plan initialize -a ${FQDN}
+
+# Set rounds to train if given
+if [[ ! -z "$ROUNDS_TO_TRAIN" ]]
+then
+    sed -i "/rounds_to_train/c\    rounds_to_train: $ROUNDS_TO_TRAIN" plan/plan.yaml
+fi
+
+
+openssl genrsa -3 -out ${FED_DIRECTORY}/key.pem 3072
+# Build graminized app image
+fx workspace graminize -s ${FED_DIRECTORY}/key.pem
+
+# CERTIFICATION PART------------------------------
+# ================================================
+create_collaborator() {
+
+    FED_WORKSPACE=$1
+    FED_DIRECTORY=$2
+    COL=$3
+    COL_DIRECTORY=$4
+    DATA_PATH=$5
+
+    ARCHIVE_NAME="${FED_WORKSPACE}.zip"
+
+    # Copy workspace to collaborator directories (these can be on different machines)
+    rm -rf ${COL_DIRECTORY}    # Remove any existing directory
+    mkdir -p ${COL_DIRECTORY}  # Create a new directory for the collaborator
+    cd ${COL_DIRECTORY}
+    fx workspace import --archive ${FED_DIRECTORY}/${ARCHIVE_NAME} # Import the workspace to this collaborator
+
+    # Create collaborator certificate request
+    cd ${COL_DIRECTORY}/${FED_WORKSPACE}
+    fx collaborator generate-cert-request -d ${DATA_PATH} -n ${COL} --silent # Remove '--silent' if you run this manually
+
+    # Sign collaborator certificate 
+    cd ${FED_DIRECTORY}  # Move back to the Aggregator
+    fx collaborator certify --request-pkg ${COL_DIRECTORY}/${FED_WORKSPACE}/col_${COL}_to_agg_cert_request.zip --silent # Remove '--silent' if you run this manually
+
+    #Import the signed certificate from the aggregator
+    cd ${COL_DIRECTORY}/${FED_WORKSPACE}
+    fx collaborator certify --import ${FED_DIRECTORY}/agg_to_col_${COL}_signed_cert.zip
+
+    cp -r ${FED_DIRECTORY}/data ${COL_DIRECTORY}/${FED_WORKSPACE}
+
+}
+# Create certificate authority for workspace
+fx workspace certify
+
+# Create aggregator certificate
+fx aggregator generate-cert-request --fqdn ${FQDN}
+
+# Sign aggregator certificate
+fx aggregator certify --fqdn ${FQDN} --silent # Remove '--silent' if you run this manually
+
+# Create collaborator #1
+COL1_DIRECTORY=${FED_DIRECTORY}/${COL1}
+create_collaborator ${FED_WORKSPACE} ${FED_DIRECTORY} ${COL1} ${COL1_DIRECTORY} ${COL1_DATA_PATH}
+
+# Create collaborator #2
+COL2_DIRECTORY=${FED_DIRECTORY}/${COL2}
+create_collaborator ${FED_WORKSPACE} ${FED_DIRECTORY} ${COL2} ${COL2_DIRECTORY} ${COL2_DATA_PATH}
+
+# CERTIFICATION PART ENDS-------------------------
+# ================================================
+
+# # Run the federation
+cd ${FED_DIRECTORY}
+
+if [ $SGX_RUN -gt 0 ]
+then
+RUN_START="docker run -it --rm --device=/dev/sgx_enclave --volume=/var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket"
+else
+RUN_START="docker run -it --rm --security-opt seccomp=unconfined -e GRAMINE_EXECUTABLE=gramine-direct"
+fi
+
+# fx aggregator start & 
+$RUN_START \
+--network=host \
+--volume=${FED_DIRECTORY}/cert:/workspace/cert \
+--volume=${FED_DIRECTORY}/logs:/workspace/logs \
+--volume=${FED_DIRECTORY}/plan/cols.yaml:/workspace/plan/cols.yaml \
+--mount type=bind,src=${FED_DIRECTORY}/save,dst=/workspace/save,readonly=0 \
+${FED_WORKSPACE} aggregator start &
+
+sleep 5 
+
+# cd ${COL1_DIRECTORY}/${FED_WORKSPACE}
+# fx collaborator start -n ${COL1} & 
+$RUN_START \
+--network=host \
+--volume=${COL1_DIRECTORY}/${FED_WORKSPACE}/cert:/workspace/cert \
+--volume=${COL1_DIRECTORY}/${FED_WORKSPACE}/plan/data.yaml:/workspace/plan/data.yaml \
+--volume=${COL1_DIRECTORY}/${FED_WORKSPACE}/data:/workspace/data \
+${FED_WORKSPACE} collaborator start -n ${COL1} &
+
+# cd ${COL2_DIRECTORY}/${FED_WORKSPACE}
+# fx collaborator start -n ${COL2}
+$RUN_START \
+--network=host \
+--volume=${COL2_DIRECTORY}/${FED_WORKSPACE}/cert:/workspace/cert \
+--volume=${COL2_DIRECTORY}/${FED_WORKSPACE}/plan/data.yaml:/workspace/plan/data.yaml \
+--volume=${COL2_DIRECTORY}/${FED_WORKSPACE}/data:/workspace/data \
+${FED_WORKSPACE} collaborator start -n ${COL2}
+
+wait
+# rm -rf ${FED_DIRECTORY}


### PR DESCRIPTION
# OpenFL + Gramine
This manual will help you run OpenFL with Aggregator-based workflow inside SGX enclave with Gramine.

## Prerequisites
Building machine:
- OpenFL
- Docker should be installed, user included in Docker group

Machines that will run an Aggregator and Collaborator containers should have the following:
- SGX enabled in BIOS
- Ubuntu with Linux kernel 5.11+
- ? SGX drivers, it is built in kernel: `/dev/sgx_enclave`
- [aesmd service](https://github.com/intel/linux-sgx) (`/var/run/aesmd/aesm.socket`)
This is a short list, see more in [Gramine docs](https://gramine.readthedocs.io/en/latest/devel/building.html).

## Workflow
The user will mainly interact with OpenFL CLI, docker CLI, and other command-line tools. But the user is also expected to modify plan.yaml file and Python code under workspace/src folder to set up an FL Experiment.
### On the building machine (Data Scientist's node):
1. As usual, **create a workspace**: 
```
export WORKSPACE_NAME=my_sgx_federation_workspace
export TEMPLATE_NAME=torch_cnn_histology

fx workspace create --prefix $WORKSPACE_NAME --template $TEMPLATE_NAME
cd $WORKSPACE_NAME
```
Modify the code and the plan.yaml, set up your training procedure. </br>
Pay attention to the following: 
- make sure the data loading code reads data from ./data folder inside the workspace
- if you download data (development scenario) make sure your code first checks if data exists, as connecting to the internet from an enclave may be problematic.
- make sure you do not use any CUDA driver-dependent packages

Default workspaces (templates) in OpenFL differ in their data downloading procedures. Workspaces with data loading flow that do not require changes to run with Gramine include:
- torch_unet_kvasir
- torch_cnn_histology
- keras_nlp

2. **Initialize the experiment plan** </br> 
Find out the FQDN of the aggregator machine and use it for plan initialization.
For example, on Unix-like OS try the following command:
```
hostname --all-fqdns | awk '{print $1}'
```
(In case this FQDN does not work for your federation, try putting the machine IP instead)
Then pass the result as `AGG_FQDN` parameter to:
```
fx plan initialize -a $AGG_FQDN
```

3. (Optional) **Generate a signing key** on the building machine if you do not have one.</br>
It will be used to calculate hashes of trusted files. If you plan to test the application without SGX (gramine-direct) you also do not need a signer key.
```
export KEY_LOCATION=.

openssl genrsa -3 -out $KEY_LOCATION/key.pem 3072
```
This key will not be packed into the final Docker image.

4. **Build the Experiment Docker image**

```
fx workspace graminize -s $KEY_LOCATION/key.pem
```
This command will build and save a Docker image with your Experiment. The saved image will contain all the required files to start a process in an enclave.</br>
If a signing key is not provided, the application will be built without SGX support, but it still can be started with gramine-direct executable.


### Image distribution:
Data scientist (builder) now must transfer the Docker image to the aggregator and collaborator machines. The Aggregator will also need initial model weights.

5. **Transfer files** to the aggregator and collaborator machines.
If there is a connection between machines, you may use `scp`. In other cases use the transfer channel that suits your situation.</br>
Send files to the aggregator machine:
```
scp BUILDING_MACHINE:WORKSPACE_PATH/WORKSPACE_NAME.tar.gz AGGREGATOR_MACHINE:SOME_PATH
scp BUILDING_MACHINE:WORKSPACE_PATH/save/WORKSPACE_NAME_init.pbuf AGGREGATOR_MACHINE:SOME_PATH
```

Send the image archive to collaborator machines:
```
scp BUILDING_MACHINE:WORKSPACE_PATH/WORKSPACE_NAME.tar.gz COLLABORATOR_MACHINE:SOME_PATH
```

Please, keep in mind, if you run a test Federation, with data downloaded from the internet, you should also transfer/download data to collaborator machines.

### On the running machines (Aggregator and Collaborator nodes):
6. **Load the image.**
Execute the following command on all running machines:
```
docker load < WORKSPACE_NAME.tar.gz
```

7. **Prepare certificates**
Certificates exchange is a big separate topic. To run an experiment following OpenFL Aggregator-based workflow, a user must follow the established procedure, please refer to [the docs](https://openfl.readthedocs.io/en/latest/running_the_federation.html#bare-metal-approach).
Following the above-mentioned procedure, running machines will acquire certificates. Moreover, as the result of this procedure, the aggregator machine will also obtain a `cols.yaml` file (required to start an experiment) with registered collaborators' names, and the collaborator machines will obtain `data.yaml` files.

We recommend replicating the OpenFL workspace folder structure on all the machines and following the usual certifying procedure. Finally, on the aggregator node you should have the following folder structure:
```
workspace/
--save/WORKSPACE_NAME_init.pbuf
--logs/
--plan/cols.yaml
--cert/
  --client/*col.crt
  --server/
    --agg_FQDN.crt
    --agg_FQDN.key
```

On collaborator nodes:
```
workspace/
--data/*dataset*
--plan/data.yaml
--cert/
  --client/
    --col_name.crt
    --col_name.key
```

To speed up the certification process for one-node test runs, it makes sense to utilize the OpenFL integration test script [make this a link after merge]  openfl/tests/github/test_graminize.sh, that will create required folders and certify an aggregator and two collaborators.

### **Run the Federation in enclaves**
#### On the Aggregator machine run:
```
export WORKSPACE_NAME=your_workspace_name
export WORKSPACE_PATH=path_to_workspace
docker run -it --rm --device=/dev/sgx_enclave --volume=/var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket \
--network=host \
--volume=${WORKSPACE_PATH}/cert:/workspace/cert \
--volume=${WORKSPACE_PATH}/logs:/workspace/logs \
--volume=${WORKSPACE_PATH}/plan/cols.yaml:/workspace/plan/cols.yaml \
--mount type=bind,src=${WORKSPACE_PATH}/save,dst=/workspace/save,readonly=0 \
${WORKSPACE_NAME} aggregator start
```

#### On the Collaborator machines run:
```
export WORKSPACE_NAME=your_workspace_name
export WORKSPACE_PATH=path_to_workspace
export COL_NAME=col_name
docker run -it --rm --device=/dev/sgx_enclave --volume=/var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket \
--network=host \
--volume=${WORKSPACE_PATH}/cert:/workspace/cert \
--volume=${WORKSPACE_PATH}/plan/data.yaml:/workspace/plan/data.yaml \
--volume=${WORKSPACE_PATH}/data:/workspace/data \
${WORKSPACE_NAME} collaborator start -n ${COL_NAME}
```

### **No SGX run (`gramine-direct`)**:
The user may run an experiment under gramine without SGX. Note how we do not mount `sgx_enclave` device and pass a `--security-opt` instead that allows syscalls required by `gramine-direct`

#### On the Aggregator machine run:
```
export WORKSPACE_NAME=your_workspace_name
export WORKSPACE_PATH=path_to_workspace
docker run -it --rm --security-opt seccomp=unconfined -e GRAMINE_EXECUTABLE=gramine-direct \
--network=host \
--volume=${WORKSPACE_PATH}/cert:/workspace/cert \
--volume=${WORKSPACE_PATH}/logs:/workspace/logs \
--volume=${WORKSPACE_PATH}/plan/cols.yaml:/workspace/plan/cols.yaml \
--mount type=bind,src=${WORKSPACE_PATH}/save,dst=/workspace/save,readonly=0 \
${WORKSPACE_NAME} aggregator start
```

#### On the Collaborator machines run:

```
export WORKSPACE_NAME=your_workspace_name
export WORKSPACE_PATH=path_to_workspace
export COL_NAME=col_name
docker run -it --rm --security-opt seccomp=unconfined -e GRAMINE_EXECUTABLE=gramine-direct \
--network=host \
--volume=${WORKSPACE_PATH}/cert:/workspace/cert \
--volume=${WORKSPACE_PATH}/plan/data.yaml:/workspace/plan/data.yaml \
--volume=${WORKSPACE_PATH}/data:/workspace/data \
${WORKSPACE_NAME} collaborator start -n ${COL_NAME}
```

## The Routine
Gramine+OpenFL PR brings in `openfl-gramine` folder, that contains the following files:
 - MANUAL.md - this manual
 - Dockerfile.gamine - the base image Dockerfile for all experiments, it starts from Python3.8 image and installs OpenFL and Gramine packages.
 - Dockerfile.graminized.workspace - this one is for building the final experiment image. It starts from the previous image and imports the experiment archive (executes 'fx workspace import') inside an image. At this stage, we have an experiment workspace and all the requirements installed inside the image. Then it runs a unified Makefile that uses the openfl.manifest.template to prepare required files to run OpenFL under gramine inside an SGX enclave.
 - Makefile - follows regular gramine workflow, please refer to (gramine docs)[] for more info
 - openfl.manifest.template - gramine manifest template, it is the same for all the experiments
 - start_process.sh - bash script used to start an OpenFL actor in a container.

There is a files access peculiarity that should be kept in mind during debugging and development.
Both Dockerfiles are read from the bare-metal OpenFL installation, i.e. from an OpenFL package on a building machine.
While the gramine manifest template and the Makefile are read in image build time from the local (in-image) OpenFL package. </br>
Thus, if one wants to make changes to the gramine manifest template or the Makefile, they should change the OpenFL installation procedure in Dockerfile.gramine, so their changes may be pulled to the base image. One option is to push the changes to a GitHub fork and install OpenFL from this fork. 
```
*Dockerfile.gramine:*

RUN git clone https://github.com/your-username/openfl.git --branch some_branch
WORKDIR /openfl
RUN --mount=type=cache,target=/root/.cache/ \
    pip install --upgrade pip && \
    pip install .
WORKDIR /
```
In this case, to rebuild the image, use `fx workspace dockerize --rebuild` with `--rebuild` flag that will pass '--no-cache' to docker build command.

Another option is to copy OpenFL source files from an on-disk cloned repo, but it would mean that the user must build the graminized image from the repo directory using Docker CLI.


## Known issues:
- Kvasir experiment: aggregation takes really long, debug log-level does not show the reason
- We need workspace zip to import it and create certs. We need to know the number of collaborators prior to zipping the workspace. SOLUTION: mount cols.yaml and data.yaml
- During plan initialization we need data to initialize the model. so at least one collaborator should be in data.yaml and its data should be available. cols.yaml may be empty at first
During cert sign request generation cols.yaml on collaborators remain empty, data.yaml is extended if needed. On aggregator, cols.yaml are updated during signing procedure, data.yaml remains unmodified
- `error: Disallowing access to file '/usr/local/lib/python3.8/__pycache__/signal.cpython-38.pyc.3423950304'; file is not protected, trusted or allowed.`

 ## TO-DO:
- [X] import manifest and makefile from OpenFL dist-package 
- [X] pass wheel repository to pip (for CPU versions of PyTorch for example)
- [ ] get rid of command line args (insecure)
- [ ] introduce `fx workspace create --prefix WORKSPACE_NAME` command without --template option to the OpenFL CLI, which will create just an empty workspace with the right folder structure.
- [ ] introduce `fx *actor* start --from image`