### PR TITLE
Optimizer parameters need to be copied if different tasks have model on different devices

### DIFF
--- a/openfl/utilities/optimizers/torch/__init__.py
+++ b/openfl/utilities/optimizers/torch/__init__.py
@@ -4,3 +4,4 @@ import pkgutil
 if pkgutil.find_loader('torch'):
     from .fedprox import FedProxOptimizer # NOQA
     from .fedprox import FedProxAdam # NOQA
+    from .optimdevice import optimizer_to # NOQA

--- a/openfl/utilities/optimizers/torch/optimdevice.py
+++ b/openfl/utilities/optimizers/torch/optimdevice.py
@@ -1,0 +1,20 @@
+"""PyTorch optimizer utility to transfer the optimizer's parametes to current device."""
+
+"""
+This function is needed to transfer the optimizer parameters to the same device where the model is.
+This is because optimized parameters must live in consistent locations when optimizers are constructed and used.
+Resembles model.to(device) for optimizer.
+
+Usage (in train task after the model is transferred to device):
+    optimizer_to(optimizer,device)
+"""
+
+import torch
+
+def optimizer_to(optim, device):
+    for param in optim.state.values():
+        for subparam in param.values():
+            if isinstance(subparam, torch.Tensor):
+                subparam.data = subparam.data.to(device)
+                if subparam._grad is not None:
+                    subparam._grad.data = subparam._grad.data.to(device)

--- a/openfl/utilities/optimizers/torch/optimdevice.py
+++ b/openfl/utilities/optimizers/torch/optimdevice.py
@@ -4,14 +4,18 @@ import torch
 
 
 def optimizer_to(optim, device):
-    """This function is needed to transfer optimizer
-    parameters to the same device where the model is.
+    """Transfer optimizer to device.
+
+    Transfer optimizer's parameters to the same device where the model is.
     This is because optimized parameters must live in consistent locations
     when optimizers are constructed and used.
     Resembles model.to(device) for optimizer.
 
     Usage (in train task after the model is transferred to device):
             optimizer_to(optimizer,device)
+    Args:
+        optimizer   :  Torch optimizer
+        device      :  model's device
     """
     for param in optim.state.values():
         for subparam in param.values():

--- a/openfl/utilities/optimizers/torch/optimdevice.py
+++ b/openfl/utilities/optimizers/torch/optimdevice.py
@@ -1,17 +1,18 @@
 """PyTorch optimizer utility to transfer the optimizer's parametes to current device."""
 
-"""
-This function is needed to transfer the optimizer parameters to the same device where the model is.
-This is because optimized parameters must live in consistent locations when optimizers are constructed and used.
-Resembles model.to(device) for optimizer.
-
-Usage (in train task after the model is transferred to device):
-    optimizer_to(optimizer,device)
-"""
-
 import torch
 
+
 def optimizer_to(optim, device):
+    """This function is needed to transfer optimizer
+    parameters to the same device where the model is.
+    This is because optimized parameters must live in consistent locations
+    when optimizers are constructed and used.
+    Resembles model.to(device) for optimizer.
+
+    Usage (in train task after the model is transferred to device):
+            optimizer_to(optimizer,device)
+    """
     for param in optim.state.values():
         for subparam in param.values():
             if isinstance(subparam, torch.Tensor):


### PR DESCRIPTION
Fixes #298 

The optimizer parameters need to be on the same device where model is. When a model's tensors are moved from one device to the other, the optimizer parameters will be different objects before and after it is moved. Solution is to transfer the optimizer's parameters after the model is moved. Usage is in train task:

```
from openfl.utilities.optimizers.torch import optimizer_to

def train(net_model, train_loader, optimizer, device):
      device = torch.device('cuda')

      net_model.train()
      net_model.to(device)
      optimizer_to(optimizer,device)
```