### PR TITLE
Flake8-annotations: fix errors in component

### DIFF
--- a/openfl/component/aggregation_functions/adagrad_adaptive_aggregation.py
+++ b/openfl/component/aggregation_functions/adagrad_adaptive_aggregation.py
@@ -25,7 +25,7 @@ class AdagradAdaptiveAggregation(AdaptiveAggregation):
         *,
         agg_func: AggregationFunction = DEFAULT_AGG_FUNC,
         params: Optional[Dict[str, np.ndarray]] = None,
-        model_interface: 'ModelInterface' = None, # NOQA
+        model_interface: Optional['ModelInterface'] = None, # NOQA
         learning_rate: float = 0.01,
         initial_accumulator_value: float = 0.1,
         epsilon: float = 1e-10,

--- a/openfl/component/aggregation_functions/adagrad_adaptive_aggregation.py
+++ b/openfl/component/aggregation_functions/adagrad_adaptive_aggregation.py
@@ -25,7 +25,7 @@ class AdagradAdaptiveAggregation(AdaptiveAggregation):
         *,
         agg_func: AggregationFunction = DEFAULT_AGG_FUNC,
         params: Optional[Dict[str, np.ndarray]] = None,
-        model_interface=None,
+        model_interface: 'ModelInterface' = None, # NOQA
         learning_rate: float = 0.01,
         initial_accumulator_value: float = 0.1,
         epsilon: float = 1e-10,

--- a/openfl/component/aggregation_functions/adam_adaptive_aggregation.py
+++ b/openfl/component/aggregation_functions/adam_adaptive_aggregation.py
@@ -26,7 +26,7 @@ class AdamAdaptiveAggregation(AdaptiveAggregation):
         *,
         agg_func: AggregationFunction = DEFAULT_AGG_FUNC,
         params: Optional[Dict[str, np.ndarray]] = None,
-        model_interface: 'ModelInterface' = None, # NOQA
+        model_interface: Optional['ModelInterface'] = None, # NOQA
         learning_rate: float = 0.01,
         betas: Tuple[float, float] = (0.9, 0.999),
         initial_accumulator_value: float = 0.0,

--- a/openfl/component/aggregation_functions/adam_adaptive_aggregation.py
+++ b/openfl/component/aggregation_functions/adam_adaptive_aggregation.py
@@ -26,7 +26,7 @@ class AdamAdaptiveAggregation(AdaptiveAggregation):
         *,
         agg_func: AggregationFunction = DEFAULT_AGG_FUNC,
         params: Optional[Dict[str, np.ndarray]] = None,
-        model_interface=None,
+        model_interface: 'ModelInterface' = None, # NOQA
         learning_rate: float = 0.01,
         betas: Tuple[float, float] = (0.9, 0.999),
         initial_accumulator_value: float = 0.0,
@@ -52,5 +52,5 @@ class AdamAdaptiveAggregation(AdaptiveAggregation):
                         learning_rate=learning_rate,
                         betas=betas,
                         initial_accumulator_value=initial_accumulator_value,
-                        epsilo=epsilon)
+                        epsilon=epsilon)
         super().__init__(opt, agg_func)

--- a/openfl/component/aggregation_functions/core/adaptive_aggregation.py
+++ b/openfl/component/aggregation_functions/core/adaptive_aggregation.py
@@ -3,9 +3,12 @@
 
 """Adaptive aggregation module."""
 
+from typing import Iterable
 from typing import List
+from typing import Tuple
 
 import numpy as np
+import pandas as pd
 
 from openfl.utilities.optimizers.numpy.base_optimizer import Optimizer
 from openfl.utilities.types import LocalTensor
@@ -44,11 +47,11 @@ class AdaptiveAggregation(AggregationFunction):
 
     def call(
         self,
-        local_tensors,
-        db_iterator,
-        tensor_name,
-        fl_round,
-        tags
+        local_tensors: List,
+        db_iterator: Iterable[pd.Series],
+        tensor_name: str,
+        fl_round: int,
+        tags: Tuple[str]
     ) -> np.ndarray:
         """Aggregate tensors.
 

--- a/openfl/component/aggregation_functions/core/adaptive_aggregation.py
+++ b/openfl/component/aggregation_functions/core/adaptive_aggregation.py
@@ -51,7 +51,7 @@ class AdaptiveAggregation(AggregationFunction):
         db_iterator: Iterable[pd.Series],
         tensor_name: str,
         fl_round: int,
-        tags: Tuple[str]
+        tags: Tuple[str, ...]
     ) -> np.ndarray:
         """Aggregate tensors.
 

--- a/openfl/component/aggregation_functions/core/adaptive_aggregation.py
+++ b/openfl/component/aggregation_functions/core/adaptive_aggregation.py
@@ -3,7 +3,7 @@
 
 """Adaptive aggregation module."""
 
-from typing import Iterable
+from typing import Iterator
 from typing import List
 from typing import Tuple
 
@@ -48,7 +48,7 @@ class AdaptiveAggregation(AggregationFunction):
     def call(
         self,
         local_tensors: List[LocalTensor],
-        db_iterator: Iterable[pd.Series],
+        db_iterator: Iterator[pd.Series],
         tensor_name: str,
         fl_round: int,
         tags: Tuple[str, ...]

--- a/openfl/component/aggregation_functions/core/adaptive_aggregation.py
+++ b/openfl/component/aggregation_functions/core/adaptive_aggregation.py
@@ -47,7 +47,7 @@ class AdaptiveAggregation(AggregationFunction):
 
     def call(
         self,
-        local_tensors: List,
+        local_tensors: List[LocalTensor],
         db_iterator: Iterable[pd.Series],
         tensor_name: str,
         fl_round: int,

--- a/openfl/component/aggregation_functions/core/interface.py
+++ b/openfl/component/aggregation_functions/core/interface.py
@@ -55,6 +55,6 @@ class AggregationFunction(metaclass=SingletonABCMeta):
                  db_iterator: Iterator[pd.Series],
                  tensor_name: str,
                  fl_round: int,
-                 tags: Tuple[str]) -> np.ndarray:
+                 tags: Tuple[str, ...]) -> np.ndarray:
         """Use magic function for ease."""
         return self.call(local_tensors, db_iterator, tensor_name, fl_round, tags)

--- a/openfl/component/aggregation_functions/core/interface.py
+++ b/openfl/component/aggregation_functions/core/interface.py
@@ -51,7 +51,7 @@ class AggregationFunction(metaclass=SingletonABCMeta):
         """
         raise NotImplementedError
 
-    def __call__(self, local_tensors: List,
+    def __call__(self, local_tensors: List[LocalTensor],
                  db_iterator: Iterator[pd.Series],
                  tensor_name: str,
                  fl_round: int,

--- a/openfl/component/aggregation_functions/core/interface.py
+++ b/openfl/component/aggregation_functions/core/interface.py
@@ -51,10 +51,10 @@ class AggregationFunction(metaclass=SingletonABCMeta):
         """
         raise NotImplementedError
 
-    def __call__(self, local_tensors,
-                 db_iterator,
-                 tensor_name,
-                 fl_round,
-                 tags):
+    def __call__(self, local_tensors: List,
+                 db_iterator: Iterator[pd.Series],
+                 tensor_name: str,
+                 fl_round: int,
+                 tags: Tuple[str]) -> np.ndarray:
         """Use magic function for ease."""
         return self.call(local_tensors, db_iterator, tensor_name, fl_round, tags)

--- a/openfl/component/aggregation_functions/fedcurv_weighted_average.py
+++ b/openfl/component/aggregation_functions/fedcurv_weighted_average.py
@@ -1,6 +1,9 @@
 # Copyright (C) 2020-2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 """FedCurv Aggregation function module."""
+from typing import Any
+from typing import List
+
 import numpy as np
 
 from .weighted_average import WeightedAverage
@@ -16,7 +19,8 @@ class FedCurvWeightedAverage(WeightedAverage):
     FedCurv paper: https://arxiv.org/pdf/1910.07796.pdf
     """
 
-    def call(self, local_tensors, db_iterator, tensor_name, fl_round, tags):
+    def call(self, local_tensors: List, db_iterator: Any,
+             tensor_name: str, fl_round: Any, tags: Any) -> np.ndarray:
         """Apply aggregation."""
         if (
             tensor_name.endswith('_u')

--- a/openfl/component/aggregation_functions/fedcurv_weighted_average.py
+++ b/openfl/component/aggregation_functions/fedcurv_weighted_average.py
@@ -24,7 +24,7 @@ class FedCurvWeightedAverage(WeightedAverage):
     """
 
     def call(self, local_tensors: List[LocalTensor], db_iterator: Iterator[pd.Series],
-             tensor_name: str, fl_round: int, tags: Tuple[str]) -> np.ndarray:
+             tensor_name: str, fl_round: int, tags: Tuple[str, ...]) -> np.ndarray:
         """Apply aggregation."""
         if (
             tensor_name.endswith('_u')

--- a/openfl/component/aggregation_functions/fedcurv_weighted_average.py
+++ b/openfl/component/aggregation_functions/fedcurv_weighted_average.py
@@ -1,11 +1,15 @@
 # Copyright (C) 2020-2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 """FedCurv Aggregation function module."""
-from typing import Any
+
+from typing import Iterator
 from typing import List
+from typing import Tuple
 
 import numpy as np
+import pandas as pd
 
+from openfl.utilities import LocalTensor
 from .weighted_average import WeightedAverage
 
 
@@ -19,8 +23,8 @@ class FedCurvWeightedAverage(WeightedAverage):
     FedCurv paper: https://arxiv.org/pdf/1910.07796.pdf
     """
 
-    def call(self, local_tensors: List, db_iterator: Any,
-             tensor_name: str, fl_round: Any, tags: Any) -> np.ndarray:
+    def call(self, local_tensors: List[LocalTensor], db_iterator: Iterator[pd.Series],
+             tensor_name: str, fl_round: int, tags: Tuple[str]) -> np.ndarray:
         """Apply aggregation."""
         if (
             tensor_name.endswith('_u')

--- a/openfl/component/aggregation_functions/geometric_median.py
+++ b/openfl/component/aggregation_functions/geometric_median.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Geometric median module."""
+from typing import Any
+from typing import List
 
 import numpy as np
 
@@ -9,12 +11,14 @@ from .core import AggregationFunction
 from .weighted_average import weighted_average
 
 
-def _geometric_median_objective(median, tensors, weights):
+def _geometric_median_objective(median: np.ndarray, tensors: np.ndarray,
+                                weights: np.ndarray) -> np.ndarray:
     """Compute geometric median objective."""
     return sum([w * _l2dist(median, x) for w, x in zip(weights, tensors)])
 
 
-def geometric_median(tensors, weights, maxiter=4, eps=1e-5, ftol=1e-6):
+def geometric_median(tensors: np.ndarray, weights: np.ndarray, maxiter: int = 4,
+                     eps: float = 1e-5, ftol: float = 1e-6) -> np.ndarray:
     """Compute geometric median of tensors with weights using Weiszfeld's Algorithm."""
     weights = np.asarray(weights) / sum(weights)
     median = weighted_average(tensors, weights)
@@ -34,7 +38,7 @@ def geometric_median(tensors, weights, maxiter=4, eps=1e-5, ftol=1e-6):
     return median
 
 
-def _l2dist(p1, p2):
+def _l2dist(p1: np.ndarray, p2: np.ndarray) -> float:
     """L2 distance between p1, p2, each of which is a list of nd-arrays."""
     if p1.ndim != p2.ndim:
         raise RuntimeError('Tensor shapes should be equal')
@@ -46,7 +50,7 @@ def _l2dist(p1, p2):
 class GeometricMedian(AggregationFunction):
     """Geometric median aggregation."""
 
-    def call(self, local_tensors, *_) -> np.ndarray:
+    def call(self, local_tensors: List, *_: Any) -> np.ndarray:
         """Aggregate tensors.
 
         Args:

--- a/openfl/component/aggregation_functions/geometric_median.py
+++ b/openfl/component/aggregation_functions/geometric_median.py
@@ -7,6 +7,7 @@ from typing import List
 
 import numpy as np
 
+from openfl.utilities import LocalTensor
 from .core import AggregationFunction
 from .weighted_average import weighted_average
 
@@ -50,7 +51,7 @@ def _l2dist(p1: np.ndarray, p2: np.ndarray) -> float:
 class GeometricMedian(AggregationFunction):
     """Geometric median aggregation."""
 
-    def call(self, local_tensors: List, *_: Any) -> np.ndarray:
+    def call(self, local_tensors: List[LocalTensor], *_: Any) -> np.ndarray:
         """Aggregate tensors.
 
         Args:

--- a/openfl/component/aggregation_functions/median.py
+++ b/openfl/component/aggregation_functions/median.py
@@ -8,13 +8,14 @@ from typing import List
 
 import numpy as np
 
+from openfl.utilities import LocalTensor
 from .core import AggregationFunction
 
 
 class Median(AggregationFunction):
     """Median aggregation."""
 
-    def call(self, local_tensors: List, *_: Any) -> np.ndarray:
+    def call(self, local_tensors: List[LocalTensor], *_: Any) -> np.ndarray:
         """Aggregate tensors.
 
         Args:

--- a/openfl/component/aggregation_functions/median.py
+++ b/openfl/component/aggregation_functions/median.py
@@ -3,6 +3,7 @@
 
 """Median module."""
 
+from typing import Any
 from typing import List
 
 import numpy as np
@@ -13,7 +14,7 @@ from .core import AggregationFunction
 class Median(AggregationFunction):
     """Median aggregation."""
 
-    def call(self, local_tensors: List, *_) -> np.ndarray:
+    def call(self, local_tensors: List, *_: Any) -> np.ndarray:
         """Aggregate tensors.
 
         Args:

--- a/openfl/component/aggregation_functions/median.py
+++ b/openfl/component/aggregation_functions/median.py
@@ -3,6 +3,8 @@
 
 """Median module."""
 
+from typing import List
+
 import numpy as np
 
 from .core import AggregationFunction
@@ -11,7 +13,7 @@ from .core import AggregationFunction
 class Median(AggregationFunction):
     """Median aggregation."""
 
-    def call(self, local_tensors, *_) -> np.ndarray:
+    def call(self, local_tensors: List, *_) -> np.ndarray:
         """Aggregate tensors.
 
         Args:

--- a/openfl/component/aggregation_functions/weighted_average.py
+++ b/openfl/component/aggregation_functions/weighted_average.py
@@ -46,4 +46,5 @@ class WeightedAverage(AggregationFunction):
             np.ndarray: aggregated tensor
         """
         tensors, weights = zip(*[(x.tensor, x.weight) for x in local_tensors])
+        tensors, weights = np.array(tensors), np.array(weights)
         return weighted_average(tensors, weights)

--- a/openfl/component/aggregation_functions/weighted_average.py
+++ b/openfl/component/aggregation_functions/weighted_average.py
@@ -2,13 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Federated averaging module."""
+from typing import Any
+from typing import List
 
 import numpy as np
 
 from .core import AggregationFunction
 
 
-def weighted_average(tensors, weights):
+def weighted_average(tensors: np.ndarray, weights: np.ndarray) -> np.ndarray:
     """Compute average."""
     return np.average(tensors, weights=weights, axis=0)
 
@@ -16,7 +18,7 @@ def weighted_average(tensors, weights):
 class WeightedAverage(AggregationFunction):
     """Weighted average aggregation."""
 
-    def call(self, local_tensors, *_) -> np.ndarray:
+    def call(self, local_tensors: List, *_: Any) -> np.ndarray:
         """Aggregate tensors.
 
         Args:

--- a/openfl/component/aggregation_functions/weighted_average.py
+++ b/openfl/component/aggregation_functions/weighted_average.py
@@ -6,11 +6,13 @@ from typing import Any
 from typing import List
 
 import numpy as np
+from numpy.typing import ArrayLike
 
+from openfl.utilities import LocalTensor
 from .core import AggregationFunction
 
 
-def weighted_average(tensors: np.ndarray, weights: np.ndarray) -> np.ndarray:
+def weighted_average(tensors: ArrayLike, weights: ArrayLike) -> np.ndarray:
     """Compute average."""
     return np.average(tensors, weights=weights, axis=0)
 
@@ -18,7 +20,7 @@ def weighted_average(tensors: np.ndarray, weights: np.ndarray) -> np.ndarray:
 class WeightedAverage(AggregationFunction):
     """Weighted average aggregation."""
 
-    def call(self, local_tensors: List, *_: Any) -> np.ndarray:
+    def call(self, local_tensors: List[LocalTensor], *_: Any) -> np.ndarray:
         """Aggregate tensors.
 
         Args:
@@ -46,5 +48,5 @@ class WeightedAverage(AggregationFunction):
             np.ndarray: aggregated tensor
         """
         tensors, weights = zip(*[(x.tensor, x.weight) for x in local_tensors])
-        tensors, weights = np.array(tensors), np.array(weights)
+
         return weighted_average(tensors, weights)

--- a/openfl/component/aggregation_functions/yogi_adaptive_aggregation.py
+++ b/openfl/component/aggregation_functions/yogi_adaptive_aggregation.py
@@ -26,7 +26,7 @@ class YogiAdaptiveAggregation(AdaptiveAggregation):
         *,
         agg_func: AggregationFunction = DEFAULT_AGG_FUNC,
         params: Optional[Dict[str, np.ndarray]] = None,
-        model_interface=None,
+        model_interface: 'ModelInterface' = None, # NOQA
         learning_rate: float = 0.01,
         betas: Tuple[float, float] = (0.9, 0.999),
         initial_accumulator_value: float = 0.0,
@@ -52,5 +52,5 @@ class YogiAdaptiveAggregation(AdaptiveAggregation):
                         learning_rate=learning_rate,
                         betas=betas,
                         initial_accumulator_value=initial_accumulator_value,
-                        epsilo=epsilon)
+                        epsilon=epsilon)
         super().__init__(opt, agg_func)

--- a/openfl/component/aggregator/aggregator.py
+++ b/openfl/component/aggregator/aggregator.py
@@ -19,7 +19,6 @@ from openfl.databases import TensorDB
 from openfl.pipelines import NoCompressionPipeline
 from openfl.pipelines import TensorCodec
 from openfl.pipelines.pipeline import TransformationPipeline
-from openfl.pipelines.pipeline import Transformer
 from openfl.protocols import base_pb2
 from openfl.protocols import utils
 from openfl.utilities import TaskResultKey
@@ -57,7 +56,7 @@ class Aggregator:
 
                  rounds_to_train: int = 256,
                  single_col_cert_common_name: Optional[str] = None,
-                 compression_pipeline: Union[Transformer, TransformationPipeline, None] = None,
+                 compression_pipeline: Optional[TransformationPipeline] = None,
                  db_store_rounds: int = 1,
                  write_logs: bool = False,
                  **kwargs) -> None:
@@ -327,7 +326,7 @@ class Aggregator:
         return tasks, self.round_number, sleep_time, time_to_quit
 
     def get_aggregated_tensor(self, collaborator_name: str, tensor_name: str,
-                              round_number: int, report: bool, tags: Tuple[str],
+                              round_number: int, report: bool, tags: Tuple[str, ...],
                               require_lossless: bool) -> base_pb2.NamedTensor:
         """
         RPC called by collaborator.

--- a/openfl/component/aggregator/aggregator.py
+++ b/openfl/component/aggregator/aggregator.py
@@ -4,6 +4,15 @@
 """Aggregator module."""
 import queue
 from logging import getLogger
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import NoReturn
+from typing import Optional
+from typing import Tuple
+from typing import Union
+
+from numpy import ndarray
 
 from openfl.component.aggregation_functions import WeightedAverage
 from openfl.databases import TensorDB
@@ -34,22 +43,22 @@ class Aggregator:
 
     def __init__(self,
 
-                 aggregator_uuid,
-                 federation_uuid,
-                 authorized_cols,
+                 aggregator_uuid: str,
+                 federation_uuid: str,
+                 authorized_cols: Union[list, str],
 
-                 init_state_path,
-                 best_state_path,
-                 last_state_path,
+                 init_state_path: str,
+                 best_state_path: str,
+                 last_state_path: str,
 
-                 assigner,
+                 assigner: Any,
 
-                 rounds_to_train=256,
-                 single_col_cert_common_name=None,
-                 compression_pipeline=None,
-                 db_store_rounds=1,
-                 write_logs=False,
-                 **kwargs):
+                 rounds_to_train: int = 256,
+                 single_col_cert_common_name: Optional[str] = None,
+                 compression_pipeline: Any = None,
+                 db_store_rounds: int = 1,
+                 write_logs: bool = False,
+                 **kwargs) -> None:
         """Initialize."""
         self.round_number = 0
         self.single_col_cert_common_name = single_col_cert_common_name
@@ -110,7 +119,7 @@ class Aggregator:
 
         self.collaborator_task_weight = {}  # {TaskResultKey: data_size}
 
-    def _load_initial_tensors(self):
+    def _load_initial_tensors(self) -> None:
         """
         Load all of the tensors required to begin federated learning.
 
@@ -136,7 +145,7 @@ class Aggregator:
         self.tensor_db.cache_tensor(tensor_key_dict)
         self.logger.debug(f'This is the initial tensor_db: {self.tensor_db}')
 
-    def _load_initial_tensors_from_dict(self, tensor_dict):
+    def _load_initial_tensors_from_dict(self, tensor_dict: Dict[str, ndarray]) -> None:
         """
         Load all of the tensors required to begin federated learning.
 
@@ -154,7 +163,7 @@ class Aggregator:
         self.tensor_db.cache_tensor(tensor_key_dict)
         self.logger.debug(f'This is the initial tensor_db: {self.tensor_db}')
 
-    def _save_model(self, round_number, file_path):
+    def _save_model(self, round_number: int, file_path: str) -> None:
         """
         Save the best or latest model.
 
@@ -190,8 +199,8 @@ class Aggregator:
             tensor_dict, round_number, self.compression_pipeline)
         utils.dump_proto(self.model, file_path)
 
-    def valid_collaborator_cn_and_id(self, cert_common_name,
-                                     collaborator_common_name):
+    def valid_collaborator_cn_and_id(self, cert_common_name: str,
+                                     collaborator_common_name: str) -> bool:
         """
         Determine if the collaborator certificate and ID are valid for this federation.
 
@@ -217,12 +226,12 @@ class Aggregator:
             return (cert_common_name == self.single_col_cert_common_name
                     and collaborator_common_name in self.authorized_cols)
 
-    def all_quit_jobs_sent(self):
+    def all_quit_jobs_sent(self) -> bool:
         """Assert all quit jobs are sent to collaborators."""
         return set(self.quit_job_sent_to) == set(self.authorized_cols)
 
     @staticmethod
-    def _get_sleep_time():
+    def _get_sleep_time() -> int:
         """
         Sleep 10 seconds.
 
@@ -232,7 +241,7 @@ class Aggregator:
         # Decrease sleep period for finer discretezation
         return 10
 
-    def _time_to_quit(self):
+    def _time_to_quit(self) -> bool:
         """
         If all rounds are complete, it's time to quit.
 
@@ -243,7 +252,8 @@ class Aggregator:
             return True
         return False
 
-    def get_tasks(self, collaborator_name):
+    def get_tasks(self,
+                  collaborator_name: str) -> Tuple[Optional[List[str]], Optional[int], int, bool]:
         """
         RPC called by a collaborator to determine which tasks to perform.
 
@@ -313,8 +323,9 @@ class Aggregator:
 
         return tasks, self.round_number, sleep_time, time_to_quit
 
-    def get_aggregated_tensor(self, collaborator_name, tensor_name,
-                              round_number, report, tags, require_lossless):
+    def get_aggregated_tensor(self, collaborator_name: str, tensor_name: str,
+                              round_number: int, report: bool, tags: List[str],
+                              require_lossless: bool) -> Any:
         """
         RPC called by collaborator.
 
@@ -380,8 +391,9 @@ class Aggregator:
 
         return named_tensor
 
-    def _nparray_to_named_tensor(self, tensor_key, nparray, send_model_deltas,
-                                 compress_lossless):
+    def _nparray_to_named_tensor(self, tensor_key: TensorKey, nparray: ndarray,
+                                 send_model_deltas: bool,
+                                 compress_lossless: bool) -> Any:
         """
         Construct the NamedTensor Protobuf.
 
@@ -436,7 +448,8 @@ class Aggregator:
 
         return named_tensor
 
-    def _collaborator_task_completed(self, collaborator, task_name, round_num):
+    def _collaborator_task_completed(self, collaborator: str, task_name: str,
+                                     round_num: int) -> bool:
         """
         Check if the collaborator has completed the task for the round.
 
@@ -458,8 +471,8 @@ class Aggregator:
         task_key = TaskResultKey(task_name, collaborator, round_num)
         return task_key in self.collaborator_tasks_results
 
-    def send_local_task_results(self, collaborator_name, round_number, task_name,
-                                data_size, named_tensors):
+    def send_local_task_results(self, collaborator_name: str, round_number: int, task_name: str,
+                                data_size: int, named_tensors: Any) -> None:
         """
         RPC called by collaborator.
 
@@ -537,7 +550,8 @@ class Aggregator:
 
         self._end_of_task_check(task_name)
 
-    def _process_named_tensor(self, named_tensor, collaborator_name):
+    def _process_named_tensor(self, named_tensor: Any,
+                              collaborator_name: str) -> Union[Tuple[Tuple, ndarray], NoReturn]:
         """
         Extract the named tensor fields.
 
@@ -631,7 +645,7 @@ class Aggregator:
 
         return final_tensor_key, final_nparray
 
-    def _end_of_task_check(self, task_name):
+    def _end_of_task_check(self, task_name: str) -> bool:
         """
         Check whether all collaborators who are supposed to perform the task complete.
 
@@ -647,7 +661,9 @@ class Aggregator:
             # now check for the end of the round
             self._end_of_round_check()
 
-    def _prepare_trained(self, tensor_name, origin, round_number, report, agg_results):
+    def _prepare_trained(self, tensor_name: str, origin: Any,
+                         round_number: int, report: bool,
+                         agg_results: ndarray) -> None:
         """
         Prepare aggregated tensorkey tags.
 
@@ -743,7 +759,7 @@ class Aggregator:
         # Finally, cache the updated model tensor
         self.tensor_db.cache_tensor({final_model_tk: new_model_nparray})
 
-    def _compute_validation_related_task_metrics(self, task_name):
+    def _compute_validation_related_task_metrics(self, task_name: str) -> Union[None, NoReturn]:
         """
         Compute all validation related metrics.
 
@@ -825,7 +841,7 @@ class Aggregator:
             if 'trained' in tags:
                 self._prepare_trained(tensor_name, origin, round_number, report, agg_results)
 
-    def _end_of_round_check(self):
+    def _end_of_round_check(self) -> None:
         """
         Check if the round complete.
 
@@ -863,7 +879,7 @@ class Aggregator:
         # Cleaning tensor db
         self.tensor_db.clean_up(self.db_store_rounds)
 
-    def _is_task_done(self, task_name):
+    def _is_task_done(self, task_name: str) -> bool:
         """Check that task is done."""
         collaborators_needed = self.assigner.get_collaborators_for_task(
             task_name, self.round_number
@@ -875,13 +891,13 @@ class Aggregator:
             ) for c in collaborators_needed
         ])
 
-    def _is_round_done(self):
+    def _is_round_done(self) -> bool:
         """Check that round is done."""
         tasks_for_round = self.assigner.get_all_tasks_for_round(self.round_number)
 
         return all([self._is_task_done(task_name) for task_name in tasks_for_round])
 
-    def _log_big_warning(self):
+    def _log_big_warning(self) -> None:
         """Warn user about single collaborator cert mode."""
         self.logger.warning(
             f'\n{the_dragon}\nYOU ARE RUNNING IN SINGLE COLLABORATOR CERT MODE! THIS IS'

--- a/openfl/component/assigner/assigner.py
+++ b/openfl/component/assigner/assigner.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Assigner module."""
 
+from typing import Dict
 from typing import List
 from typing import NoReturn
 from typing import Optional
@@ -34,7 +35,7 @@ class Assigner:
         \* - ``tasks`` argument is taken from ``tasks`` section of FL plan YAML file.
     """
 
-    def __init__(self, tasks: List[object], authorized_cols: List[str],
+    def __init__(self, tasks: Optional[Dict[str, Dict[str, str]]], authorized_cols: List[str],
                  rounds_to_train: int, **kwargs) -> None:
         """Initialize."""
         self.tasks = tasks

--- a/openfl/component/assigner/assigner.py
+++ b/openfl/component/assigner/assigner.py
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 """Assigner module."""
 
+from typing import List
+from typing import NoReturn
+from typing import Optional
+
 
 class Assigner:
     r"""
@@ -30,8 +34,8 @@ class Assigner:
         \* - ``tasks`` argument is taken from ``tasks`` section of FL plan YAML file.
     """
 
-    def __init__(self, tasks, authorized_cols,
-                 rounds_to_train, **kwargs):
+    def __init__(self, tasks: List[object], authorized_cols: List[str],
+                 rounds_to_train: int, **kwargs) -> None:
         """Initialize."""
         self.tasks = tasks
         self.authorized_cols = authorized_cols
@@ -44,19 +48,19 @@ class Assigner:
 
         self.define_task_assignments()
 
-    def define_task_assignments(self):
+    def define_task_assignments(self) -> NoReturn:
         """Abstract method."""
         raise NotImplementedError
 
-    def get_tasks_for_collaborator(self, collaborator_name, round_number):
+    def get_tasks_for_collaborator(self, collaborator_name: str, round_number: int) -> NoReturn:
         """Abstract method."""
         raise NotImplementedError
 
-    def get_collaborators_for_task(self, task_name, round_number):
+    def get_collaborators_for_task(self, task_name: str, round_number: int) -> NoReturn:
         """Abstract method."""
         raise NotImplementedError
 
-    def get_all_tasks_for_round(self, round_number):
+    def get_all_tasks_for_round(self, round_number: int) -> List:
         """
         Return tasks for the current round.
 
@@ -65,7 +69,7 @@ class Assigner:
         """
         return self.all_tasks_in_groups
 
-    def get_aggregation_type_for_task(self, task_name):
+    def get_aggregation_type_for_task(self, task_name: str) -> Optional[str]:
         """Extract aggregation type from self.tasks."""
         if 'aggregation_type' not in self.tasks[task_name]:
             return None

--- a/openfl/component/assigner/custom_assigner.py
+++ b/openfl/component/assigner/custom_assigner.py
@@ -2,11 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 """Custom Assigner module."""
 
-
 import logging
 from collections import defaultdict
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import List
 
 from openfl.component.aggregation_functions import WeightedAverage
+from openfl.component.aggregation_functions.core import AggregationFunction
 
 logger = logging.getLogger(__name__)
 
@@ -17,11 +21,11 @@ class Assigner:
     def __init__(
             self,
             *,
-            assigner_function,
-            aggregation_functions_by_task,
-            authorized_cols,
-            rounds_to_train
-    ):
+            assigner_function: Callable[[object, int, int], object],
+            aggregation_functions_by_task: Dict[str, AggregationFunction],
+            authorized_cols: List,
+            rounds_to_train: int
+    ) -> None:
         """Initialize."""
         self.agg_functions_by_task = aggregation_functions_by_task
         self.agg_functions_by_task_name = {}
@@ -34,7 +38,7 @@ class Assigner:
 
         self.define_task_assignments()
 
-    def define_task_assignments(self):
+    def define_task_assignments(self) -> None:
         """Abstract method."""
         for round_number in range(self.rounds_to_train):
             tasks_by_collaborator = self.assigner_function(
@@ -52,15 +56,17 @@ class Assigner:
                             task.name
                         ] = self.agg_functions_by_task.get(task.function_name, WeightedAverage())
 
-    def get_tasks_for_collaborator(self, collaborator_name, round_number):
+    def get_tasks_for_collaborator(self, collaborator_name: str,
+                                   round_number: int) -> List[Any]:
         """Abstract method."""
         return self.collaborator_tasks[round_number][collaborator_name]
 
-    def get_collaborators_for_task(self, task_name, round_number):
+    def get_collaborators_for_task(self, task_name: str,
+                                   round_number: int) -> List[Any]:
         """Abstract method."""
         return self.collaborators_for_task[round_number][task_name]
 
-    def get_all_tasks_for_round(self, round_number):
+    def get_all_tasks_for_round(self, round_number: int) -> List:
         """
         Return tasks for the current round.
 
@@ -69,7 +75,7 @@ class Assigner:
         """
         return [task.name for task in self.all_tasks_for_round[round_number].values()]
 
-    def get_aggregation_type_for_task(self, task_name):
+    def get_aggregation_type_for_task(self, task_name: str) -> AggregationFunction:
         """Extract aggregation type from self.tasks."""
         agg_fn = self.agg_functions_by_task_name.get(task_name, WeightedAverage())
         return agg_fn

--- a/openfl/component/assigner/custom_assigner.py
+++ b/openfl/component/assigner/custom_assigner.py
@@ -4,13 +4,14 @@
 
 import logging
 from collections import defaultdict
-from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import List
+from typing import Union
 
 from openfl.component.aggregation_functions import WeightedAverage
 from openfl.component.aggregation_functions.core import AggregationFunction
+from openfl.component.assigner.tasks import Task
 
 logger = logging.getLogger(__name__)
 
@@ -57,12 +58,12 @@ class Assigner:
                         ] = self.agg_functions_by_task.get(task.function_name, WeightedAverage())
 
     def get_tasks_for_collaborator(self, collaborator_name: str,
-                                   round_number: int) -> List[Any]:
+                                   round_number: int) -> List[Union[str, Task]]:
         """Abstract method."""
         return self.collaborator_tasks[round_number][collaborator_name]
 
     def get_collaborators_for_task(self, task_name: str,
-                                   round_number: int) -> List[Any]:
+                                   round_number: int) -> List[str]:
         """Abstract method."""
         return self.collaborators_for_task[round_number][task_name]
 

--- a/openfl/component/assigner/custom_assigner.py
+++ b/openfl/component/assigner/custom_assigner.py
@@ -23,7 +23,7 @@ class Assigner:
             *,
             assigner_function: Callable[[object, int, int], object],
             aggregation_functions_by_task: Dict[str, AggregationFunction],
-            authorized_cols: List,
+            authorized_cols: List[str],
             rounds_to_train: int
     ) -> None:
         """Initialize."""
@@ -66,7 +66,7 @@ class Assigner:
         """Abstract method."""
         return self.collaborators_for_task[round_number][task_name]
 
-    def get_all_tasks_for_round(self, round_number: int) -> List:
+    def get_all_tasks_for_round(self, round_number: int) -> List[str]:
         """
         Return tasks for the current round.
 

--- a/openfl/component/assigner/random_grouped_assigner.py
+++ b/openfl/component/assigner/random_grouped_assigner.py
@@ -3,6 +3,10 @@
 
 """Random grouped assigner module."""
 
+from typing import Dict
+from typing import List
+from typing import NoReturn
+from typing import Union
 
 import numpy as np
 
@@ -35,12 +39,12 @@ class RandomGroupedAssigner(Assigner):
         \* - Plan setting.
     """
 
-    def __init__(self, task_groups, **kwargs):
+    def __init__(self, task_groups: List[object], **kwargs) -> None:
         """Initialize."""
         self.task_groups = task_groups
         super().__init__(**kwargs)
 
-    def define_task_assignments(self):
+    def define_task_assignments(self) -> Union[None, NoReturn]:
         """All of the logic to set up the map of tasks to collaborators is done here."""
         assert (np.abs(1.0 - np.sum([group['percentage']
                                      for group in self.task_groups])) < 0.01), (
@@ -87,10 +91,10 @@ class RandomGroupedAssigner(Assigner):
                 col_idx += num_col_in_group
             assert (col_idx == col_list_size), 'Task groups were not divided properly'
 
-    def get_tasks_for_collaborator(self, collaborator_name, round_number):
+    def get_tasks_for_collaborator(self, collaborator_name: str, round_number: int) -> Dict:
         """Get tasks for the collaborator specified."""
         return self.collaborator_tasks[collaborator_name][round_number]
 
-    def get_collaborators_for_task(self, task_name, round_number):
+    def get_collaborators_for_task(self, task_name: str, round_number: int) -> Dict:
         """Get collaborators for the task specified."""
         return self.collaborators_for_task[task_name][round_number]

--- a/openfl/component/assigner/random_grouped_assigner.py
+++ b/openfl/component/assigner/random_grouped_assigner.py
@@ -93,6 +93,6 @@ class RandomGroupedAssigner(Assigner):
         """Get tasks for the collaborator specified."""
         return self.collaborator_tasks[collaborator_name][round_number]
 
-    def get_collaborators_for_task(self, task_name: str, round_number: int) -> List[Any]:
+    def get_collaborators_for_task(self, task_name: str, round_number: int) -> List[str]:
         """Get collaborators for the task specified."""
         return self.collaborators_for_task[task_name][round_number]

--- a/openfl/component/assigner/random_grouped_assigner.py
+++ b/openfl/component/assigner/random_grouped_assigner.py
@@ -3,10 +3,8 @@
 
 """Random grouped assigner module."""
 
-from typing import Dict
+from typing import Any
 from typing import List
-from typing import NoReturn
-from typing import Union
 
 import numpy as np
 
@@ -39,12 +37,12 @@ class RandomGroupedAssigner(Assigner):
         \* - Plan setting.
     """
 
-    def __init__(self, task_groups: List[object], **kwargs) -> None:
+    def __init__(self, task_groups: List[Any], **kwargs) -> None:
         """Initialize."""
         self.task_groups = task_groups
         super().__init__(**kwargs)
 
-    def define_task_assignments(self) -> Union[None, NoReturn]:
+    def define_task_assignments(self) -> None:
         """All of the logic to set up the map of tasks to collaborators is done here."""
         assert (np.abs(1.0 - np.sum([group['percentage']
                                      for group in self.task_groups])) < 0.01), (
@@ -91,10 +89,10 @@ class RandomGroupedAssigner(Assigner):
                 col_idx += num_col_in_group
             assert (col_idx == col_list_size), 'Task groups were not divided properly'
 
-    def get_tasks_for_collaborator(self, collaborator_name: str, round_number: int) -> Dict:
+    def get_tasks_for_collaborator(self, collaborator_name: str, round_number: int) -> List[str]:
         """Get tasks for the collaborator specified."""
         return self.collaborator_tasks[collaborator_name][round_number]
 
-    def get_collaborators_for_task(self, task_name: str, round_number: int) -> Dict:
+    def get_collaborators_for_task(self, task_name: str, round_number: int) -> List[Any]:
         """Get collaborators for the task specified."""
         return self.collaborators_for_task[task_name][round_number]

--- a/openfl/component/assigner/static_grouped_assigner.py
+++ b/openfl/component/assigner/static_grouped_assigner.py
@@ -92,6 +92,6 @@ class StaticGroupedAssigner(Assigner):
         """Get tasks for the collaborator specified."""
         return self.collaborator_tasks[collaborator_name][round_number]
 
-    def get_collaborators_for_task(self, task_name: str, round_number: int) -> List[Any]:
+    def get_collaborators_for_task(self, task_name: str, round_number: int) -> List[str]:
         """Get collaborators for the task specified."""
         return self.collaborators_for_task[task_name][round_number]

--- a/openfl/component/assigner/static_grouped_assigner.py
+++ b/openfl/component/assigner/static_grouped_assigner.py
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Static grouped assigner module."""
-from typing import Dict
+
+from typing import Any
 from typing import List
 
 from .assigner import Assigner
@@ -34,7 +35,7 @@ class StaticGroupedAssigner(Assigner):
         \* - Plan setting.
     """
 
-    def __init__(self, task_groups: List[object], **kwargs) -> None:
+    def __init__(self, task_groups: List[Any], **kwargs) -> None:
         """Initialize."""
         self.task_groups = task_groups
         super().__init__(**kwargs)
@@ -87,10 +88,10 @@ class StaticGroupedAssigner(Assigner):
                     # that task
                     self.collaborators_for_task[task][round_] += group_col_list
 
-    def get_tasks_for_collaborator(self, collaborator_name: str, round_number: int) -> Dict:
+    def get_tasks_for_collaborator(self, collaborator_name: str, round_number: int) -> List[str]:
         """Get tasks for the collaborator specified."""
         return self.collaborator_tasks[collaborator_name][round_number]
 
-    def get_collaborators_for_task(self, task_name: str, round_number: int) -> Dict:
+    def get_collaborators_for_task(self, task_name: str, round_number: int) -> List[Any]:
         """Get collaborators for the task specified."""
         return self.collaborators_for_task[task_name][round_number]

--- a/openfl/component/assigner/static_grouped_assigner.py
+++ b/openfl/component/assigner/static_grouped_assigner.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Static grouped assigner module."""
+from typing import Dict
+from typing import List
 
 from .assigner import Assigner
 
@@ -32,12 +34,12 @@ class StaticGroupedAssigner(Assigner):
         \* - Plan setting.
     """
 
-    def __init__(self, task_groups, **kwargs):
+    def __init__(self, task_groups: List[object], **kwargs) -> None:
         """Initialize."""
         self.task_groups = task_groups
         super().__init__(**kwargs)
 
-    def define_task_assignments(self):
+    def define_task_assignments(self) -> None:
         """All of the logic to set up the map of tasks to collaborators is done here."""
         cols_amount = sum([
             len(group['collaborators']) for group in self.task_groups
@@ -85,10 +87,10 @@ class StaticGroupedAssigner(Assigner):
                     # that task
                     self.collaborators_for_task[task][round_] += group_col_list
 
-    def get_tasks_for_collaborator(self, collaborator_name, round_number):
+    def get_tasks_for_collaborator(self, collaborator_name: str, round_number: int) -> Dict:
         """Get tasks for the collaborator specified."""
         return self.collaborator_tasks[collaborator_name][round_number]
 
-    def get_collaborators_for_task(self, task_name, round_number):
+    def get_collaborators_for_task(self, task_name: str, round_number: int) -> Dict:
         """Get collaborators for the task specified."""
         return self.collaborators_for_task[task_name][round_number]

--- a/openfl/component/ca/ca.py
+++ b/openfl/component/ca/ca.py
@@ -131,7 +131,7 @@ def get_token(name: str, ca_url: str,
     ])
 
 
-def get_ca_bin_paths(ca_path: Path) -> Tuple[Optional[Path], Optional[Path]]:
+def get_ca_bin_paths(ca_path: Union[Path, str]) -> Tuple[Optional[Path], Optional[Path]]:
     """Get paths of step binaries."""
     ca_path = Path(ca_path)
     step = None
@@ -146,8 +146,8 @@ def get_ca_bin_paths(ca_path: Path) -> Tuple[Optional[Path], Optional[Path]]:
     return step, step_ca
 
 
-def certify(name: str, cert_path: Path, token_with_cert: str,
-            ca_path: Path) -> None:
+def certify(name: str, cert_path: Union[Path, str], token_with_cert: str,
+            ca_path: Union[Path, str]) -> None:
     """Create an envoy workspace."""
     os.makedirs(cert_path, exist_ok=True)
 
@@ -170,13 +170,13 @@ def certify(name: str, cert_path: Path, token_with_cert: str,
          f'{cert_path}/{name}.key --kty EC --curve P-384 -f --token {token}', shell=True)
 
 
-def remove_ca(ca_path: str) -> None:
+def remove_ca(ca_path: Union[Path, str]) -> None:
     """Kill step-ca process and rm ca directory."""
     _check_kill_process('step-ca')
     shutil.rmtree(ca_path, ignore_errors=True)
 
 
-def install(ca_path: str, ca_url: str, password: str) -> None:
+def install(ca_path: Union[Path, str], ca_url: str, password: str) -> None:
     """
     Create certificate authority for federation.
 

--- a/openfl/component/ca/ca.py
+++ b/openfl/component/ca/ca.py
@@ -15,7 +15,6 @@ import urllib.request
 from logging import getLogger
 from pathlib import Path
 from subprocess import call
-from typing import NoReturn
 from typing import Optional
 from typing import Tuple
 from typing import Union
@@ -90,7 +89,7 @@ def download_step_bin(url: str, grep_name: str, architecture: str,
 
 
 def get_token(name: str, ca_url: str,
-              ca_path: Union[Path, str] = '.') -> Union[str, None, NoReturn]:
+              ca_path: Union[Path, str] = '.') -> Optional[str]:
     """
     Create authentication token.
 
@@ -148,7 +147,7 @@ def get_ca_bin_paths(ca_path: Path) -> Tuple[Optional[Path], Optional[Path]]:
 
 
 def certify(name: str, cert_path: Path, token_with_cert: str,
-            ca_path: Path) -> Union[None, NoReturn]:
+            ca_path: Path) -> None:
     """Create an envoy workspace."""
     os.makedirs(cert_path, exist_ok=True)
 

--- a/openfl/component/collaborator/collaborator.py
+++ b/openfl/component/collaborator/collaborator.py
@@ -10,6 +10,7 @@ from typing import Any
 from typing import Dict
 from typing import List
 from typing import NamedTuple
+from typing import Optional
 from typing import Tuple
 from typing import Union
 
@@ -17,10 +18,13 @@ from numpy import ndarray
 
 from openfl.component.assigner.tasks import Task
 from openfl.databases import TensorDB
+from openfl.federated.task.task_runner import CoreTaskRunner
 from openfl.pipelines import NoCompressionPipeline
 from openfl.pipelines import TensorCodec
+from openfl.pipelines.pipeline import Transformer
 from openfl.protocols import utils
 from openfl.protocols.base_pb2 import NamedTensor
+from openfl.transport import AggregatorGRPCClient
 from openfl.utilities import TensorKey
 
 
@@ -80,13 +84,13 @@ class Collaborator:
                  collaborator_name: str,
                  aggregator_uuid: str,
                  federation_uuid: str,
-                 client: Any,
-                 task_runner: Any,
+                 client: AggregatorGRPCClient,
+                 task_runner: CoreTaskRunner,
                  task_config: Any,
                  opt_treatment: Union[OptTreatment, str] = 'RESET',
                  device_assignment_policy: str = 'CPU_ONLY',
                  delta_updates: bool = False,
-                 compression_pipeline: Any = None,
+                 compression_pipeline: Optional[Transformer] = None,
                  db_store_rounds: int = 1,
                  **kwargs) -> None:
         """Initialize."""

--- a/openfl/component/collaborator/collaborator.py
+++ b/openfl/component/collaborator/collaborator.py
@@ -136,7 +136,7 @@ class Collaborator:
 
         self.task_runner.set_optimizer_treatment(self.opt_treatment.name)
 
-    def set_available_devices(self, cuda: Union[Tuple[()], Tuple[str]] = ()) -> None:
+    def set_available_devices(self, cuda: Tuple[str, ...]) -> None:
         """
         Set available CUDA devices.
 

--- a/openfl/component/director/director.py
+++ b/openfl/component/director/director.py
@@ -92,7 +92,7 @@ class Director:
         return True
 
     def get_trained_model(self, experiment_name: str, caller: str,
-                          model_type: str) -> Optional[Dict['str', ndarray]]:
+                          model_type: str) -> Optional[Dict[str, ndarray]]:
         """Get trained model."""
         if (experiment_name not in self.experiments_registry
                 or caller not in self.experiments_registry[experiment_name].users):

--- a/openfl/component/director/director.py
+++ b/openfl/component/director/director.py
@@ -8,6 +8,7 @@ import logging
 import time
 from collections import defaultdict
 from pathlib import Path
+from typing import Any
 from typing import AsyncGenerator
 from typing import Dict
 from typing import Iterable
@@ -191,7 +192,7 @@ class Director:
             self, *,
             envoy_name: str,
             is_experiment_running: bool,
-            cuda_devices_status: Optional[List] = None,
+            cuda_devices_status: Optional[List[Dict[str, Any]]] = None,
     ) -> int:
         """Accept health check from envoy."""
         shard_info = self._shard_registry.get(envoy_name)

--- a/openfl/component/director/director.py
+++ b/openfl/component/director/director.py
@@ -8,7 +8,6 @@ import logging
 import time
 from collections import defaultdict
 from pathlib import Path
-from typing import Any
 from typing import AsyncGenerator
 from typing import Dict
 from typing import Iterable
@@ -16,6 +15,8 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 from typing import Union
+
+from numpy import ndarray
 
 from .experiment import Experiment
 from .experiment import ExperimentsRegistry
@@ -35,8 +36,8 @@ class Director:
             root_certificate: Union[Path, str] = None,
             private_key: Union[Path, str] = None,
             certificate: Union[Path, str] = None,
-            sample_shape: list = None,
-            target_shape: list = None,
+            sample_shape: Optional[List[str]] = None,
+            target_shape: Optional[List[str]] = None,
             settings: dict = None
     ) -> None:
         """Initialize a director object."""
@@ -91,7 +92,7 @@ class Director:
         return True
 
     def get_trained_model(self, experiment_name: str, caller: str,
-                          model_type: str) -> Union[Dict, None]:
+                          model_type: str) -> Optional[Dict['str', ndarray]]:
         """Get trained model."""
         if (experiment_name not in self.experiments_registry
                 or caller not in self.experiments_registry[experiment_name].users):
@@ -125,7 +126,7 @@ class Director:
 
         return experiment_name
 
-    def get_dataset_info(self) -> Tuple[List, List]:
+    def get_dataset_info(self) -> Tuple[List[str], List[str]]:
         """Get dataset info."""
         return self.sample_shape, self.target_shape
 
@@ -134,7 +135,7 @@ class Director:
         return [shard_status['shard_info'] for shard_status in self._shard_registry.values()]
 
     async def stream_metrics(self, experiment_name: str,
-                             caller: str) -> AsyncGenerator[Optional[Union[Dict, None]], Any]:
+                             caller: str) -> AsyncGenerator[Optional[Dict], None]:
         """
         Stream metrics from the aggregator.
 
@@ -305,7 +306,7 @@ def _get_model_download_statuses(experiment: Experiment) -> List[dict]:
     return model_statuses
 
 
-def _get_experiment_progress(experiment: Experiment) -> Union[float, None]:
+def _get_experiment_progress(experiment: Experiment) -> Optional[float]:
     if experiment.status == Status.IN_PROGRESS:
         return experiment.aggregator.round_number / experiment.aggregator.rounds_to_train
 

--- a/openfl/component/director/experiment.py
+++ b/openfl/component/director/experiment.py
@@ -7,6 +7,8 @@ import asyncio
 import logging
 from contextlib import asynccontextmanager
 from pathlib import Path
+from typing import Any
+from typing import AsyncGenerator
 from typing import Iterable
 from typing import List
 from typing import Union
@@ -61,7 +63,7 @@ class Experiment:
             root_certificate: Union[Path, str] = None,
             private_key: Union[Path, str] = None,
             certificate: Union[Path, str] = None,
-    ):
+    ) -> None:
         """Run experiment."""
         self.status = Status.IN_PROGRESS
         try:
@@ -167,7 +169,7 @@ class ExperimentsRegistry:
         """Get experiment by name."""
         return self.__dict[key]
 
-    def get(self, key: str, default=None) -> Experiment:
+    def get(self, key: str, default: Any = None) -> Experiment:
         """Get experiment by name."""
         return self.__dict.get(key, default)
 
@@ -189,7 +191,7 @@ class ExperimentsRegistry:
         self.__active_experiment_name = None
 
     @asynccontextmanager
-    async def get_next_experiment(self):
+    async def get_next_experiment(self) -> AsyncGenerator[Experiment, Any]:
         """Context manager.
 
         On enter get experiment from pending_experiments.

--- a/openfl/component/director/experiment.py
+++ b/openfl/component/director/experiment.py
@@ -191,7 +191,7 @@ class ExperimentsRegistry:
         self.__active_experiment_name = None
 
     @asynccontextmanager
-    async def get_next_experiment(self) -> AsyncGenerator[Experiment, Any]:
+    async def get_next_experiment(self) -> AsyncGenerator[Experiment, None]:
         """Context manager.
 
         On enter get experiment from pending_experiments.

--- a/openfl/component/envoy/envoy.py
+++ b/openfl/component/envoy/envoy.py
@@ -9,6 +9,8 @@ import traceback
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from typing import Any
+from typing import List
 from typing import Optional
 from typing import Type
 from typing import Union
@@ -69,7 +71,7 @@ class Envoy:
         self.is_experiment_running = False
         self._health_check_future = None
 
-    def run(self):
+    def run(self) -> None:
         """Run of the envoy working cycle."""
         while True:
             try:
@@ -100,7 +102,7 @@ class Envoy:
                 self.is_experiment_running = False
 
     @staticmethod
-    def _save_data_stream_to_file(data_stream):
+    def _save_data_stream_to_file(data_stream: Any) -> Path:
         data_file_path = Path(str(uuid.uuid4())).absolute()
         with open(data_file_path, 'wb') as data_file:
             for response in data_stream:
@@ -110,7 +112,7 @@ class Envoy:
                     raise Exception('Broken archive')
         return data_file_path
 
-    def send_health_check(self):
+    def send_health_check(self) -> None:
         """Send health check to the director."""
         logger.info('The health check sender is started.')
         while True:
@@ -122,7 +124,7 @@ class Envoy:
             )
             time.sleep(timeout)
 
-    def _get_cuda_device_info(self):
+    def _get_cuda_device_info(self) -> Optional[List]:
         cuda_devices_info = None
         try:
             if self.cuda_device_monitor is not None:
@@ -150,7 +152,7 @@ class Envoy:
                              f'Check your cuda device monitor plugin.')
         return cuda_devices_info
 
-    def _run_collaborator(self, plan='plan/plan.yaml'):
+    def _run_collaborator(self, plan: str = 'plan/plan.yaml') -> None:
         """Run the collaborator for the experiment running."""
         plan = Plan.parse(plan_config_path=Path(plan))
 
@@ -163,7 +165,7 @@ class Envoy:
         col.set_available_devices(cuda=self.cuda_devices)
         col.run()
 
-    def start(self):
+    def start(self) -> None:
         """Start the envoy."""
         try:
             is_accepted = self.director_client.report_shard_info(

--- a/openfl/component/envoy/envoy.py
+++ b/openfl/component/envoy/envoy.py
@@ -10,6 +10,7 @@ import uuid
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
+from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Type
@@ -124,7 +125,7 @@ class Envoy:
             )
             time.sleep(timeout)
 
-    def _get_cuda_device_info(self) -> Optional[List]:
+    def _get_cuda_device_info(self) -> Optional[List[Dict[str, Union[int, str]]]]:
         cuda_devices_info = None
         try:
             if self.cuda_device_monitor is not None:


### PR DESCRIPTION
Preparations to add [Flake8-annotations](https://pypi.org/project/flake8-annotations/) plugin. 

This fix is only for errors in **component** folder.

It is assumed that the next flake8-annotations errors will be ignored: 
* ANN002 - Missing type annotation for `*args`
* ANN003 - Missing type annotation for `**kwargs`
* ANN101 - Missing type annotation for `self` in method
* ANN102 - Missing type annotation for `cls` in classmethod
