### PR TITLE
Docker scan fixes

### DIFF
--- a/openfl-gramine/Dockerfile.gramine
+++ b/openfl-gramine/Dockerfile.gramine
@@ -18,7 +18,7 @@ RUN curl -fsSLo /usr/share/keyrings/gramine-keyring.gpg https://packages.gramine
 RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-    gramine \
+    gramine libprotobuf-c-dev \
     && rm -rf /var/lib/apt/lists/*
     # there is an issue for libprotobuf-c in gramine repo, install from apt for now
 

--- a/openfl-gramine/Dockerfile.gramine
+++ b/openfl-gramine/Dockerfile.gramine
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE=python:3.8
 FROM ${BASE_IMAGE}
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # until these changes are not in pip, install from repo
 RUN git clone https://github.com/intel/openfl.git
 WORKDIR /openfl

--- a/openfl-gramine/Dockerfile.gramine
+++ b/openfl-gramine/Dockerfile.gramine
@@ -18,7 +18,8 @@ RUN curl -fsSLo /usr/share/keyrings/gramine-keyring.gpg https://packages.gramine
 RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-    gramine libprotobuf-c-dev
+    gramine libprotobuf-c-dev \
+    && rm -rf /var/lib/apt/lists/*
     # there is an issue for libprotobuf-c in gramine repo, install from apt for now
 
 # graminelibos is under this dir

--- a/openfl-gramine/Dockerfile.gramine
+++ b/openfl-gramine/Dockerfile.gramine
@@ -18,7 +18,7 @@ RUN curl -fsSLo /usr/share/keyrings/gramine-keyring.gpg https://packages.gramine
 RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-    gramine libprotobuf-c-dev \
+    gramine \
     && rm -rf /var/lib/apt/lists/*
     # there is an issue for libprotobuf-c in gramine repo, install from apt for now
 

--- a/openfl-gramine/Dockerfile.graminized.workspace
+++ b/openfl-gramine/Dockerfile.graminized.workspace
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=gramine_openfl
 FROM ${BASE_IMAGE} as builder
 
 ARG WORKSPACE_ARCHIVE
-ADD ${WORKSPACE_ARCHIVE} /workspace.zip
+COPY ${WORKSPACE_ARCHIVE} /workspace.zip
 RUN --mount=type=cache,target=/root/.cache/ \
     fx workspace import --archive /workspace.zip
 

--- a/tests/github/test_graminize.sh
+++ b/tests/github/test_graminize.sh
@@ -1,4 +1,4 @@
-set -e
+set -euxo pipefail
 # Test the pipeline
 # =========== Set SGX_RUN variable to 0 or 1 ============
 
@@ -15,11 +15,6 @@ FQDN=localhost
 COL1_DATA_PATH=1
 COL2_DATA_PATH=2
 
-if [ $REBUILD_IMAGES -gt 0 ]
-then
-REBUILD_OPTION="--rebuild"
-fi
-
 # START
 # =====
 # Make sure you are in a Python virtual environment with the FL package installed.
@@ -34,8 +29,14 @@ FED_DIRECTORY=`pwd`  # Get the absolute directory path for the workspace
 fx plan initialize -a ${FQDN}
 
 openssl genrsa -3 -out ${FED_DIRECTORY}/key.pem 3072
+
 # Build graminized app image
-fx workspace graminize -s ${FED_DIRECTORY}/key.pem --no-save $REBUILD_OPTION
+if [ $REBUILD_IMAGES -gt 0 ]
+then
+fx workspace graminize -s ${FED_DIRECTORY}/key.pem --no-save --rebuild
+else
+fx workspace graminize -s ${FED_DIRECTORY}/key.pem --no-save
+fi
 
 # CERTIFICATION PART------------------------------
 # ================================================


### PR DESCRIPTION
The following command was executed with hadolint v2.8.0:
```
hadolint --ignore SC1091 --ignore DL3002 --ignore DL3003 --ignore DL3006 --ignore DL3008 --ignore DL3013 --ignore DL3018 --ignore DL4001 openfl-gramine/Dockerfile.gramine
```
Output is just one warning:
openfl-gramine/Dockerfile.gramine:9 DL3042 warning: Avoid use of cache directory with pip. Use `pip install --no-cache-dir <package>`
</br>
Running hadolint on openfl-gramine/Dockerfile.graminized.worksapce did not trigger any warrning.