### PR TITLE
Flake8-annotations: fix errors in federated, part 1(4)

### DIFF
--- a/openfl/federated/data/__init__.py
+++ b/openfl/federated/data/__init__.py
@@ -23,5 +23,5 @@ if pkgutil.find_loader('tensorflow'):
 if pkgutil.find_loader('torch'):
     from .loader_pt import PyTorchDataLoader  # NOQA
     from .federated_data import FederatedDataSet  # NOQA
-if pkgutil.find_loader('torch') and pkgutil.find_loader('tensorflow') and pkgutil.find_loader('fastestimator'):  # NOQA
+if pkgutil.find_loader('torch') and pkgutil.find_loader('tensorflow'):
     from .loader_fe import FastEstimatorDataLoader  # NOQA

--- a/openfl/federated/data/__init__.py
+++ b/openfl/federated/data/__init__.py
@@ -23,5 +23,5 @@ if pkgutil.find_loader('tensorflow'):
 if pkgutil.find_loader('torch'):
     from .loader_pt import PyTorchDataLoader  # NOQA
     from .federated_data import FederatedDataSet  # NOQA
-if pkgutil.find_loader('torch') and pkgutil.find_loader('tensorflow'):
+if pkgutil.find_loader('torch') and pkgutil.find_loader('tensorflow') and pkgutil.find_loader('fastestimator'):  # NOQA
     from .loader_fe import FastEstimatorDataLoader  # NOQA

--- a/openfl/federated/data/federated_data.py
+++ b/openfl/federated/data/federated_data.py
@@ -3,6 +3,10 @@
 
 """FederatedDataset module."""
 
+from typing import List
+from typing import Optional
+from typing import Union
+
 import numpy as np
 
 from openfl.utilities.data_splitters import EqualNumPyDataSplitter
@@ -34,8 +38,11 @@ class FederatedDataSet(PyTorchDataLoader):
     train_splitter: NumPyDataSplitter
     valid_splitter: NumPyDataSplitter
 
-    def __init__(self, X_train, y_train, X_valid, y_valid,
-                 batch_size=1, num_classes=None, train_splitter=None, valid_splitter=None):
+    def __init__(self, X_train: np.ndarray, y_train: np.ndarray,
+                 X_valid: np.ndarray, y_valid: np.ndarray,
+                 batch_size: int = 1, num_classes: Optional[int] = None,
+                 train_splitter: Optional[NumPyDataSplitter] = None,
+                 valid_splitter: Optional[NumPyDataSplitter] = None) -> None:
         """
         Initialize.
 
@@ -74,7 +81,8 @@ class FederatedDataSet(PyTorchDataLoader):
         self.valid_splitter = self._get_splitter_or_default(valid_splitter)
 
     @staticmethod
-    def _get_splitter_or_default(value):
+    def _get_splitter_or_default(value: Optional[NumPyDataSplitter]
+                                 ) -> Union[NumPyDataSplitter, EqualNumPyDataSplitter]:
         if value is None:
             return EqualNumPyDataSplitter()
         if isinstance(value, NumPyDataSplitter):
@@ -82,7 +90,7 @@ class FederatedDataSet(PyTorchDataLoader):
         else:
             raise NotImplementedError(f'Data splitter {value} is not supported')
 
-    def split(self, num_collaborators):
+    def split(self, num_collaborators: int) -> List['FederatedDataSet']:
         """Create a Federated Dataset for each of the collaborators.
 
         Args:

--- a/openfl/federated/data/federated_data.py
+++ b/openfl/federated/data/federated_data.py
@@ -81,8 +81,10 @@ class FederatedDataSet(PyTorchDataLoader):
         self.valid_splitter = self._get_splitter_or_default(valid_splitter)
 
     @staticmethod
-    def _get_splitter_or_default(value: Optional[NumPyDataSplitter]
-                                 ) -> Union[NumPyDataSplitter, EqualNumPyDataSplitter]:
+    def _get_splitter_or_default(
+        value: Optional[NumPyDataSplitter]
+    ) -> Union[NumPyDataSplitter, EqualNumPyDataSplitter]:
+
         if value is None:
             return EqualNumPyDataSplitter()
         if isinstance(value, NumPyDataSplitter):

--- a/openfl/federated/data/loader.py
+++ b/openfl/federated/data/loader.py
@@ -3,11 +3,13 @@
 
 """DataLoader module."""
 
+from typing import NoReturn
+
 
 class DataLoader:
     """Federated Learning Data Loader Class."""
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         """
         Instantiate the data object.
 
@@ -16,7 +18,7 @@ class DataLoader:
         """
         pass
 
-    def get_feature_shape(self):
+    def get_feature_shape(self) -> NoReturn:
         """
         Get the shape of an example feature array.
 
@@ -25,7 +27,7 @@ class DataLoader:
         """
         raise NotImplementedError
 
-    def get_train_loader(self, **kwargs):
+    def get_train_loader(self, **kwargs) -> NoReturn:
         """
         Get training data loader.
 
@@ -34,7 +36,7 @@ class DataLoader:
         """
         raise NotImplementedError
 
-    def get_valid_loader(self):
+    def get_valid_loader(self) -> NoReturn:
         """
         Get validation data loader.
 
@@ -43,7 +45,7 @@ class DataLoader:
         """
         raise NotImplementedError
 
-    def get_infer_loader(self):
+    def get_infer_loader(self) -> NoReturn:
         """
         Get inferencing data loader.
 
@@ -53,7 +55,7 @@ class DataLoader:
         """
         return NotImplementedError
 
-    def get_train_data_size(self):
+    def get_train_data_size(self) -> NoReturn:
         """
         Get total number of training samples.
 
@@ -62,7 +64,7 @@ class DataLoader:
         """
         raise NotImplementedError
 
-    def get_valid_data_size(self):
+    def get_valid_data_size(self) -> NoReturn:
         """
         Get total number of validation samples.
 

--- a/openfl/federated/data/loader_fe.py
+++ b/openfl/federated/data/loader_fe.py
@@ -5,19 +5,18 @@
 
 from typing import Tuple
 
-from fastestimator import Pipeline
-
 from .loader import DataLoader
 
 
 class FastEstimatorDataLoader(DataLoader):
     """Federation Data Loader for FastEstimator."""
 
-    def __init__(self, pipeline: Pipeline, **kwargs) -> None:
+    def __init__(self, pipeline: 'Pipeline', **kwargs) -> None:  # NOQA
         """
         Instantiate the data object.
 
         Args:
+            pipeline: Pipeline from fastestimator
             batch_size: Size of batches used for all data loaders
             kwargs: consumes all un-used kwargs
 

--- a/openfl/federated/data/loader_fe.py
+++ b/openfl/federated/data/loader_fe.py
@@ -3,13 +3,17 @@
 
 """FastEsitmatorDataLoader module."""
 
+from typing import Tuple
+
+from fastestimator import Pipeline
+
 from .loader import DataLoader
 
 
 class FastEstimatorDataLoader(DataLoader):
     """Federation Data Loader for FastEstimator."""
 
-    def __init__(self, pipeline, **kwargs):
+    def __init__(self, pipeline: Pipeline, **kwargs) -> None:
         """
         Instantiate the data object.
 
@@ -32,7 +36,7 @@ class FastEstimatorDataLoader(DataLoader):
         # (self, batch_size, **kwargs), should call this __init__ and then
         # define self.X_train, self.y_train, self.X_valid, and self.y_valid
 
-    def get_train_data_size(self):
+    def get_train_data_size(self) -> int:
         """
         Get total number of training samples.
 
@@ -41,7 +45,7 @@ class FastEstimatorDataLoader(DataLoader):
         """
         return len(self.pipeline.data['train'])
 
-    def get_valid_data_size(self):
+    def get_valid_data_size(self) -> int:
         """
         Get total number of validation samples.
 
@@ -50,7 +54,7 @@ class FastEstimatorDataLoader(DataLoader):
         """
         return len(self.pipeline.data['test'])
 
-    def get_feature_shape(self):
+    def get_feature_shape(self) -> Tuple[int, ...]:
         """
         Get feature shape.
 

--- a/openfl/federated/data/loader_keras.py
+++ b/openfl/federated/data/loader_keras.py
@@ -3,6 +3,10 @@
 
 """KerasDataLoader module."""
 
+from typing import Iterator
+from typing import Optional
+from typing import Tuple
+
 import numpy as np
 
 from .loader import DataLoader
@@ -11,7 +15,7 @@ from .loader import DataLoader
 class KerasDataLoader(DataLoader):
     """Federation Data Loader for TensorFlow Models."""
 
-    def __init__(self, batch_size, **kwargs):
+    def __init__(self, batch_size: int, **kwargs) -> None:
         """
         Instantiate the data object.
 
@@ -32,7 +36,7 @@ class KerasDataLoader(DataLoader):
         # (self, batch_size, **kwargs), should call this __init__ and then
         # define self.X_train, self.y_train, self.X_valid, and self.y_valid
 
-    def get_feature_shape(self):
+    def get_feature_shape(self) -> Tuple[int, ...]:
         """Get the shape of an example feature array.
 
         Returns:
@@ -40,7 +44,8 @@ class KerasDataLoader(DataLoader):
         """
         return self.X_train[0].shape
 
-    def get_train_loader(self, batch_size=None, num_batches=None):
+    def get_train_loader(self, batch_size: Optional[int] = None, num_batches: Optional[int] = None
+                         ) -> Iterator[Tuple[np.ndarray, np.ndarray]]:
         """
         Get training data loader.
 
@@ -51,7 +56,8 @@ class KerasDataLoader(DataLoader):
         return self._get_batch_generator(X=self.X_train, y=self.y_train, batch_size=batch_size,
                                          num_batches=num_batches)
 
-    def get_valid_loader(self, batch_size=None):
+    def get_valid_loader(self, batch_size: Optional[int] = None
+                         ) -> Iterator[Tuple[np.ndarray, np.ndarray]]:
         """
         Get validation data loader.
 
@@ -60,7 +66,7 @@ class KerasDataLoader(DataLoader):
         """
         return self._get_batch_generator(X=self.X_valid, y=self.y_valid, batch_size=batch_size)
 
-    def get_train_data_size(self):
+    def get_train_data_size(self) -> int:
         """
         Get total number of training samples.
 
@@ -69,7 +75,7 @@ class KerasDataLoader(DataLoader):
         """
         return self.X_train.shape[0]
 
-    def get_valid_data_size(self):
+    def get_valid_data_size(self) -> int:
         """
         Get total number of validation samples.
 
@@ -79,7 +85,9 @@ class KerasDataLoader(DataLoader):
         return self.X_valid.shape[0]
 
     @staticmethod
-    def _batch_generator(X, y, idxs, batch_size, num_batches):
+    def _batch_generator(X: np.ndarray, y: np.ndarray,
+                         idxs: np.ndarray, batch_size: int, num_batches: int
+                         ) -> Iterator[Tuple[np.ndarray, np.ndarray]]:
         """
         Generate batch of data.
 
@@ -99,7 +107,9 @@ class KerasDataLoader(DataLoader):
             b = a + batch_size
             yield X[idxs[a:b]], y[idxs[a:b]]
 
-    def _get_batch_generator(self, X, y, batch_size, num_batches=None):
+    def _get_batch_generator(self, X: np.ndarray, y: np.ndarray,
+                             batch_size: Optional[int], num_batches: Optional[int] = None
+                             ) -> Iterator[Tuple[np.ndarray, np.ndarray]]:
         """
         Return the dataset generator.
 

--- a/openfl/federated/data/loader_pt.py
+++ b/openfl/federated/data/loader_pt.py
@@ -4,6 +4,10 @@
 """PyTorchDataLoader module."""
 
 from math import ceil
+from typing import Iterator
+from typing import Optional
+from typing import Tuple
+
 
 import numpy as np
 
@@ -13,7 +17,7 @@ from .loader import DataLoader
 class PyTorchDataLoader(DataLoader):
     """Federation Data Loader for TensorFlow Models."""
 
-    def __init__(self, batch_size, random_seed=None, **kwargs):
+    def __init__(self, batch_size: int, random_seed: Optional[int] = None, **kwargs) -> None:
         """
         Instantiate the data object.
 
@@ -35,7 +39,7 @@ class PyTorchDataLoader(DataLoader):
         # (self, batch_size, **kwargs), should call this __init__ and then
         # define self.X_train, self.y_train, self.X_valid, and self.y_valid
 
-    def get_feature_shape(self):
+    def get_feature_shape(self) -> Tuple[int, ...]:
         """Get the shape of an example feature array.
 
         Returns:
@@ -43,7 +47,8 @@ class PyTorchDataLoader(DataLoader):
         """
         return self.X_train[0].shape
 
-    def get_train_loader(self, batch_size=None, num_batches=None):
+    def get_train_loader(self, batch_size: Optional[int] = None, num_batches: Optional[int] = None
+                         ) -> Iterator[Tuple[np.ndarray, np.ndarray]]:
         """
         Get training data loader.
 
@@ -54,7 +59,8 @@ class PyTorchDataLoader(DataLoader):
         return self._get_batch_generator(
             X=self.X_train, y=self.y_train, batch_size=batch_size, num_batches=num_batches)
 
-    def get_valid_loader(self, batch_size=None):
+    def get_valid_loader(self, batch_size: Optional[int] = None
+                         ) -> Iterator[Tuple[np.ndarray, np.ndarray]]:
         """
         Get validation data loader.
 
@@ -63,7 +69,7 @@ class PyTorchDataLoader(DataLoader):
         """
         return self._get_batch_generator(X=self.X_valid, y=self.y_valid, batch_size=batch_size)
 
-    def get_train_data_size(self):
+    def get_train_data_size(self) -> int:
         """
         Get total number of training samples.
 
@@ -72,7 +78,7 @@ class PyTorchDataLoader(DataLoader):
         """
         return self.X_train.shape[0]
 
-    def get_valid_data_size(self):
+    def get_valid_data_size(self) -> int:
         """
         Get total number of validation samples.
 
@@ -82,7 +88,9 @@ class PyTorchDataLoader(DataLoader):
         return self.X_valid.shape[0]
 
     @staticmethod
-    def _batch_generator(X, y, idxs, batch_size, num_batches):
+    def _batch_generator(X: np.ndarray, y: np.ndarray, idxs: np.ndarray,
+                         batch_size: int, num_batches: int
+                         ) -> Iterator[Tuple[np.ndarray, np.ndarray]]:
         """
         Generate batch of data.
 
@@ -102,7 +110,9 @@ class PyTorchDataLoader(DataLoader):
             b = a + batch_size
             yield X[idxs[a:b]], y[idxs[a:b]]
 
-    def _get_batch_generator(self, X, y, batch_size, num_batches=None):
+    def _get_batch_generator(self, X: np.ndarray, y: np.ndarray, batch_size: int,
+                             num_batches: Optional[int] = None
+                             ) -> Iterator[Tuple[np.ndarray, np.ndarray]]:
         """
         Return the dataset generator.
 

--- a/openfl/federated/data/loader_pt.py
+++ b/openfl/federated/data/loader_pt.py
@@ -47,8 +47,9 @@ class PyTorchDataLoader(DataLoader):
         """
         return self.X_train[0].shape
 
-    def get_train_loader(self, batch_size: Optional[int] = None, num_batches: Optional[int] = None
-                         ) -> Iterator[Tuple[np.ndarray, np.ndarray]]:
+    def get_train_loader(
+        self, batch_size: Optional[int] = None, num_batches: Optional[int] = None
+    ) -> Iterator[Tuple[np.ndarray, np.ndarray]]:
         """
         Get training data loader.
 

--- a/openfl/federated/data/loader_tf.py
+++ b/openfl/federated/data/loader_tf.py
@@ -3,6 +3,10 @@
 
 """TensorflowDataLoader module."""
 
+from typing import Iterator
+from typing import Optional
+from typing import Tuple
+
 import numpy as np
 
 from .loader import DataLoader
@@ -11,7 +15,7 @@ from .loader import DataLoader
 class TensorFlowDataLoader(DataLoader):
     """Federation Data Loader for TensorFlow Models."""
 
-    def __init__(self, batch_size, **kwargs):
+    def __init__(self, batch_size: int, **kwargs) -> None:
         """
         Instantiate the data object.
 
@@ -32,7 +36,7 @@ class TensorFlowDataLoader(DataLoader):
         # (self, batch_size, **kwargs), should call this __init__ and then
         # define self.X_train, self.y_train, self.X_valid, and self.y_valid
 
-    def get_feature_shape(self):
+    def get_feature_shape(self) -> Tuple[int, ...]:
         """
         Get the shape of an example feature array.
 
@@ -41,7 +45,8 @@ class TensorFlowDataLoader(DataLoader):
         """
         return self.X_train[0].shape
 
-    def get_train_loader(self, batch_size=None):
+    def get_train_loader(self, batch_size: Optional[int] = None
+                         ) -> Iterator[Tuple[np.ndarray, np.ndarray]]:
         """
         Get training data loader.
 
@@ -51,7 +56,8 @@ class TensorFlowDataLoader(DataLoader):
         """
         return self._get_batch_generator(X=self.X_train, y=self.y_train, batch_size=batch_size)
 
-    def get_valid_loader(self, batch_size=None):
+    def get_valid_loader(self, batch_size: Optional[int] = None
+                         ) -> Iterator[Tuple[np.ndarray, np.ndarray]]:
         """
         Get validation data loader.
 
@@ -60,7 +66,7 @@ class TensorFlowDataLoader(DataLoader):
         """
         return self._get_batch_generator(X=self.X_valid, y=self.y_valid, batch_size=batch_size)
 
-    def get_train_data_size(self):
+    def get_train_data_size(self) -> Tuple[int, ...]:
         """
         Get total number of training samples.
 
@@ -69,7 +75,7 @@ class TensorFlowDataLoader(DataLoader):
         """
         return self.X_train.shape[0]
 
-    def get_valid_data_size(self):
+    def get_valid_data_size(self) -> Tuple[int, ...]:
         """
         Get total number of validation samples.
 
@@ -79,7 +85,9 @@ class TensorFlowDataLoader(DataLoader):
         return self.X_valid.shape[0]
 
     @staticmethod
-    def _batch_generator(X, y, idxs, batch_size, num_batches):
+    def _batch_generator(X: np.ndarray, y: np.ndarray,
+                         idxs: np.ndarray, batch_size: int,
+                         num_batches: int) -> Iterator[Tuple[np.ndarray, np.ndarray]]:
         """
         Generate batch of data.
 
@@ -99,7 +107,8 @@ class TensorFlowDataLoader(DataLoader):
             b = a + batch_size
             yield X[idxs[a:b]], y[idxs[a:b]]
 
-    def _get_batch_generator(self, X, y, batch_size):
+    def _get_batch_generator(self, X: np.ndarray, y: np.ndarray, batch_size: int
+                             ) -> Iterator[Tuple[np.ndarray, np.ndarray]]:
         """
         Return the dataset generator.
 


### PR DESCRIPTION
Preparations to add [Flake8-annotations](https://pypi.org/project/flake8-annotations/) plugin.

This fix is only for errors in **federated/data** folder.

It is assumed that the next flake8-annotations errors will be ignored:

ANN002 - Missing type annotation for `*args`
ANN003 - Missing type annotation for `**kwargs
`
ANN101 - Missing type annotation for `self` in method
ANN102 - Missing type annotation for `cls` in classmethod