### PR TITLE
Github Actions Basic CI

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -40,7 +40,7 @@ jobs:
         pytest
     - name: Test TaskRunner API
       run: |
-        python tests/github/test_hello_federation.sh
+        bash tests/github/test_hello_federation.sh
     - name: Interactive API - pytorch_kvasir_unet
       run: |
         ./tests/github/interactive_api_director/experiments/pytorch_kvasir_unet/run.sh

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -40,7 +40,7 @@ jobs:
         pytest
     - name: Test TaskRunner API
       run: |
-        bash tests/github/test_hello_federation.sh keras_cnn_mnist aggregator col1 col2 --rounds-to-train 3
+        bash tests/github/test_hello_federation.sh keras_cnn_mnist aggregator col1 col2 $(hostname --all-fqdns | awk '{print $1}') --rounds-to-train 3
     - name: Interactive API - pytorch_kvasir_unet
       run: |
         cd tests/github/interactive_api_director/experiments/pytorch_kvasir_unet

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -43,6 +43,7 @@ jobs:
         bash tests/github/test_hello_federation.sh keras_cnn_mnist aggregator col1 col2 $(hostname --all-fqdns | awk '{print $1}') --rounds-to-train 3
     - name: Interactive API - pytorch_kvasir_unet
       run: |
+        python setup.py build_grpc
         cd tests/github/interactive_api_director/experiments/pytorch_kvasir_unet
         ./run.sh
     - name: Interactive API - tensorflow_mnist

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,44 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python application
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.8"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pytest
+    - name: Test interactive API
+      run: |
+        python tests/github/interactive_api_director/exp_1.py
+    - name: Test TaskRunner API
+        python tests/github/test_hello_federation.sh

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -40,7 +40,7 @@ jobs:
         pytest
     - name: Test TaskRunner API
       run: |
-        bash tests/github/test_hello_federation.sh keras_cnn_mnist --rounds-to-train 3
+        bash tests/github/test_hello_federation.sh keras_cnn_mnist aggregator col1 col2 --rounds-to-train 3
     - name: Interactive API - pytorch_kvasir_unet
       run: |
         cd tests/github/interactive_api_director/experiments/pytorch_kvasir_unet

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -38,9 +38,12 @@ jobs:
     - name: Test with pytest
       run: |
         pytest
-    - name: Test interactive API
-      run: |
-        python tests/github/interactive_api_director/exp_1.py
     - name: Test TaskRunner API
       run: |
         python tests/github/test_hello_federation.sh
+    - name: Interactive API - pytorch_kvasir_unet
+      run: |
+        ./tests/github/interactive_api_director/experiments/pytorch_kvasir_unet/run.sh
+    - name: Interactive API - tensorflow_mnist
+      run: |
+        ./tests/github/interactive_api_director/experiments/tensorflow_mnist/run.sh  

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -3,7 +3,11 @@
 
 name: Continuous Integration
 
-on: [push]
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
 
 permissions:
   contents: read
@@ -37,4 +41,5 @@ jobs:
       run: |
         python tests/github/interactive_api_director/exp_1.py
     - name: Test TaskRunner API
+      run: |
         python tests/github/test_hello_federation.sh

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -40,7 +40,7 @@ jobs:
         pytest
     - name: Test TaskRunner API
       run: |
-        bash tests/github/test_hello_federation.sh
+        bash tests/github/test_hello_federation.sh --rounds-to-train 3
     - name: Interactive API - pytorch_kvasir_unet
       run: |
         cd tests/github/interactive_api_director/experiments/pytorch_kvasir_unet

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -43,7 +43,9 @@ jobs:
         bash tests/github/test_hello_federation.sh
     - name: Interactive API - pytorch_kvasir_unet
       run: |
-        ./tests/github/interactive_api_director/experiments/pytorch_kvasir_unet/run.sh
+        cd tests/github/interactive_api_director/experiments/pytorch_kvasir_unet
+        ./run.sh
     - name: Interactive API - tensorflow_mnist
       run: |
-        ./tests/github/interactive_api_director/experiments/tensorflow_mnist/run.sh  
+        cd tests/github/interactive_api_director/experiments/pytorch_kvasir_unet
+        ./run.sh  

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -38,15 +38,17 @@ jobs:
     - name: Test with pytest
       run: |
         pytest
-    - name: Test TaskRunner API
+    - name: Interactive API - tensorflow_mnist
       run: |
-        bash tests/github/test_hello_federation.sh keras_cnn_mnist aggregator col1 col2 $(hostname --all-fqdns | awk '{print $1}') --rounds-to-train 3
+        python setup.py build_grpc
+        cd tests/github/interactive_api_director/experiments/tensorflow_mnist
+        ./run.sh 
     - name: Interactive API - pytorch_kvasir_unet
       run: |
         python setup.py build_grpc
         cd tests/github/interactive_api_director/experiments/pytorch_kvasir_unet
         ./run.sh
-    - name: Interactive API - tensorflow_mnist
+    - name: Test TaskRunner API
       run: |
-        cd tests/github/interactive_api_director/experiments/pytorch_kvasir_unet
-        ./run.sh  
+        bash tests/github/test_hello_federation.sh keras_cnn_mnist aggregator col1 col2 $(hostname --all-fqdns | awk '{print $1}') --rounds-to-train 3
+

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,13 +1,9 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python application
+name: Continuous Integration
 
-on:
-  push:
-    branches: [ develop ]
-  pull_request:
-    branches: [ develop ]
+on: [push]
 
 permissions:
   contents: read

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -40,7 +40,7 @@ jobs:
         pytest
     - name: Test TaskRunner API
       run: |
-        bash tests/github/test_hello_federation.sh --rounds-to-train 3
+        bash tests/github/test_hello_federation.sh keras_cnn_mnist --rounds-to-train 3
     - name: Interactive API - pytorch_kvasir_unet
       run: |
         cd tests/github/interactive_api_director/experiments/pytorch_kvasir_unet

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -46,6 +46,7 @@ jobs:
     - name: Interactive API - pytorch_kvasir_unet
       run: |
         python setup.py build_grpc
+        pip install torch torchvision
         cd tests/github/interactive_api_director/experiments/pytorch_kvasir_unet
         ./run.sh
     - name: Test TaskRunner API

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -27,6 +27,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest
+        pip install -r requirements-test.txt
         pip install .
     - name: Lint with flake8
       run: |

--- a/tests/github/interactive_api_director/experiments/tensorflow_mnist/envoy/sd_requirements.txt
+++ b/tests/github/interactive_api_director/experiments/tensorflow_mnist/envoy/sd_requirements.txt
@@ -1,0 +1,1 @@
+tensorflow


### PR DESCRIPTION
This PR add an initial CI pipeline for:
- OpenFL installation with Python 3.8
- Flake8 integration
- Pytest for OpenFL unit tests
- Interactive API end-to-end tests:
  - Pytorch Kvasir example
  - Tensorflow MNIST example
- TaskRunner API end-to-end test for Keras CNN MNIST

Future PR's will address:
- Installation for all supported versions of Python
- Breaking up CI pipeline into multiple stages for external contributor interpretability 