### PR TITLE
Flake8-annotations: fix errors in openfl-workspace, part 1

### DIFF
--- a/openfl-workspace/keras_nlp/src/dataloader_utils.py
+++ b/openfl-workspace/keras_nlp/src/dataloader_utils.py
@@ -7,6 +7,9 @@ from logging import getLogger
 from os import getcwd
 from os import path
 from os import remove
+from typing import Any
+from typing import Dict
+from typing import Tuple
 from zipfile import ZipFile
 
 import numpy as np
@@ -15,7 +18,8 @@ import requests
 logger = getLogger(__name__)
 
 
-def download_data_():
+@staticmethod
+def download_data_() -> Any:
     """Download data.
 
     Returns:
@@ -59,7 +63,8 @@ def download_data_():
         return ''
 
 
-def import_raw_data_(data_path='', num_samples=0):
+def import_raw_data_(data_path: Any = '',
+                     num_samples: int = 0) -> Tuple[Dict, np.ndarray, np.ndarray, np.ndarray]:
     """Import data.
 
     Returns:
@@ -146,8 +151,8 @@ def import_raw_data_(data_path='', num_samples=0):
     return details, encoder_input_data, decoder_input_data, decoder_target_data
 
 
-def get_datasets_(encoder_input_data, decoder_input_data,
-                  decoder_target_data, num_samples, split_ratio):
+def get_datasets_(encoder_input_data: np.ndarray, decoder_input_data: np.ndarray,
+                  decoder_target_data: np.ndarray, num_samples: int, split_ratio: float) -> Dict:
     """Create train/val.
 
     Returns:
@@ -181,7 +186,8 @@ def get_datasets_(encoder_input_data, decoder_input_data,
     return results
 
 
-def load_shard(collaborator_count, shard_num, data_path, num_samples, split_ratio):
+def load_shard(collaborator_count: int, shard_num: Any, data_path: str,
+               num_samples: int, split_ratio: float) -> Tuple:
     """Load data-shards.
 
     Returns:

--- a/openfl-workspace/keras_nlp/src/dataloader_utils.py
+++ b/openfl-workspace/keras_nlp/src/dataloader_utils.py
@@ -7,7 +7,6 @@ from logging import getLogger
 from os import getcwd
 from os import path
 from os import remove
-from typing import Any
 from typing import Dict
 from typing import Tuple
 from zipfile import ZipFile
@@ -190,7 +189,7 @@ def get_datasets_(encoder_input_data: np.ndarray, decoder_input_data: np.ndarray
 
 
 def load_shard(
-    collaborator_count: int, shard_num: Any, data_path: str,
+    collaborator_count: int, shard_num: str, data_path: str,
     num_samples: int, split_ratio: float
 ) -> Tuple[Tuple[np.ndarray, ...], Tuple[np.ndarray, ...], Dict[str, int]]:
     """Load data-shards.

--- a/openfl-workspace/keras_nlp/src/dataloader_utils.py
+++ b/openfl-workspace/keras_nlp/src/dataloader_utils.py
@@ -19,7 +19,7 @@ logger = getLogger(__name__)
 
 
 @staticmethod
-def download_data_() -> Any:
+def download_data_() -> str:
     """Download data.
 
     Returns:
@@ -63,8 +63,10 @@ def download_data_() -> Any:
         return ''
 
 
-def import_raw_data_(data_path: Any = '',
-                     num_samples: int = 0) -> Tuple[Dict, np.ndarray, np.ndarray, np.ndarray]:
+def import_raw_data_(
+    data_path: str = '',
+    num_samples: int = 0
+) -> Tuple[Dict[str, int], np.ndarray, np.ndarray, np.ndarray]:
     """Import data.
 
     Returns:
@@ -152,7 +154,8 @@ def import_raw_data_(data_path: Any = '',
 
 
 def get_datasets_(encoder_input_data: np.ndarray, decoder_input_data: np.ndarray,
-                  decoder_target_data: np.ndarray, num_samples: int, split_ratio: float) -> Dict:
+                  decoder_target_data: np.ndarray,
+                  num_samples: int, split_ratio: float) -> Dict[str, np.ndarray]:
     """Create train/val.
 
     Returns:
@@ -186,8 +189,10 @@ def get_datasets_(encoder_input_data: np.ndarray, decoder_input_data: np.ndarray
     return results
 
 
-def load_shard(collaborator_count: int, shard_num: Any, data_path: str,
-               num_samples: int, split_ratio: float) -> Tuple:
+def load_shard(
+    collaborator_count: int, shard_num: Any, data_path: str,
+    num_samples: int, split_ratio: float
+) -> Tuple[Tuple[np.ndarray, ...], Tuple[np.ndarray, ...], Dict[str, int]]:
     """Load data-shards.
 
     Returns:

--- a/openfl-workspace/keras_nlp/src/dataloader_utils.py
+++ b/openfl-workspace/keras_nlp/src/dataloader_utils.py
@@ -17,7 +17,6 @@ import requests
 logger = getLogger(__name__)
 
 
-@staticmethod
 def download_data_() -> str:
     """Download data.
 

--- a/openfl-workspace/keras_nlp/src/nlp_dataloader.py
+++ b/openfl-workspace/keras_nlp/src/nlp_dataloader.py
@@ -4,10 +4,10 @@ Licensed subject to the terms of the separately executed evaluation
 license agreement between Intel Corporation and you.
 """
 from logging import getLogger
-from typing import Callable
-from typing import Iterable
+from typing import Iterator
 from typing import List
 from typing import Optional
+from typing import Tuple
 
 import numpy as np
 import src.dataloader_utils as dlu
@@ -21,7 +21,7 @@ class NLPDataLoader(KerasDataLoader):
     """NLP Dataloader template."""
 
     def __init__(self, collaborator_count: int, split_ratio: float,
-                 num_samples: int, data_path: str, batch_size: Optional[int], **kwargs) -> None:
+                 num_samples: int, data_path: str, batch_size: int, **kwargs) -> None:
         """Instantiate the data object.
 
         Args:
@@ -51,11 +51,11 @@ class NLPDataLoader(KerasDataLoader):
         self.X_valid = [valid[0], valid[1]]
         self.y_valid = valid[2]
 
-    def get_feature_shape(self) -> tuple:
+    def get_feature_shape(self) -> Tuple[int, ...]:
         """Get the shape of an example feature array."""
         return self.X_train[0].shape
 
-    def get_train_loader(self, batch_size: Optional[int] = None) -> Callable[..., Callable]:
+    def get_train_loader(self, batch_size: Optional[int] = None) -> Iterator[List[np.ndarray]]:
         """
         Get training data loader.
 
@@ -66,7 +66,7 @@ class NLPDataLoader(KerasDataLoader):
         return self._get_batch_generator(X1=self.X_train[0], X2=self.X_train[1],
                                          y=self.y_train, batch_size=batch_size)
 
-    def get_valid_loader(self, batch_size: Optional[int] = None) -> Callable[..., Callable]:
+    def get_valid_loader(self, batch_size: Optional[int] = None) -> Iterator[List[np.ndarray]]:
         """
         Get validation data loader.
 
@@ -98,7 +98,7 @@ class NLPDataLoader(KerasDataLoader):
     def _batch_generator(X1: np.ndarray, X2: np.ndarray,
                          y: np.ndarray, idxs: np.ndarray,
                          batch_size: Optional[int],
-                         num_batches: int) -> Iterable[List[np.ndarray]]:
+                         num_batches: int) -> Iterator[List[np.ndarray]]:
         """
         Generate batch of data.
 
@@ -117,7 +117,8 @@ class NLPDataLoader(KerasDataLoader):
             yield [X1[idxs[a:b]], X2[idxs[a:b]]], y[idxs[a:b]]
 
     def _get_batch_generator(self, X1: np.ndarray, X2: np.ndarray,
-                             y: np.ndarray, batch_size: Optional[int]) -> Callable[..., Iterable]:
+                             y: np.ndarray,
+                             batch_size: Optional[int]) -> Iterator[List[np.ndarray]]:
         """
         Return the dataset generator.
 

--- a/openfl-workspace/keras_nlp/src/nlp_dataloader.py
+++ b/openfl-workspace/keras_nlp/src/nlp_dataloader.py
@@ -97,7 +97,7 @@ class NLPDataLoader(KerasDataLoader):
     @staticmethod
     def _batch_generator(X1: np.ndarray, X2: np.ndarray,
                          y: np.ndarray, idxs: np.ndarray,
-                         batch_size: Optional[int],
+                         batch_size: int,
                          num_batches: int) -> Iterator[List[np.ndarray]]:
         """
         Generate batch of data.

--- a/openfl-workspace/keras_nlp/src/nlp_dataloader.py
+++ b/openfl-workspace/keras_nlp/src/nlp_dataloader.py
@@ -4,6 +4,10 @@ Licensed subject to the terms of the separately executed evaluation
 license agreement between Intel Corporation and you.
 """
 from logging import getLogger
+from typing import Callable
+from typing import Iterable
+from typing import List
+from typing import Optional
 
 import numpy as np
 import src.dataloader_utils as dlu
@@ -16,8 +20,8 @@ logger = getLogger(__name__)
 class NLPDataLoader(KerasDataLoader):
     """NLP Dataloader template."""
 
-    def __init__(self, collaborator_count, split_ratio,
-                 num_samples, data_path, batch_size, **kwargs):
+    def __init__(self, collaborator_count: int, split_ratio: float,
+                 num_samples: int, data_path: str, batch_size: Optional[int], **kwargs) -> None:
         """Instantiate the data object.
 
         Args:
@@ -47,11 +51,11 @@ class NLPDataLoader(KerasDataLoader):
         self.X_valid = [valid[0], valid[1]]
         self.y_valid = valid[2]
 
-    def get_feature_shape(self):
+    def get_feature_shape(self) -> tuple:
         """Get the shape of an example feature array."""
         return self.X_train[0].shape
 
-    def get_train_loader(self, batch_size=None):
+    def get_train_loader(self, batch_size: Optional[int] = None) -> Callable[..., Callable]:
         """
         Get training data loader.
 
@@ -62,7 +66,7 @@ class NLPDataLoader(KerasDataLoader):
         return self._get_batch_generator(X1=self.X_train[0], X2=self.X_train[1],
                                          y=self.y_train, batch_size=batch_size)
 
-    def get_valid_loader(self, batch_size=None):
+    def get_valid_loader(self, batch_size: Optional[int] = None) -> Callable[..., Callable]:
         """
         Get validation data loader.
 
@@ -72,7 +76,7 @@ class NLPDataLoader(KerasDataLoader):
         return self._get_batch_generator(X1=self.X_valid[0], X2=self.X_valid[1],
                                          y=self.y_valid, batch_size=batch_size)
 
-    def get_train_data_size(self):
+    def get_train_data_size(self) -> int:
         """
         Get total number of training samples.
 
@@ -81,7 +85,7 @@ class NLPDataLoader(KerasDataLoader):
         """
         return self.X_train[0].shape[0]
 
-    def get_valid_data_size(self):
+    def get_valid_data_size(self) -> int:
         """
         Get total number of validation samples.
 
@@ -91,7 +95,10 @@ class NLPDataLoader(KerasDataLoader):
         return self.X_valid[0].shape[0]
 
     @staticmethod
-    def _batch_generator(X1, X2, y, idxs, batch_size, num_batches):
+    def _batch_generator(X1: np.ndarray, X2: np.ndarray,
+                         y: np.ndarray, idxs: np.ndarray,
+                         batch_size: Optional[int],
+                         num_batches: int) -> Iterable[List[np.ndarray]]:
         """
         Generate batch of data.
 
@@ -109,7 +116,8 @@ class NLPDataLoader(KerasDataLoader):
             b = a + batch_size
             yield [X1[idxs[a:b]], X2[idxs[a:b]]], y[idxs[a:b]]
 
-    def _get_batch_generator(self, X1, X2, y, batch_size):
+    def _get_batch_generator(self, X1: np.ndarray, X2: np.ndarray,
+                             y: np.ndarray, batch_size: Optional[int]) -> Callable[..., Iterable]:
         """
         Return the dataset generator.
 

--- a/openfl-workspace/keras_nlp/src/nlp_dataloader.py
+++ b/openfl-workspace/keras_nlp/src/nlp_dataloader.py
@@ -8,6 +8,7 @@ from typing import Iterator
 from typing import List
 from typing import Optional
 from typing import Tuple
+from typing import Union
 
 import numpy as np
 import src.dataloader_utils as dlu
@@ -118,7 +119,7 @@ class NLPDataLoader(KerasDataLoader):
 
     def _get_batch_generator(self, X1: np.ndarray, X2: np.ndarray,
                              y: np.ndarray,
-                             batch_size: Optional[int]) -> Iterator[List[np.ndarray]]:
+                             batch_size: Union[int, None]) -> Iterator[List[np.ndarray]]:
         """
         Return the dataset generator.
 


### PR DESCRIPTION
Preparations to add [Flake8-annotations](https://pypi.org/project/flake8-annotations/) plugin (**optional changes**).

This fix is only for errors in **openfl-workspace** folder.

It is assumed that the next flake8-annotations errors will be ignored:

ANN002 - Missing type annotation for `*args`
ANN003 - Missing type annotation for `**kwargs`
ANN101 - Missing type annotation for `self` in method
ANN102 - Missing type annotation for `cls` in classmethod