### PR TITLE
Flake8-annotations: fix errors in openfl-tutorials

### DIFF
--- a/openfl-tutorials/interactive_api/MXNet_landmarks/envoy/landmark_shard_descriptor.py
+++ b/openfl-tutorials/interactive_api/MXNet_landmarks/envoy/landmark_shard_descriptor.py
@@ -39,7 +39,7 @@ class LandmarkShardDataset(ShardDataset):
         # Shuffling the results dataset after choose half pictures of each class
         shuffle(self.img_names)
 
-    def __getitem__(self, index) -> np.ndarray:
+    def __getitem__(self, index: int) -> np.ndarray:
         """Return a item by the index."""
         # Get name key points file
         # f.e. image name:  'img_123.npy, corresponding name of the key points: 'keypoints_123.npy'
@@ -74,7 +74,7 @@ class LandmarkShardDescriptor(ShardDescriptor):
         if self._target_shape[0] != '1':
             raise ValueError('Target has a wrong shape')
 
-    def process_data(self, name_csv_file) -> None:
+    def process_data(self, name_csv_file: str) -> None:
         """Process data from csv to numpy format and save it in the same folder."""
         data_df = pd.read_csv(self.data_folder / name_csv_file)
         data_df.fillna(method='ffill', inplace=True)
@@ -116,7 +116,7 @@ class LandmarkShardDescriptor(ShardDescriptor):
         (self.data_folder / 'training.csv').unlink()
         self.save_all_md5()
 
-    def get_dataset(self, dataset_type='train') -> LandmarkShardDataset:
+    def get_dataset(self, dataset_type: str = 'train') -> LandmarkShardDataset:
         """Return a shard dataset by type."""
         return LandmarkShardDataset(
             dataset_dir=self.data_folder,

--- a/openfl-tutorials/interactive_api/MXNet_landmarks/workspace/mxnet_adapter.py
+++ b/openfl-tutorials/interactive_api/MXNet_landmarks/workspace/mxnet_adapter.py
@@ -69,7 +69,7 @@ class FrameworkAdapterPlugin(FrameworkAdapterPluginInterface):
             model_params[param_name].set_data(nd.array(tensor_dict.pop(param_name), ctx=device))
 
 
-def _get_optimizer_state(optimizer: Optional[mx.gluon.Trainer]) -> Dict:
+def _get_optimizer_state(optimizer: Optional[mx.gluon.Trainer]) -> Dict[str, np.ndarray]:
     """Return the optimizer state.
 
     Args:
@@ -85,7 +85,8 @@ def _get_optimizer_state(optimizer: Optional[mx.gluon.Trainer]) -> Dict:
 
 
 def _set_optimizer_state(optimizer: Optional[mx.gluon.Trainer],
-                         device: Optional[mx.context], opt_state_dict: Dict) -> None:
+                         device: Optional[mx.context],
+                         opt_state_dict: Dict[str, np.ndarray]) -> None:
     """Set the optimizer state.
 
     Args:

--- a/openfl-tutorials/interactive_api/MXNet_landmarks/workspace/mxnet_adapter.py
+++ b/openfl-tutorials/interactive_api/MXNet_landmarks/workspace/mxnet_adapter.py
@@ -4,7 +4,9 @@
 
 from pickle import dumps
 from pickle import loads
+from typing import Any
 from typing import Dict
+from typing import Optional
 
 import mxnet as mx
 import numpy as np
@@ -22,7 +24,8 @@ class FrameworkAdapterPlugin(FrameworkAdapterPluginInterface):
         """Initialize framework adapter."""
 
     @staticmethod
-    def get_tensor_dict(model, optimizer=None) -> Dict[str, np.ndarray]:
+    def get_tensor_dict(model: Any,
+                        optimizer: Optional[mx.gluon.Trainer] = None) -> Dict[str, np.ndarray]:
         """
         Extract tensor dict from a model and an optimizer.
 
@@ -42,8 +45,9 @@ class FrameworkAdapterPlugin(FrameworkAdapterPluginInterface):
         return state
 
     @staticmethod
-    def set_tensor_dict(model, tensor_dict: Dict[str, np.ndarray],
-                        optimizer=None, device=None) -> None:
+    def set_tensor_dict(model: Any, tensor_dict: Dict[str, np.ndarray],
+                        optimizer: Optional[mx.gluon.Trainer] = None,
+                        device: Optional[mx.context] = None) -> None:
         """
         Set tensor dict from a model and an optimizer.
 
@@ -65,7 +69,7 @@ class FrameworkAdapterPlugin(FrameworkAdapterPluginInterface):
             model_params[param_name].set_data(nd.array(tensor_dict.pop(param_name), ctx=device))
 
 
-def _get_optimizer_state(optimizer):
+def _get_optimizer_state(optimizer: Optional[mx.gluon.Trainer]) -> Dict:
     """Return the optimizer state.
 
     Args:
@@ -80,7 +84,8 @@ def _get_optimizer_state(optimizer):
     return result_states
 
 
-def _set_optimizer_state(optimizer, device, opt_state_dict):
+def _set_optimizer_state(optimizer: Optional[mx.gluon.Trainer],
+                         device: Optional[mx.context], opt_state_dict: Dict) -> None:
     """Set the optimizer state.
 
     Args:

--- a/openfl-tutorials/interactive_api/PyTorch_DogsCats_ViT/envoy/dogs_cats_shard_descriptor.py
+++ b/openfl-tutorials/interactive_api/PyTorch_DogsCats_ViT/envoy/dogs_cats_shard_descriptor.py
@@ -10,7 +10,10 @@ from hashlib import md5
 from logging import getLogger
 from pathlib import Path
 from random import shuffle
+from typing import Dict
+from typing import List
 from typing import Optional
+from typing import Tuple
 from zipfile import ZipFile
 
 import numpy as np
@@ -27,7 +30,8 @@ class DogsCatsShardDataset(ShardDataset):
     """Dogs and cats Shard dataset class."""
 
     def __init__(self, data_type: str, dataset_dir: Path,
-                 rank: int = 1, worldsize: int = 1, enforce_image_hw=None):
+                 rank: int = 1, worldsize: int = 1,
+                 enforce_image_hw: Optional[Tuple[int, int]] = None) -> None:
         """Initialize DogsCatsShardDataset."""
         self.rank = rank
         self.worldsize = worldsize
@@ -46,7 +50,7 @@ class DogsCatsShardDataset(ShardDataset):
         # Shuffling the results dataset after choose half pictures of each class
         shuffle(self.img_names)
 
-    def __getitem__(self, index):
+    def __getitem__(self, index: int) -> Tuple[np.ndarray, np.ndarray]:
         """Return a item by the index."""
         name = self.img_names[index]
         # Reading data
@@ -65,7 +69,7 @@ class DogsCatsShardDataset(ShardDataset):
 
         return img, np.asarray([img_class], dtype=np.uint8)
 
-    def __len__(self):
+    def __len__(self) -> int:
         """Return the len of the dataset."""
         return len(self.img_names)
 
@@ -97,7 +101,7 @@ class DogsCatsShardDescriptor(ShardDescriptor):
 
         assert self._target_shape[0] == '1', 'Target shape Error'
 
-    def download_dataset(self):
+    def download_dataset(self) -> None:
         """Download dataset from Kaggle."""
         if not os.path.exists(self.data_folder):
             os.mkdir(self.data_folder)
@@ -122,7 +126,7 @@ class DogsCatsShardDescriptor(ShardDescriptor):
 
             self.save_all_md5()
 
-    def get_dataset(self, dataset_type='train'):
+    def get_dataset(self, dataset_type: str = 'train') -> DogsCatsShardDataset:
         """Return a shard dataset by type."""
         return DogsCatsShardDataset(
             data_type=dataset_type,
@@ -132,7 +136,7 @@ class DogsCatsShardDescriptor(ShardDescriptor):
             enforce_image_hw=self.enforce_image_hw
         )
 
-    def calc_all_md5(self):
+    def calc_all_md5(self) -> Dict:
         """Calculate hash of all dataset."""
         md5_dict = {}
         for root, _, files in os.walk(self.data_folder):
@@ -149,13 +153,13 @@ class DogsCatsShardDescriptor(ShardDescriptor):
                     md5_dict[rel_file] = md5_calc.hexdigest()
         return md5_dict
 
-    def save_all_md5(self):
+    def save_all_md5(self) -> None:
         """Save dataset hash."""
         all_md5 = self.calc_all_md5()
         with open(os.path.join(self.data_folder, 'dataset.json'), 'w') as f:
             json.dump(all_md5, f)
 
-    def is_dataset_complete(self):
+    def is_dataset_complete(self) -> bool:
         """Check dataset integrity."""
         new_md5 = self.calc_all_md5()
         try:
@@ -167,12 +171,12 @@ class DogsCatsShardDescriptor(ShardDescriptor):
         return new_md5 == old_md5
 
     @property
-    def sample_shape(self):
+    def sample_shape(self) -> List[str]:
         """Return the sample shape info."""
         return self._sample_shape
 
     @property
-    def target_shape(self):
+    def target_shape(self) -> List[str]:
         """Return the target shape info."""
         return self._target_shape
 

--- a/openfl-tutorials/interactive_api/PyTorch_DogsCats_ViT/envoy/dogs_cats_shard_descriptor.py
+++ b/openfl-tutorials/interactive_api/PyTorch_DogsCats_ViT/envoy/dogs_cats_shard_descriptor.py
@@ -136,7 +136,7 @@ class DogsCatsShardDescriptor(ShardDescriptor):
             enforce_image_hw=self.enforce_image_hw
         )
 
-    def calc_all_md5(self) -> Dict:
+    def calc_all_md5(self) -> Dict[str]:
         """Calculate hash of all dataset."""
         md5_dict = {}
         for root, _, files in os.walk(self.data_folder):

--- a/openfl-tutorials/interactive_api/PyTorch_Histology/envoy/histology_shard_descriptor.py
+++ b/openfl-tutorials/interactive_api/PyTorch_Histology/envoy/histology_shard_descriptor.py
@@ -6,6 +6,8 @@
 import logging
 import os
 from pathlib import Path
+from typing import Any
+from typing import List
 from typing import Tuple
 from urllib.request import urlretrieve
 from zipfile import ZipFile
@@ -27,7 +29,8 @@ class HistologyShardDataset(ShardDataset):
 
     TRAIN_SPLIT_RATIO = 0.8
 
-    def __init__(self, data_folder: Path, data_type='train', rank=1, worldsize=1):
+    def __init__(self, data_folder: Path, data_type: str = 'train',
+                 rank: int = 1, worldsize: int = 1) -> None:
         """Histology shard dataset class."""
         self.data_type = data_type
         root = Path(data_folder) / 'Kather_texture_2016_image_tiles_5000'
@@ -56,7 +59,7 @@ class HistologyShardDataset(ShardDataset):
         """Return the len of the shard dataset."""
         return len(self.idx)
 
-    def load_pil(self, path):
+    def load_pil(self, path: Any) -> Image:
         """Load image."""
         with open(path, 'rb') as f:
             img = Image.open(f)
@@ -84,13 +87,13 @@ class HistologyShardDescriptor(ShardDescriptor):
             data_folder: Path = DEFAULT_PATH,
             rank_worldsize: str = '1,1',
             **kwargs
-    ):
+    ) -> None:
         """Initialize HistologyShardDescriptor."""
         self.data_folder = Path.cwd() / data_folder
         self.download_data()
         self.rank, self.worldsize = tuple(int(num) for num in rank_worldsize.split(','))
 
-    def download_data(self):
+    def download_data(self) -> None:
         """Download prepared shard dataset."""
         os.makedirs(self.data_folder, exist_ok=True)
         filepath = self.data_folder / HistologyShardDescriptor.FILENAME
@@ -101,7 +104,7 @@ class HistologyShardDescriptor(ShardDescriptor):
             with ZipFile(filepath, 'r') as f:
                 f.extractall(self.data_folder)
 
-    def get_dataset(self, dataset_type):
+    def get_dataset(self, dataset_type: str) -> HistologyShardDataset:
         """Return a shard dataset by type."""
         return HistologyShardDataset(
             data_folder=self.data_folder,
@@ -111,13 +114,13 @@ class HistologyShardDescriptor(ShardDescriptor):
         )
 
     @property
-    def sample_shape(self):
+    def sample_shape(self) -> List:
         """Return the sample shape info."""
         shape = self.get_dataset('train')[0][0].size
         return [str(dim) for dim in shape]
 
     @property
-    def target_shape(self):
+    def target_shape(self) -> List:
         """Return the target shape info."""
         target = self.get_dataset('train')[0][1]
         shape = np.array([target]).shape

--- a/openfl-tutorials/interactive_api/PyTorch_Histology/envoy/histology_shard_descriptor.py
+++ b/openfl-tutorials/interactive_api/PyTorch_Histology/envoy/histology_shard_descriptor.py
@@ -114,13 +114,13 @@ class HistologyShardDescriptor(ShardDescriptor):
         )
 
     @property
-    def sample_shape(self) -> List:
+    def sample_shape(self) -> List[str]:
         """Return the sample shape info."""
         shape = self.get_dataset('train')[0][0].size
         return [str(dim) for dim in shape]
 
     @property
-    def target_shape(self) -> List:
+    def target_shape(self) -> List[str]:
         """Return the target shape info."""
         target = self.get_dataset('train')[0][1]
         shape = np.array([target]).shape

--- a/openfl-tutorials/interactive_api/PyTorch_Histology_FedCurv/envoy/histology_shard_descriptor.py
+++ b/openfl-tutorials/interactive_api/PyTorch_Histology_FedCurv/envoy/histology_shard_descriptor.py
@@ -6,6 +6,7 @@
 import logging
 import os
 from pathlib import Path
+from typing import List
 from typing import Tuple
 from urllib.request import urlretrieve
 from zipfile import ZipFile
@@ -28,7 +29,8 @@ class HistologyShardDataset(ShardDataset):
 
     TRAIN_SPLIT_RATIO = 0.8
 
-    def __init__(self, data_folder: Path, data_type='train', rank=1, worldsize=1):
+    def __init__(self, data_folder: Path, data_type: str = 'train',
+                 rank: int = 1, worldsize: int = 1) -> None:
         """Histology shard dataset class."""
         self.data_type = data_type
         root = Path(data_folder) / 'Kather_texture_2016_image_tiles_5000'
@@ -64,7 +66,7 @@ class HistologyShardDataset(ShardDataset):
         """Return the len of the shard dataset."""
         return len(self.idx)
 
-    def load_pil(self, path):
+    def load_pil(self, path: Path) -> Image:
         """Load image."""
         with open(path, 'rb') as f:
             img = Image.open(f)
@@ -92,13 +94,13 @@ class HistologyShardDescriptor(ShardDescriptor):
             data_folder: Path = DEFAULT_PATH,
             rank_worldsize: str = '1,1',
             **kwargs
-    ):
+    ) -> None:
         """Initialize HistologyShardDescriptor."""
         self.data_folder = Path.cwd() / data_folder
         self.download_data()
         self.rank, self.worldsize = tuple(int(num) for num in rank_worldsize.split(','))
 
-    def download_data(self):
+    def download_data(self) -> None:
         """Download prepared shard dataset."""
         os.makedirs(self.data_folder, exist_ok=True)
         filepath = self.data_folder / HistologyShardDescriptor.FILENAME
@@ -109,7 +111,7 @@ class HistologyShardDescriptor(ShardDescriptor):
             with ZipFile(filepath, 'r') as f:
                 f.extractall(self.data_folder)
 
-    def get_dataset(self, dataset_type):
+    def get_dataset(self, dataset_type: str) -> HistologyShardDataset:
         """Return a shard dataset by type."""
         return HistologyShardDataset(
             data_folder=self.data_folder,
@@ -119,13 +121,13 @@ class HistologyShardDescriptor(ShardDescriptor):
         )
 
     @property
-    def sample_shape(self):
+    def sample_shape(self) -> List[str]:
         """Return the sample shape info."""
         shape = self.get_dataset('train')[0][0].size
         return [str(dim) for dim in shape]
 
     @property
-    def target_shape(self):
+    def target_shape(self) -> List[str]:
         """Return the target shape info."""
         target = self.get_dataset('train')[0][1]
         shape = np.array([target]).shape

--- a/openfl-tutorials/interactive_api/PyTorch_Huggingface_transformers_SUPERB/envoy/superb_shard_descriptor.py
+++ b/openfl-tutorials/interactive_api/PyTorch_Huggingface_transformers_SUPERB/envoy/superb_shard_descriptor.py
@@ -10,6 +10,7 @@ from typing import Tuple
 
 from datasets import load_dataset
 from datasets import load_metric
+from datasets.arrow_dataset import Dataset
 
 from openfl.interface.interactive_api.shard_descriptor import ShardDataset
 from openfl.interface.interactive_api.shard_descriptor import ShardDescriptor
@@ -18,7 +19,7 @@ from openfl.interface.interactive_api.shard_descriptor import ShardDescriptor
 class SuperbShardDataset(ShardDataset):
     """SUPERB Shard dataset class."""
 
-    def __init__(self, dataset: Tuple[Dict, List], rank: int = 1, worldsize: int = 1) -> None:
+    def __init__(self, dataset: Dataset, rank: int = 1, worldsize: int = 1) -> None:
         """Initialize Superb shard Dataset."""
         self.rank = rank
         self.worldsize = worldsize

--- a/openfl-tutorials/interactive_api/PyTorch_Huggingface_transformers_SUPERB/envoy/superb_shard_descriptor.py
+++ b/openfl-tutorials/interactive_api/PyTorch_Huggingface_transformers_SUPERB/envoy/superb_shard_descriptor.py
@@ -18,7 +18,7 @@ from openfl.interface.interactive_api.shard_descriptor import ShardDescriptor
 class SuperbShardDataset(ShardDataset):
     """SUPERB Shard dataset class."""
 
-    def __init__(self, dataset, rank: int = 1, worldsize: int = 1) -> None:
+    def __init__(self, dataset: Tuple[Dict, List], rank: int = 1, worldsize: int = 1) -> None:
         """Initialize Superb shard Dataset."""
         self.rank = rank
         self.worldsize = worldsize

--- a/openfl-tutorials/interactive_api/PyTorch_Kvasir_UNet/envoy/kvasir_shard_descriptor.py
+++ b/openfl-tutorials/interactive_api/PyTorch_Kvasir_UNet/envoy/kvasir_shard_descriptor.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 from typing import List
 from typing import Optional
+from typing import Tuple
 
 import numpy as np
 from PIL import Image
@@ -20,7 +21,7 @@ class KvasirShardDataset(ShardDataset):
 
     def __init__(self, dataset_dir: Path, rank: int = 1,
                  worldsize: int = 1,
-                 enforce_image_hw: Optional[tuple] = None) -> None:
+                 enforce_image_hw: Optional[Tuple[int, int]] = None) -> None:
         """Initialize KvasirShardDataset."""
         self.rank = rank
         self.worldsize = worldsize
@@ -37,7 +38,7 @@ class KvasirShardDataset(ShardDataset):
         # Sharding
         self.images_names = self.images_names[self.rank - 1::self.worldsize]
 
-    def __getitem__(self, index: int) -> tuple:
+    def __getitem__(self, index: int) -> Tuple[np.ndarray, np.ndarray]:
         """Return a item by the index."""
         name = self.images_names[index]
         # Reading data

--- a/openfl-tutorials/interactive_api/PyTorch_Kvasir_UNet/envoy/kvasir_shard_descriptor.py
+++ b/openfl-tutorials/interactive_api/PyTorch_Kvasir_UNet/envoy/kvasir_shard_descriptor.py
@@ -4,6 +4,8 @@
 
 import os
 from pathlib import Path
+from typing import List
+from typing import Optional
 
 import numpy as np
 from PIL import Image
@@ -16,7 +18,9 @@ from openfl.utilities import validate_file_hash
 class KvasirShardDataset(ShardDataset):
     """Kvasir Shard dataset class."""
 
-    def __init__(self, dataset_dir: Path, rank=1, worldsize=1, enforce_image_hw=None):
+    def __init__(self, dataset_dir: Path, rank: int = 1,
+                 worldsize: int = 1,
+                 enforce_image_hw: Optional[tuple] = None) -> None:
         """Initialize KvasirShardDataset."""
         self.rank = rank
         self.worldsize = worldsize
@@ -33,7 +37,7 @@ class KvasirShardDataset(ShardDataset):
         # Sharding
         self.images_names = self.images_names[self.rank - 1::self.worldsize]
 
-    def __getitem__(self, index):
+    def __getitem__(self, index: int) -> tuple:
         """Return a item by the index."""
         name = self.images_names[index]
         # Reading data
@@ -50,7 +54,7 @@ class KvasirShardDataset(ShardDataset):
 
         return img, mask[:, :, 0].astype(np.uint8)
 
-    def __len__(self):
+    def __len__(self) -> int:
         """Return the len of the dataset."""
         return len(self.images_names)
 
@@ -60,7 +64,7 @@ class KvasirShardDescriptor(ShardDescriptor):
 
     def __init__(self, data_folder: str = 'kvasir_data',
                  rank_worldsize: str = '1,1',
-                 enforce_image_hw: str = None) -> None:
+                 enforce_image_hw: Optional[str] = None) -> None:
         """Initialize KvasirShardDescriptor."""
         super().__init__()
         # Settings for sharding the dataset
@@ -80,7 +84,7 @@ class KvasirShardDescriptor(ShardDescriptor):
         self._sample_shape = [str(dim) for dim in sample.shape]
         self._target_shape = [str(dim) for dim in target.shape]
 
-    def get_dataset(self, dataset_type='train'):
+    def get_dataset(self, dataset_type: str = 'train') -> KvasirShardDataset:
         """Return a shard dataset by type."""
         return KvasirShardDataset(
             dataset_dir=self.data_folder,
@@ -90,7 +94,7 @@ class KvasirShardDescriptor(ShardDescriptor):
         )
 
     @staticmethod
-    def download_data(data_folder):
+    def download_data(data_folder: Path) -> None:
         """Download data."""
         zip_file_path = data_folder / 'kvasir.zip'
         os.makedirs(data_folder, exist_ok=True)
@@ -104,12 +108,12 @@ class KvasirShardDescriptor(ShardDescriptor):
                   f' -d {data_folder.relative_to(Path.cwd())}')
 
     @property
-    def sample_shape(self):
+    def sample_shape(self) -> List[str]:
         """Return the sample shape info."""
         return self._sample_shape
 
     @property
-    def target_shape(self):
+    def target_shape(self) -> List[str]:
         """Return the target shape info."""
         return self._target_shape
 

--- a/openfl-tutorials/interactive_api/PyTorch_Kvasir_UNet/envoy/kvasir_shard_descriptor_with_data_splitter.py
+++ b/openfl-tutorials/interactive_api/PyTorch_Kvasir_UNet/envoy/kvasir_shard_descriptor_with_data_splitter.py
@@ -5,6 +5,8 @@
 
 import os
 from pathlib import Path
+from typing import List
+from typing import Optional
 
 import numpy as np
 from PIL import Image
@@ -18,7 +20,8 @@ from openfl.utilities.data_splitters import RandomNumPyDataSplitter
 class KvasirShardDataset(ShardDataset):
     """Kvasir Shard dataset class."""
 
-    def __init__(self, dataset_dir: Path, rank=1, worldsize=1, enforce_image_hw=None):
+    def __init__(self, dataset_dir: Path, rank: int = 1, worldsize: int = 1,
+                 enforce_image_hw: Optional[str] = None) -> None:
         """Initialize KvasirShardDataset."""
         self.rank = rank
         self.worldsize = worldsize
@@ -38,7 +41,7 @@ class KvasirShardDataset(ShardDataset):
         shard_idx = data_splitter.split(self.images_names, self.worldsize)[self.rank]
         self.images_names = [self.images_names[i] for i in shard_idx]
 
-    def __getitem__(self, index):
+    def __getitem__(self, index: int) -> tuple:
         """Return a item by the index."""
         name = self.images_names[index]
         # Reading data
@@ -55,7 +58,7 @@ class KvasirShardDataset(ShardDataset):
 
         return img, mask[:, :, 0].astype(np.uint8)
 
-    def __len__(self):
+    def __len__(self) -> int:
         """Return the len of the dataset."""
         return len(self.images_names)
 
@@ -65,7 +68,7 @@ class KvasirShardDescriptor(ShardDescriptor):
 
     def __init__(self, data_folder: str = 'kvasir_data',
                  rank_worldsize: str = '1,1',
-                 enforce_image_hw: str = None) -> None:
+                 enforce_image_hw: Optional[str] = None) -> None:
         """Initialize KvasirShardDescriptor."""
         super().__init__()
         # Settings for sharding the dataset
@@ -79,7 +82,7 @@ class KvasirShardDescriptor(ShardDescriptor):
         if enforce_image_hw is not None:
             self.enforce_image_hw = tuple(int(size) for size in enforce_image_hw.split(','))
 
-    def get_dataset(self, dataset_type='train'):
+    def get_dataset(self, dataset_type: str = 'train') -> KvasirShardDataset:
         """Return a shard dataset by type."""
         return KvasirShardDataset(
             dataset_dir=self.data_folder,
@@ -89,7 +92,7 @@ class KvasirShardDescriptor(ShardDescriptor):
         )
 
     @staticmethod
-    def download_data(data_folder):
+    def download_data(data_folder: Path) -> None:
         """Download data."""
         zip_file_path = data_folder / 'kvasir.zip'
         os.makedirs(data_folder, exist_ok=True)
@@ -103,12 +106,12 @@ class KvasirShardDescriptor(ShardDescriptor):
                   f' -d {data_folder.relative_to(Path.cwd())}')
 
     @property
-    def sample_shape(self):
+    def sample_shape(self) -> List[str]:
         """Return the sample shape info."""
         return ['300', '400', '3']
 
     @property
-    def target_shape(self):
+    def target_shape(self) -> List[str]:
         """Return the target shape info."""
         return ['300', '400']
 

--- a/openfl-tutorials/interactive_api/PyTorch_Kvasir_UNet/workspace/layers.py
+++ b/openfl-tutorials/interactive_api/PyTorch_Kvasir_UNet/workspace/layers.py
@@ -5,7 +5,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 
-def soft_dice_loss(output, target):
+def soft_dice_loss(output: torch.tensor, target: torch.tensor) -> torch.tensor:
     """Calculate loss."""
     num = target.size(0)
     m1 = output.view(num, -1)
@@ -16,7 +16,7 @@ def soft_dice_loss(output, target):
     return score
 
 
-def soft_dice_coef(output, target):
+def soft_dice_coef(output: torch.tensor, target: torch.tensor) -> torch.tensor:
     """Calculate soft DICE coefficient."""
     num = target.size(0)
     m1 = output.view(num, -1)
@@ -29,7 +29,7 @@ def soft_dice_coef(output, target):
 class DoubleConv(nn.Module):
     """Pytorch double conv class."""
 
-    def __init__(self, in_ch, out_ch):
+    def __init__(self, in_ch: int, out_ch: int) -> None:
         """Initialize layer."""
         super(DoubleConv, self).__init__()
         self.in_ch = in_ch
@@ -43,7 +43,7 @@ class DoubleConv(nn.Module):
             nn.ReLU(inplace=True),
         )
 
-    def forward(self, x):
+    def forward(self, x: torch.tensor) -> torch.tensor:
         """Do forward pass."""
         x = self.conv(x)
         return x
@@ -52,7 +52,7 @@ class DoubleConv(nn.Module):
 class Down(nn.Module):
     """Pytorch nn module subclass."""
 
-    def __init__(self, in_ch, out_ch):
+    def __init__(self, in_ch: int, out_ch: int) -> None:
         """Initialize layer."""
         super(Down, self).__init__()
         self.mpconv = nn.Sequential(
@@ -60,7 +60,7 @@ class Down(nn.Module):
             DoubleConv(in_ch, out_ch)
         )
 
-    def forward(self, x):
+    def forward(self, x: torch.tensor) -> torch.tensor:
         """Do forward pass."""
         x = self.mpconv(x)
         return x
@@ -69,7 +69,7 @@ class Down(nn.Module):
 class Up(nn.Module):
     """Pytorch nn module subclass."""
 
-    def __init__(self, in_ch, out_ch, bilinear=False):
+    def __init__(self, in_ch: int, out_ch: int, bilinear: bool = False) -> None:
         """Initialize layer."""
         super(Up, self).__init__()
         self.in_ch = in_ch
@@ -84,7 +84,7 @@ class Up(nn.Module):
             self.up = nn.ConvTranspose2d(in_ch, in_ch // 2, 2, stride=2)
         self.conv = DoubleConv(in_ch, out_ch)
 
-    def forward(self, x1, x2):
+    def forward(self, x1: torch.tensor, x2: torch.tensor) -> torch.tensor:
         """Do forward pass."""
         x1 = self.up(x1)
         diff_y = x2.size()[2] - x1.size()[2]

--- a/openfl-tutorials/interactive_api/PyTorch_Lightning_MNIST_GAN/envoy/mnist_shard_descriptor.py
+++ b/openfl-tutorials/interactive_api/PyTorch_Lightning_MNIST_GAN/envoy/mnist_shard_descriptor.py
@@ -20,7 +20,8 @@ logger = logging.getLogger(__name__)
 class MnistShardDataset(ShardDataset):
     """Mnist Shard dataset class."""
 
-    def __init__(self, x, y, data_type, rank: int = 1, worldsize: int = 1) -> None:
+    def __init__(self, x: Any, y: Any, data_type: str,
+                 rank: int = 1, worldsize: int = 1) -> None:
         """Initialize Mnist shard Dataset."""
         self.data_type = data_type
         self.rank = rank

--- a/openfl-tutorials/interactive_api/PyTorch_Lightning_MNIST_GAN/workspace/plugin_for_multiple_optimizers.py
+++ b/openfl-tutorials/interactive_api/PyTorch_Lightning_MNIST_GAN/workspace/plugin_for_multiple_optimizers.py
@@ -3,6 +3,8 @@
 from typing import Any
 from typing import Dict
 
+from numpy import ndarray
+
 from openfl.plugins.frameworks_adapters.pytorch_adapter import _get_optimizer_state
 from openfl.plugins.frameworks_adapters.pytorch_adapter import FrameworkAdapterPlugin
 from openfl.plugins.frameworks_adapters.pytorch_adapter import to_cpu_numpy
@@ -16,7 +18,7 @@ class FrameworkAdapterPluginforMultipleOpt(FrameworkAdapterPlugin):
         super().__init__()
 
     @staticmethod
-    def get_tensor_dict(model: Any, optimizers: Any = None) -> Dict:
+    def get_tensor_dict(model: Any, optimizers: Any = None) -> Dict[str, ndarray]:
         """
         Extract tensor dict from a model and a list of optimizers.
 

--- a/openfl-tutorials/interactive_api/PyTorch_Lightning_MNIST_GAN/workspace/plugin_for_multiple_optimizers.py
+++ b/openfl-tutorials/interactive_api/PyTorch_Lightning_MNIST_GAN/workspace/plugin_for_multiple_optimizers.py
@@ -1,5 +1,7 @@
 """Pytorch Framework Adapter plugin for multiple optimizers."""
 
+from typing import Any
+from typing import Dict
 
 from openfl.plugins.frameworks_adapters.pytorch_adapter import _get_optimizer_state
 from openfl.plugins.frameworks_adapters.pytorch_adapter import FrameworkAdapterPlugin
@@ -9,12 +11,12 @@ from openfl.plugins.frameworks_adapters.pytorch_adapter import to_cpu_numpy
 class FrameworkAdapterPluginforMultipleOpt(FrameworkAdapterPlugin):
     """Framework adapter plugin class for multiple optimizers."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize framework adapter."""
         super().__init__()
 
     @staticmethod
-    def get_tensor_dict(model, optimizers=None):
+    def get_tensor_dict(model: Any, optimizers: Any = None) -> Dict:
         """
         Extract tensor dict from a model and a list of optimizers.
 

--- a/openfl-tutorials/interactive_api/PyTorch_MVTec_PatchSVDD/workspace/data_transf.py
+++ b/openfl-tutorials/interactive_api/PyTorch_MVTec_PatchSVDD/workspace/data_transf.py
@@ -1,12 +1,15 @@
 """Data transform functions."""
 
+from typing import Any
+from typing import Tuple
+
 import numpy as np
 from sklearn.metrics import balanced_accuracy_score
 from sklearn.metrics import precision_recall_curve
 from sklearn.metrics import roc_auc_score
 
 
-def bilinears(images, shape) -> np.ndarray:
+def bilinears(images: np.ndarray, shape: Tuple[int, int]) -> np.ndarray:
     """Generate binlinears."""
     import cv2
     n = images.shape[0]
@@ -17,7 +20,7 @@ def bilinears(images, shape) -> np.ndarray:
     return ret
 
 
-def bal_acc_score(obj, predictions, labels):
+def bal_acc_score(obj: Any, predictions: np.ndarray, labels: np.ndarray) -> float:
     """Calculate balanced accuracy score."""
     precision, recall, thresholds = precision_recall_curve(labels.flatten(), predictions.flatten())
     f1_score = (2 * precision * recall) / (precision + recall)
@@ -27,14 +30,14 @@ def bal_acc_score(obj, predictions, labels):
     return ba_score
 
 
-def detection_auroc(obj, anomaly_scores, labels):
+def detection_auroc(obj: Any, anomaly_scores: np.ndarray, labels: np.ndarray) -> float:
     """Calculate detection auroc."""
     # 1: anomaly 0: normal
     auroc = roc_auc_score(labels, anomaly_scores)
     return auroc
 
 
-def segmentation_auroc(obj, anomaly_maps, masks):
+def segmentation_auroc(obj: Any, anomaly_maps: np.ndarray, masks: np.ndarray) -> float:
     """Calculate segmentation auroc."""
     gt = masks
     gt = gt.astype(np.int32)

--- a/openfl-tutorials/interactive_api/PyTorch_MVTec_PatchSVDD/workspace/inspection.py
+++ b/openfl-tutorials/interactive_api/PyTorch_MVTec_PatchSVDD/workspace/inspection.py
@@ -2,6 +2,10 @@
 
 import os
 import shutil
+from typing import Any
+from typing import Dict
+from typing import Tuple
+from typing import Union
 
 import ngtpy
 import numpy as np
@@ -12,7 +16,8 @@ from sklearn.neighbors import KDTree
 from utils import distribute_scores
 
 
-def search_nn(test_emb, train_emb_flat, nn=1, method='kdt'):
+def search_nn(test_emb: np.ndarray, train_emb_flat: np.ndarray, nn: int = 1,
+              method: str = 'kdt') -> Tuple[np.ndarray, np.ndarray]:
     """Seach nearest neighbors."""
     if method == 'ngt':
         return search_nn_ngt(test_emb, train_emb_flat, nn=nn)
@@ -32,7 +37,8 @@ def search_nn(test_emb, train_emb_flat, nn=1, method='kdt'):
     return l2_maps, closest_inds
 
 
-def search_nn_ngt(test_emb, train_emb_flat, nn=1):
+def search_nn_ngt(test_emb: np.ndarray, train_emb_flat: np.ndarray,
+                  nn: int = 1) -> Tuple[np.ndarray, np.ndarray]:
     """Search nearest neighbors."""
     ntest, i, j, d = test_emb.shape
     closest_inds = np.empty((ntest, i, j, nn), dtype=np.int32)
@@ -59,7 +65,8 @@ def search_nn_ngt(test_emb, train_emb_flat, nn=1):
     return l2_maps, closest_inds
 
 
-def assess_anomaly_maps(obj, anomaly_maps, masks, labels):
+def assess_anomaly_maps(obj: Any, anomaly_maps: np.ndarray, masks: np.ndarray,
+                        labels: np.ndarray) -> Tuple[np.ndarray, np.ndarray, float]:
     """Assess anomaly maps."""
     auroc_seg = segmentation_auroc(obj, anomaly_maps, masks)
 
@@ -69,7 +76,10 @@ def assess_anomaly_maps(obj, anomaly_maps, masks, labels):
     return auroc_det, auroc_seg, ba_score
 
 
-def eval_embeddings_nn_multik(obj, embs64, embs32, masks, labels, nn=1):
+def eval_embeddings_nn_multik(obj: Any, embs64: Tuple[np.ndarray, np.ndarray],
+                              embs32: Tuple[np.ndarray, np.ndarray],
+                              masks: np.ndarray, labels: np.ndarray,
+                              nn: int = 1) -> Dict[str, Union[np.ndarray, float]]:
     """Evaluate embeddings."""
     emb_tr, emb_te = embs64
     maps_64 = measure_emb_nn(emb_te, emb_tr, method='kdt', nn=nn)
@@ -111,7 +121,9 @@ def eval_embeddings_nn_multik(obj, embs64, embs32, masks, labels, nn=1):
     }
 
 
-def eval_embeddings_nn_maps(obj, embs64, embs32, masks, labels, nn=1):
+def eval_embeddings_nn_maps(obj: Any, embs64: Tuple[np.ndarray, np.ndarray],
+                            embs32: Tuple[np.ndarray, np.ndarray],
+                            masks: Any, labels: Any, nn: int = 1) -> np.ndarray:
     """Evaluate embeddings."""
     emb_tr, emb_te = embs64
     maps_64 = measure_emb_nn(emb_te, emb_tr, method='kdt', nn=nn)
@@ -125,7 +137,8 @@ def eval_embeddings_nn_maps(obj, embs64, embs32, masks, labels, nn=1):
     return maps_mult
 
 
-def measure_emb_nn(emb_te, emb_tr, method='kdt', nn=1):
+def measure_emb_nn(emb_te: np.ndarray, emb_tr: np.ndarray,
+                   method: str = 'kdt', nn: int = 1) -> np.ndarray:
     """Measure embeddings."""
     d = emb_tr.shape[-1]
     train_emb_all = emb_tr.reshape(-1, d)

--- a/openfl-tutorials/interactive_api/PyTorch_MVTec_PatchSVDD/workspace/utils.py
+++ b/openfl-tutorials/interactive_api/PyTorch_MVTec_PatchSVDD/workspace/utils.py
@@ -41,7 +41,7 @@ def task(_: Any) -> Iterable:
 class DictionaryConcatDataset(Dataset):
     """Concate dictionaries."""
 
-    def __init__(self, d_of_datasets: Dict) -> None:
+    def __init__(self, d_of_datasets: Dict[str, Dataset]) -> None:
         """Initialize."""
         self.d_of_datasets = d_of_datasets
         lengths = [len(d) for d in d_of_datasets.values()]
@@ -49,7 +49,7 @@ class DictionaryConcatDataset(Dataset):
         self.keys = self.d_of_datasets.keys()
         assert min(lengths) == max(lengths), 'Length of the datasets should be the same'
 
-    def __getitem__(self, idx: int) -> Dict:
+    def __getitem__(self, idx: int) -> Dict[str, Any]:
         """Get item."""
         return {
             key: self.d_of_datasets[key][idx]

--- a/openfl-tutorials/interactive_api/PyTorch_MVTec_PatchSVDD/workspace/utils.py
+++ b/openfl-tutorials/interactive_api/PyTorch_MVTec_PatchSVDD/workspace/utils.py
@@ -2,6 +2,10 @@
 
 import os
 from contextlib import contextmanager
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import Union
 
 import _pickle as p
 import numpy as np
@@ -9,7 +13,8 @@ import torch
 from torch.utils.data import Dataset
 
 
-def to_device(obj, device, non_blocking=False):
+def to_device(obj: Union[torch.Tensor, dict, list, tuple],
+              device: str, non_blocking: bool = False) -> Union[torch.Tensor, dict, list, tuple]:
     """Copy to device."""
     if isinstance(obj, torch.Tensor):
         return obj.to(device, non_blocking=non_blocking)
@@ -28,7 +33,7 @@ def to_device(obj, device, non_blocking=False):
 
 
 @contextmanager
-def task(_):
+def task(_: Any) -> Iterable:
     """Yield."""
     yield
 
@@ -36,7 +41,7 @@ def task(_):
 class DictionaryConcatDataset(Dataset):
     """Concate dictionaries."""
 
-    def __init__(self, d_of_datasets):
+    def __init__(self, d_of_datasets: Dict) -> None:
         """Initialize."""
         self.d_of_datasets = d_of_datasets
         lengths = [len(d) for d in d_of_datasets.values()]
@@ -44,19 +49,19 @@ class DictionaryConcatDataset(Dataset):
         self.keys = self.d_of_datasets.keys()
         assert min(lengths) == max(lengths), 'Length of the datasets should be the same'
 
-    def __getitem__(self, idx):
+    def __getitem__(self, idx: int) -> Dict:
         """Get item."""
         return {
             key: self.d_of_datasets[key][idx]
             for key in self.keys
         }
 
-    def __len__(self):
+    def __len__(self) -> int:
         """Get length."""
         return self._length
 
 
-def crop_chw(image, i, j, k, s=1):
+def crop_chw(image: Any, i: int, j: int, k: int, s: int = 1) -> Any:
     """Crop func."""
     if s == 1:
         h, w = i, j
@@ -66,7 +71,7 @@ def crop_chw(image, i, j, k, s=1):
     return image[:, h: h + k, w: w + k]
 
 
-def cnn_output_size(h, k, s=1, p=0) -> int:
+def cnn_output_size(h: int, k: int, s: int = 1, p: int = 0) -> int:
     """Output size.
 
     :param int H: input_size
@@ -79,39 +84,39 @@ def cnn_output_size(h, k, s=1, p=0) -> int:
     return 1 + (h - k + 2 * p) // s
 
 
-def crop_image_chw(image, coord, k):
+def crop_image_chw(image: Any, coord: int, k: int) -> Any:
     """Crop func."""
     h, w = coord
     return image[:, h: h + k, w: w + k]
 
 
-def load_binary(fpath, encoding='ASCII'):
+def load_binary(fpath: Any, encoding: str = 'ASCII') -> Any:
     """Load binaries."""
     with open(fpath, 'rb') as f:
         return p.load(f, encoding=encoding)
 
 
-def save_binary(d, fpath):
+def save_binary(d: Any, fpath: Any) -> None:
     """Save binary."""
     with open(fpath, 'wb') as f:
         p.dump(d, f)
 
 
-def makedirpath(fpath: str):
+def makedirpath(fpath: str) -> None:
     """Make path."""
     dpath = os.path.dirname(fpath)
     if dpath:
         os.makedirs(dpath, exist_ok=True)
 
 
-def distribute_scores(score_masks, output_shape, k: int, s: int) -> np.ndarray:
+def distribute_scores(score_masks: Any, output_shape: Any, k: int, s: int) -> np.ndarray:
     """Distribute scores."""
     n_all = score_masks.shape[0]
     results = [distribute_score(score_masks[n], output_shape, k, s) for n in range(n_all)]
     return np.asarray(results)
 
 
-def distribute_score(score_mask, output_shape, k: int, s: int) -> np.ndarray:
+def distribute_score(score_mask: Any, output_shape: Any, k: int, s: int) -> np.ndarray:
     """Distribute scores."""
     h, w = output_shape
     mask = np.zeros([h, w], dtype=np.float32)

--- a/openfl-tutorials/interactive_api/PyTorch_Market_Re-ID/envoy/market_shard_descriptor.py
+++ b/openfl-tutorials/interactive_api/PyTorch_Market_Re-ID/envoy/market_shard_descriptor.py
@@ -8,6 +8,7 @@ import re
 import zipfile
 from pathlib import Path
 from typing import List
+from typing import Tuple
 
 import gdown
 from PIL import Image
@@ -21,7 +22,8 @@ logger = logging.getLogger(__name__)
 class MarketShardDataset(ShardDataset):
     """Market shard dataset."""
 
-    def __init__(self, dataset_dir: Path, dataset_type: str, rank=1, worldsize=1):
+    def __init__(self, dataset_dir: Path, dataset_type: str,
+                 rank: int = 1, worldsize: int = 1) -> None:
         """Initialize MarketShardDataset."""
         self.dataset_dir = dataset_dir
         self.dataset_type = dataset_type
@@ -31,11 +33,11 @@ class MarketShardDataset(ShardDataset):
         self.imgs_path = list(dataset_dir.glob('*.jpg'))[self.rank - 1::self.worldsize]
         self.pattern = re.compile(r'([-\d]+)_c(\d)')
 
-    def __len__(self):
+    def __len__(self) -> int:
         """Length of shard."""
         return len(self.imgs_path)
 
-    def __getitem__(self, index: int):
+    def __getitem__(self, index: int) -> Tuple['Image', Tuple[int, int]]:
         """Return an item by the index."""
         img_path = self.imgs_path[index]
         pid, camid = map(int, self.pattern.search(img_path.name).groups())
@@ -80,7 +82,7 @@ class MarketShardDescriptor(ShardDescriptor):
         """Get available shard dataset types."""
         return list(self.path_by_type)
 
-    def get_dataset(self, dataset_type='train'):
+    def get_dataset(self, dataset_type: str = 'train') -> MarketShardDataset:
         """Return a dataset by type."""
         if dataset_type not in self.path_by_type:
             raise Exception(f'Wrong dataset type: {dataset_type}.'
@@ -93,12 +95,12 @@ class MarketShardDescriptor(ShardDescriptor):
         )
 
     @property
-    def sample_shape(self):
+    def sample_shape(self) -> List[str, str, str]:
         """Return the sample shape info."""
         return ['64', '128', '3']
 
     @property
-    def target_shape(self):
+    def target_shape(self) -> List[str]:
         """Return the target shape info."""
         return ['2']
 
@@ -108,7 +110,7 @@ class MarketShardDescriptor(ShardDescriptor):
         return (f'Market dataset, shard number {self.rank} '
                 f'out of {self.worldsize}')
 
-    def download(self):
+    def download(self) -> None:
         """Download Market1501 dataset."""
         logger.info('Download Market1501 dataset.')
         if self.dataset_dir.exists():
@@ -127,7 +129,7 @@ class MarketShardDescriptor(ShardDescriptor):
 
         Path(output).unlink()  # remove zip
 
-    def _check_before_run(self):
+    def _check_before_run(self) -> None:
         """Check if all files are available before going deeper."""
         if not self.dataset_dir.exists():
             raise RuntimeError(f'{self.dataset_dir} does not exist')

--- a/openfl-tutorials/interactive_api/PyTorch_Market_Re-ID/workspace/losses.py
+++ b/openfl-tutorials/interactive_api/PyTorch_Market_Re-ID/workspace/losses.py
@@ -13,14 +13,15 @@ from torch import nn
 class ArcFaceLoss(nn.Module):
     """ArcFace loss."""
 
-    def __init__(self, margin=0.1, scale=16, easy_margin=False):
+    def __init__(self, margin: float = 0.1, scale: float = 16,
+                 easy_margin: bool = False) -> None:
         """Initialize ArcFace loss."""
         super(ArcFaceLoss, self).__init__()
         self.m = margin
         self.s = scale
         self.easy_margin = easy_margin
 
-    def forward(self, pred, target):
+    def forward(self, pred: torch.tensor, target: torch.tensor) -> torch.tensor:
         """Compute forward."""
         # make a one-hot index
         index = pred.data * 0.0  # size = (B, Classnum)
@@ -60,7 +61,7 @@ class TripletLoss(nn.Module):
         distance (str): distance for triplet.
     """
 
-    def __init__(self, margin=0.3, distance='cosine'):
+    def __init__(self, margin: float = 0.3, distance: str = 'cosine') -> None:
         """Initialize Triplet loss."""
         super(TripletLoss, self).__init__()
 
@@ -68,7 +69,7 @@ class TripletLoss(nn.Module):
         self.margin = margin
         self.ranking_loss = nn.MarginRankingLoss(margin=margin)
 
-    def forward(self, inputs, targets):
+    def forward(self, inputs: torch.tensor, targets: torch.tensor) -> torch.tensor:
         """
         Compute forward.
 

--- a/openfl-tutorials/interactive_api/PyTorch_Market_Re-ID/workspace/tools.py
+++ b/openfl-tutorials/interactive_api/PyTorch_Market_Re-ID/workspace/tools.py
@@ -7,6 +7,9 @@ import copy
 import random
 from collections import defaultdict
 from logging import getLogger
+from typing import Any
+from typing import Iterable
+from typing import Tuple
 
 import numpy as np
 import torch
@@ -22,18 +25,18 @@ class AverageMeter:
     Code imported from https://github.com/pytorch/examples/blob/master/imagenet/main.py#L247-L262
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize Average Meter."""
         self.reset()
 
-    def reset(self):
+    def reset(self) -> None:
         """Reset values."""
         self.val = 0
         self.avg = 0
         self.sum = 0
         self.count = 0
 
-    def update(self, val, n=1):
+    def update(self, val: Any, n: Any = 1) -> None:
         """Update values."""
         self.val = val
         self.sum += val * n
@@ -41,7 +44,7 @@ class AverageMeter:
         self.avg = self.sum / self.count
 
 
-def compute_ap_cmc(index, good_index, junk_index):
+def compute_ap_cmc(index: int, good_index: Any, junk_index: Any) -> Tuple:
     """Compute validation metrics."""
     ap = 0
     cmc = np.zeros(len(index))
@@ -65,7 +68,9 @@ def compute_ap_cmc(index, good_index, junk_index):
     return ap, cmc
 
 
-def evaluate(distmat, q_pids, g_pids, q_camids, g_camids):
+def evaluate(distmat: np.ndarray, q_pids: torch.tensor,
+             g_pids: torch.tensor, q_camids: torch.tensor,
+             g_camids: torch.tensor) -> Tuple[np.ndarray, float]:
     """Evaluate model."""
     num_q, num_g = distmat.shape
     index = np.argsort(distmat, axis=1)  # from small to large
@@ -102,7 +107,8 @@ def evaluate(distmat, q_pids, g_pids, q_camids, g_camids):
 
 
 @torch.no_grad()
-def extract_feature(model, dataloader):
+def extract_feature(model: Any,
+                    dataloader: Any) -> Tuple[torch.tensor, torch.tensor, torch.tensor]:
     """Extract features for validation."""
     features, pids, camids = [], [], []
     for imgs, (batch_pids, batch_camids) in dataloader:
@@ -122,7 +128,7 @@ def extract_feature(model, dataloader):
     return features, pids, camids
 
 
-def fliplr(img):
+def fliplr(img: torch.tensor) -> torch.tensor:
     """Flip horizontal."""
     inv_idx = torch.arange(img.size(3) - 1, -1, -1).long()  # N x C x H x W
     img_flip = img.index_select(3, inv_idx)
@@ -142,7 +148,7 @@ class RandomIdentitySampler(Sampler):
     - num_instances (int): number of instances per identity.
     """
 
-    def __init__(self, data_source, num_instances=4):
+    def __init__(self, data_source: tuple, num_instances: int = 4) -> None:
         """Initialize Sampler."""
         self.data_source = data_source
         self.num_instances = num_instances
@@ -161,7 +167,7 @@ class RandomIdentitySampler(Sampler):
                 num = self.num_instances
             self.length += num - num % self.num_instances
 
-    def __iter__(self):
+    def __iter__(self) -> Iterable:
         """Iterate over Sampler."""
         list_container = []
 
@@ -185,6 +191,6 @@ class RandomIdentitySampler(Sampler):
 
         return iter(ret)
 
-    def __len__(self):
+    def __len__(self) -> int:
         """Return number of examples in an epoch."""
         return self.length

--- a/openfl-tutorials/interactive_api/PyTorch_Market_Re-ID/workspace/tools.py
+++ b/openfl-tutorials/interactive_api/PyTorch_Market_Re-ID/workspace/tools.py
@@ -15,6 +15,8 @@ import numpy as np
 import torch
 from torch.utils.data.sampler import Sampler
 
+from openfl.openfl.interface.interactive_api.shard_descriptor import ShardDataset
+
 logger = getLogger(__name__)
 
 
@@ -44,7 +46,7 @@ class AverageMeter:
         self.avg = self.sum / self.count
 
 
-def compute_ap_cmc(index: int, good_index: Any, junk_index: Any) -> Tuple:
+def compute_ap_cmc(index: int, good_index: Any, junk_index: Any) -> Tuple[float, np.ndarray]:
     """Compute validation metrics."""
     ap = 0
     cmc = np.zeros(len(index))
@@ -148,7 +150,7 @@ class RandomIdentitySampler(Sampler):
     - num_instances (int): number of instances per identity.
     """
 
-    def __init__(self, data_source: tuple, num_instances: int = 4) -> None:
+    def __init__(self, data_source: ShardDataset, num_instances: int = 4) -> None:
         """Initialize Sampler."""
         self.data_source = data_source
         self.num_instances = num_instances

--- a/openfl-tutorials/interactive_api/PyTorch_Market_Re-ID/workspace/transforms.py
+++ b/openfl-tutorials/interactive_api/PyTorch_Market_Re-ID/workspace/transforms.py
@@ -2,9 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Image transform tools."""
-
 import math
 import random
+from typing import Any
+from typing import List
+from typing import Optional
+from typing import Union
 
 from PIL import Image
 
@@ -19,14 +22,15 @@ class ResizeRandomCropping:
         p (float): probability of performing this transformation. Default: 0.5.
     """
 
-    def __init__(self, height, width, p=0.5, interpolation=Image.BILINEAR):
+    def __init__(self, height: Union[float, int], width: Union[float, int],
+                 p: float = 0.5, interpolation: Any = Image.BILINEAR) -> None:
         """Initialize cropping."""
         self.height = height
         self.width = width
         self.p = p
         self.interpolation = interpolation
 
-    def __call__(self, img):
+    def __call__(self, img: Image) -> Image:
         """
         Call of cropping.
 
@@ -64,7 +68,9 @@ class RandomErasing:
          mean: Erasing value.
     """
 
-    def __init__(self, probability=0.5, sl=0.02, sh=0.4, r1=0.3, mean=None):
+    def __init__(self, probability: float = 0.5,
+                 sl: float = 0.02, sh: float = 0.4, r1: float = 0.3,
+                 mean: Optional[List] = None) -> None:
         """Initialize Erasing."""
         if not mean:
             mean = [0.4914, 0.4822, 0.4465]
@@ -75,7 +81,7 @@ class RandomErasing:
         self.sh = sh
         self.r1 = r1
 
-    def __call__(self, img):
+    def __call__(self, img: Image) -> Image:
         """Call of Erasing."""
         if random.uniform(0, 1) >= self.probability:
             return img

--- a/openfl-tutorials/interactive_api/PyTorch_Market_Re-ID/workspace/transforms.py
+++ b/openfl-tutorials/interactive_api/PyTorch_Market_Re-ID/workspace/transforms.py
@@ -70,7 +70,7 @@ class RandomErasing:
 
     def __init__(self, probability: float = 0.5,
                  sl: float = 0.02, sh: float = 0.4, r1: float = 0.3,
-                 mean: Optional[List] = None) -> None:
+                 mean: Optional[List[int]] = None) -> None:
         """Initialize Erasing."""
         if not mean:
             mean = [0.4914, 0.4822, 0.4465]

--- a/openfl-tutorials/interactive_api/PyTorch_TinyImageNet/envoy/tinyimagenet_shard_descriptor.py
+++ b/openfl-tutorials/interactive_api/PyTorch_TinyImageNet/envoy/tinyimagenet_shard_descriptor.py
@@ -8,6 +8,7 @@ import logging
 import os
 import shutil
 from pathlib import Path
+from typing import List
 from typing import Tuple
 
 from PIL import Image
@@ -23,7 +24,8 @@ class TinyImageNetDataset(ShardDataset):
 
     NUM_IMAGES_PER_CLASS = 500
 
-    def __init__(self, data_folder: Path, data_type='train', rank=1, worldsize=1):
+    def __init__(self, data_folder: Path, data_type: str = 'train',
+                 rank: int = 1, worldsize: int = 1) -> None:
         """Initialize TinyImageNetDataset."""
         self.data_type = data_type
         self._common_data_folder = data_folder
@@ -77,14 +79,14 @@ class TinyImageNetShardDescriptor(ShardDescriptor):
             data_folder: str = 'data',
             rank_worldsize: str = '1,1',
             **kwargs
-    ):
+    ) -> None:
         """Initialize TinyImageNetShardDescriptor."""
         self.common_data_folder = Path.cwd() / data_folder
         self.data_folder = Path.cwd() / data_folder / 'tiny-imagenet-200'
         self.download_data()
         self.rank, self.worldsize = tuple(int(num) for num in rank_worldsize.split(','))
 
-    def download_data(self):
+    def download_data(self) -> None:
         """Download prepared shard dataset."""
         zip_file_path = self.common_data_folder / 'tiny-imagenet-200.zip'
         os.makedirs(self.common_data_folder, exist_ok=True)
@@ -92,7 +94,7 @@ class TinyImageNetShardDescriptor(ShardDescriptor):
                   f' -O {zip_file_path}')
         shutil.unpack_archive(str(zip_file_path), str(self.common_data_folder))
 
-    def get_dataset(self, dataset_type):
+    def get_dataset(self, dataset_type: str) -> TinyImageNetDataset:
         """Return a shard dataset by type."""
         return TinyImageNetDataset(
             data_folder=self.data_folder,
@@ -102,12 +104,12 @@ class TinyImageNetShardDescriptor(ShardDescriptor):
         )
 
     @property
-    def sample_shape(self):
+    def sample_shape(self) -> List[str, str, str]:
         """Return the sample shape info."""
         return ['64', '64', '3']
 
     @property
-    def target_shape(self):
+    def target_shape(self) -> List[str, str]:
         """Return the target shape info."""
         return ['64', '64']
 

--- a/openfl-tutorials/interactive_api/Tensorflow_MNIST/envoy/mnist_shard_descriptor.py
+++ b/openfl-tutorials/interactive_api/Tensorflow_MNIST/envoy/mnist_shard_descriptor.py
@@ -85,7 +85,7 @@ class MnistShardDescriptor(ShardDescriptor):
         return (f'Mnist dataset, shard number {self.rank}'
                 f' out of {self.worldsize}')
 
-    def download_data(self) -> Tuple[Tuple, Tuple]:
+    def download_data(self) -> Tuple[Tuple[np.ndarray, np.ndarray], Tuple[np.ndarray, np.ndarray]]:
         """Download prepared dataset."""
         local_file_path = 'mnist.npz'
         mnist_url = 'https://storage.googleapis.com/tensorflow/tf-keras-datasets/mnist.npz'

--- a/openfl-tutorials/interactive_api/Tensorflow_MNIST/envoy/mnist_shard_descriptor.py
+++ b/openfl-tutorials/interactive_api/Tensorflow_MNIST/envoy/mnist_shard_descriptor.py
@@ -6,6 +6,7 @@
 import logging
 import os
 from typing import List
+from typing import Tuple
 
 import numpy as np
 import requests
@@ -19,7 +20,8 @@ logger = logging.getLogger(__name__)
 class MnistShardDataset(ShardDataset):
     """Mnist Shard dataset class."""
 
-    def __init__(self, x, y, data_type, rank=1, worldsize=1):
+    def __init__(self, x: np.ndarray, y: np.ndarray,
+                 data_type: str, rank: int = 1, worldsize: int = 1) -> None:
         """Initialize TinyImageNetDataset."""
         self.data_type = data_type
         self.rank = rank
@@ -27,11 +29,11 @@ class MnistShardDataset(ShardDataset):
         self.x = x[self.rank - 1::self.worldsize]
         self.y = y[self.rank - 1::self.worldsize]
 
-    def __getitem__(self, index: int):
+    def __getitem__(self, index: int) -> Tuple[np.ndarray, np.ndarray]:
         """Return an item by the index."""
         return self.x[index], self.y[index]
 
-    def __len__(self):
+    def __len__(self) -> int:
         """Return the len of the dataset."""
         return len(self.x)
 
@@ -43,7 +45,7 @@ class MnistShardDescriptor(ShardDescriptor):
             self,
             rank_worldsize: str = '1, 1',
             **kwargs
-    ):
+    ) -> None:
         """Initialize MnistShardDescriptor."""
         self.rank, self.worldsize = tuple(int(num) for num in rank_worldsize.split(','))
         (x_train, y_train), (x_test, y_test) = self.download_data()
@@ -56,7 +58,7 @@ class MnistShardDescriptor(ShardDescriptor):
         """Get available shard dataset types."""
         return list(self.data_by_type)
 
-    def get_dataset(self, dataset_type='train'):
+    def get_dataset(self, dataset_type: str = 'train') -> MnistShardDataset:
         """Return a shard dataset by type."""
         if dataset_type not in self.data_by_type:
             raise Exception(f'Wrong dataset type: {dataset_type}')
@@ -68,12 +70,12 @@ class MnistShardDescriptor(ShardDescriptor):
         )
 
     @property
-    def sample_shape(self):
+    def sample_shape(self) -> List[str]:
         """Return the sample shape info."""
         return ['784']
 
     @property
-    def target_shape(self):
+    def target_shape(self) -> List[str]:
         """Return the target shape info."""
         return ['1']
 
@@ -83,7 +85,7 @@ class MnistShardDescriptor(ShardDescriptor):
         return (f'Mnist dataset, shard number {self.rank}'
                 f' out of {self.worldsize}')
 
-    def download_data(self):
+    def download_data(self) -> Tuple[Tuple, Tuple]:
         """Download prepared dataset."""
         local_file_path = 'mnist.npz'
         mnist_url = 'https://storage.googleapis.com/tensorflow/tf-keras-datasets/mnist.npz'

--- a/openfl-tutorials/interactive_api/Tensorflow_MNIST/workspace/layers.py
+++ b/openfl-tutorials/interactive_api/Tensorflow_MNIST/workspace/layers.py
@@ -2,11 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Useful keras functions."""
+from typing import Any
+
 from tensorflow import keras
 from tensorflow.keras import layers
 
 
-def create_model():
+def create_model() -> Any:
     """Create keras model."""
     inputs = keras.Input(shape=(784,), name='digits')
     x1 = layers.Dense(64, activation='relu')(inputs)

--- a/openfl-tutorials/interactive_api/Tensorflow_Word_Prediction/envoy/shard_descriptor.py
+++ b/openfl-tutorials/interactive_api/Tensorflow_Word_Prediction/envoy/shard_descriptor.py
@@ -6,6 +6,7 @@ import re
 import urllib.request
 import zipfile
 from pathlib import Path
+from typing import Any
 
 import gdown
 import numpy as np
@@ -18,16 +19,16 @@ from openfl.interface.interactive_api.shard_descriptor import ShardDescriptor
 class NextWordShardDataset(ShardDataset):
     """Shard Dataset for text."""
 
-    def __init__(self, X, y):
+    def __init__(self, X: np.ndarray, y: np.ndarray) -> None:
         """Initialize NextWordShardDataset."""
         self.X = X
         self.y = y
 
-    def __len__(self):
+    def __len__(self) -> int:
         """Count number of sequences."""
         return len(self.X)
 
-    def __getitem__(self, index: int):
+    def __getitem__(self, index: int) -> tuple:
         """Return an item by the index."""
         return self.X[index], self.y[index]
 
@@ -46,7 +47,8 @@ class NextWordShardDescriptor(ShardDescriptor):
         data = self.load_data(dataset_dir)  # list of words
         self.X, self.y = self.get_sequences(data)
 
-    def get_dataset(self, dataset_type='train', train_val_split=0.8):
+    def get_dataset(self, dataset_type: str = 'train',
+                    train_val_split: float = 0.8) -> NextWordShardDataset:
         """Return a dataset by type."""
         train_size = round(len(self.X) * train_val_split)
         if dataset_type == 'train':
@@ -61,13 +63,13 @@ class NextWordShardDescriptor(ShardDescriptor):
         return NextWordShardDataset(X, y)
 
     @property
-    def sample_shape(self):
+    def sample_shape(self) -> list:
         """Return the sample shape info."""
         length, n_gram, vector_size = self.X.shape
         return [str(n_gram), str(vector_size)]  # three vectors
 
     @property
-    def target_shape(self):
+    def target_shape(self) -> list:
         """Return the target shape info."""
         length, vocab_size = self.y.shape
         return [str(vocab_size)]  # row at one-hot matrix with n = vocab_size
@@ -78,14 +80,14 @@ class NextWordShardDescriptor(ShardDescriptor):
         return f'Dataset from {self.title} by {self.author}'
 
     @staticmethod
-    def load_data(path):
+    def load_data(path: Any) -> list:
         """Load text file, return list of words."""
         file = open(path, 'r', encoding='utf8').read()
         data = re.findall(r'[a-z]+', file.lower())
         return data
 
     @staticmethod
-    def get_sequences(data):
+    def get_sequences(data: list) -> tuple:
         """Transform words to sequences, for X transform to vectors as well."""
         # spacy en_core_web_sm vocab_size = 10719, vector_size = 96
         x_seq = []
@@ -112,7 +114,7 @@ class NextWordShardDescriptor(ShardDescriptor):
         return x_seq, y
 
     @staticmethod
-    def download_data(title):
+    def download_data(title: str) -> Path:
         """Download text by title form Github Gist."""
         url = ('https://gist.githubusercontent.com/katerina-merkulova/e351b11c67832034b49652835b'
                '14adb0/raw/5b6667c3a2e1266f3d9125510069d23d8f24dc73/' + title.replace(' ', '_')
@@ -126,7 +128,7 @@ class NextWordShardDescriptor(ShardDescriptor):
         return filepath
 
     @staticmethod
-    def download_vectors():
+    def download_vectors() -> None:
         """Download vectors."""
         if Path('keyed_vectors.feather').exists():
             return None

--- a/openfl-tutorials/interactive_api/Tensorflow_Word_Prediction/envoy/shard_descriptor.py
+++ b/openfl-tutorials/interactive_api/Tensorflow_Word_Prediction/envoy/shard_descriptor.py
@@ -7,6 +7,8 @@ import urllib.request
 import zipfile
 from pathlib import Path
 from typing import Any
+from typing import List
+from typing import Tuple
 
 import gdown
 import numpy as np
@@ -28,7 +30,7 @@ class NextWordShardDataset(ShardDataset):
         """Count number of sequences."""
         return len(self.X)
 
-    def __getitem__(self, index: int) -> tuple:
+    def __getitem__(self, index: int) -> Tuple[np.ndarray, np.ndarray]:
         """Return an item by the index."""
         return self.X[index], self.y[index]
 
@@ -63,13 +65,13 @@ class NextWordShardDescriptor(ShardDescriptor):
         return NextWordShardDataset(X, y)
 
     @property
-    def sample_shape(self) -> list:
+    def sample_shape(self) -> List[str, str]:
         """Return the sample shape info."""
         length, n_gram, vector_size = self.X.shape
         return [str(n_gram), str(vector_size)]  # three vectors
 
     @property
-    def target_shape(self) -> list:
+    def target_shape(self) -> List[str]:
         """Return the target shape info."""
         length, vocab_size = self.y.shape
         return [str(vocab_size)]  # row at one-hot matrix with n = vocab_size
@@ -80,14 +82,14 @@ class NextWordShardDescriptor(ShardDescriptor):
         return f'Dataset from {self.title} by {self.author}'
 
     @staticmethod
-    def load_data(path: Any) -> list:
+    def load_data(path: Any) -> List[str]:
         """Load text file, return list of words."""
         file = open(path, 'r', encoding='utf8').read()
         data = re.findall(r'[a-z]+', file.lower())
         return data
 
     @staticmethod
-    def get_sequences(data: list) -> tuple:
+    def get_sequences(data: List[str]) -> Tuple[np.ndarray, np.ndarray]:
         """Transform words to sequences, for X transform to vectors as well."""
         # spacy en_core_web_sm vocab_size = 10719, vector_size = 96
         x_seq = []

--- a/openfl-tutorials/interactive_api/numpy_linear_regression/workspace/custom_adapter.py
+++ b/openfl-tutorials/interactive_api/numpy_linear_regression/workspace/custom_adapter.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2020-2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 """Custom model numpy adapter."""
+from typing import Any
+from typing import Dict
 
 from openfl.plugins.frameworks_adapters.framework_adapter_interface import (
     FrameworkAdapterPluginInterface,
@@ -11,11 +13,12 @@ class CustomFrameworkAdapter(FrameworkAdapterPluginInterface):
     """Framework adapter plugin class."""
 
     @staticmethod
-    def get_tensor_dict(model, optimizer=None):
+    def get_tensor_dict(model: Any, optimizer: Any = None) -> Dict:
         """Extract tensors from a model."""
         return {'w': model.weights}
 
     @staticmethod
-    def set_tensor_dict(model, tensor_dict, optimizer=None, device='cpu'):
+    def set_tensor_dict(model: Any, tensor_dict: Any,
+                        optimizer: Any = None, device: Any = 'cpu') -> Any:
         """Load tensors to a model."""
         model.weights = tensor_dict['w']

--- a/openfl-tutorials/interactive_api/numpy_linear_regression/workspace/custom_adapter.py
+++ b/openfl-tutorials/interactive_api/numpy_linear_regression/workspace/custom_adapter.py
@@ -4,6 +4,8 @@
 from typing import Any
 from typing import Dict
 
+from numpy import ndarray
+
 from openfl.plugins.frameworks_adapters.framework_adapter_interface import (
     FrameworkAdapterPluginInterface,
 )
@@ -13,12 +15,12 @@ class CustomFrameworkAdapter(FrameworkAdapterPluginInterface):
     """Framework adapter plugin class."""
 
     @staticmethod
-    def get_tensor_dict(model: Any, optimizer: Any = None) -> Dict:
+    def get_tensor_dict(model: Any, optimizer: Any = None) -> Dict[str, ndarray]:
         """Extract tensors from a model."""
         return {'w': model.weights}
 
     @staticmethod
     def set_tensor_dict(model: Any, tensor_dict: Any,
-                        optimizer: Any = None, device: Any = 'cpu') -> Any:
+                        optimizer: Any = None, device: Any = 'cpu') -> None:
         """Load tensors to a model."""
         model.weights = tensor_dict['w']


### PR DESCRIPTION
Preparations to add [Flake8-annotations](https://pypi.org/project/flake8-annotations/) plugin (**optional changes**).

This fix is only for errors in **openfl-tutorials** folder.

It is assumed that the next flake8-annotations errors will be ignored:

ANN002 - Missing type annotation for `*args`
ANN003 - Missing type annotation for `**kwargs`
ANN101 - Missing type annotation for `self` in method
ANN102 - Missing type annotation for `cls` in classmethod