### PR TITLE
Fix flatten function for nested objects

### DIFF
--- a/openfl/native/native.py
+++ b/openfl/native/native.py
@@ -51,6 +51,7 @@ def setup_plan(log_level='CRITICAL'):
 
     return plan
 
+
 def flatten(config, return_complete=False):
     """Flatten nested config."""
     flattened_config = flatten_json.flatten(config, '.')
@@ -103,7 +104,7 @@ def update_plan(override_config, plan=None, resolve=True):
             # TODO: We probably need to validate the new key somehow
             logger.warning(f'Did not find {key} in config. Make sure it should exist. Creating...')
         if type(val) == list:
-            for idx,v in enumerate(val):
+            for idx, v in enumerate(val):
                 flat_plan_config[f'{key}.{idx}'] = v
         else:
             flat_plan_config[key] = val

--- a/openfl/native/native.py
+++ b/openfl/native/native.py
@@ -67,7 +67,7 @@ def flatten(config, return_complete=False):
     return flattened_config
 
 
-def update_plan(override_config):
+def update_plan(override_config, plan=None, resolve=True):
     """
     Update the plan with the provided override and save it to disk.
     If the override value is a list, keys corresponding to each list
@@ -83,7 +83,8 @@ def update_plan(override_config):
     Returns:
         None
     """
-    plan = setup_plan()
+    if plan is None:
+        plan = setup_plan()
     flat_plan_config = flatten(plan.config, return_complete=True)
     for k, v in override_config.items():
         if k in flat_plan_config:
@@ -93,7 +94,8 @@ def update_plan(override_config):
             logger.warn(f'Did not find {k} in config. Make sure it should exist. Creating...')
         flat_plan_config[k] = v
     plan.config = unflatten(flat_plan_config, '.')
-    plan.resolve()
+    if resolve:
+        plan.resolve()
     return plan
 
 

--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,7 @@ setup(
         'jupyterlab',
         'numpy',
         'pandas',
-        'protobuf',
+        'protobuf==3.19.4',
         'requests',
         'rich',
         'scikit-learn',

--- a/tests/openfl/native/__init__.py
+++ b/tests/openfl/native/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""tests.openfl.native package."""

--- a/tests/openfl/native/base_example.yaml
+++ b/tests/openfl/native/base_example.yaml
@@ -5,3 +5,4 @@ Planet:
         USA:
           Oregon: 'Portland'
   Mars: ['Water', 'Ice']
+  Pluto: []

--- a/tests/openfl/native/base_example.yaml
+++ b/tests/openfl/native/base_example.yaml
@@ -1,0 +1,6 @@
+Planet:
+  Earth:
+    Continent:
+      North-America:
+        USA:
+          Oregon: 'Portland'

--- a/tests/openfl/native/base_example.yaml
+++ b/tests/openfl/native/base_example.yaml
@@ -4,3 +4,4 @@ Planet:
       North-America:
         USA:
           Oregon: 'Portland'
+  Mars: ['Water', 'Ice']

--- a/tests/openfl/native/test_update_plan.py
+++ b/tests/openfl/native/test_update_plan.py
@@ -19,7 +19,7 @@ from openfl.native import update_plan
 def test_update_plan_new_key_value_addition(override_config,expected_result):
     """Test update_plan for adding a new key value pair."""
     plan = Plan()
-    plan.config = Plan.load(Path('./base_example.yaml'))
+    plan.config = Plan.load(Path('./tests/openfl/native/base_example.yaml'))
     result = update_plan(override_config, plan=plan, resolve=False)
     assert result.config == expected_result
 
@@ -36,7 +36,7 @@ def test_update_plan_new_key_value_addition(override_config,expected_result):
 def test_update_plan_new_key_list_value_addition(override_config,expected_result):
     """Test update_plan or adding a new key with value as a list."""
     plan = Plan()
-    plan.config = Plan.load(Path('./base_example.yaml'))
+    plan.config = Plan.load(Path('./tests/openfl/native/base_example.yaml'))
     result = update_plan(override_config, plan=plan, resolve=False)
     assert result.config == expected_result
 
@@ -49,7 +49,7 @@ def test_update_plan_new_key_list_value_addition(override_config,expected_result
 def test_update_plan_existing_key_value_updation(override_config,expected_result):
     """Test update_plan for adding a new key value pair."""
     plan = Plan()
-    plan.config = Plan.load(Path('./base_example.yaml'))
+    plan.config = Plan.load(Path('./tests/openfl/native/base_example.yaml'))
     result = update_plan(override_config, plan=plan, resolve=False)
     assert result.config == expected_result
 
@@ -64,6 +64,6 @@ def test_update_plan_existing_key_value_updation(override_config,expected_result
 def test_update_plan_existing_key_list_value_updation(override_config,expected_result):
     """Test update_plan or adding a new key with value as a list."""
     plan = Plan()
-    plan.config = Plan.load(Path('./base_example.yaml'))
+    plan.config = Plan.load(Path('./tests/openfl/native/base_example.yaml'))
     result = update_plan(override_config, plan=plan, resolve=False)
     assert result.config == expected_result

--- a/tests/openfl/native/test_update_plan.py
+++ b/tests/openfl/native/test_update_plan.py
@@ -12,11 +12,13 @@ from openfl.native import update_plan
     'override_config,expected_result', [
         ({},
          {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': 'Portland'}}}},
-                     'Mars': ['Water', 'Ice']}}),
+                     'Mars': ['Water', 'Ice'],
+                     'Pluto': []}}),
         ({'Planet.Earth.Continent.Australia': 'Sydney'},
          {'Planet': {'Earth': {'Continent': {'Australia': 'Sydney',
                                              'North-America': {'USA': {'Oregon': 'Portland'}}}},
-                     'Mars': ['Water', 'Ice']}})
+                     'Mars': ['Water', 'Ice'],
+                     'Pluto': []}})
     ])
 def test_update_plan_new_key_value_addition(override_config, expected_result):
     """Test update_plan for adding a new key value pair."""
@@ -31,11 +33,13 @@ def test_update_plan_new_key_value_addition(override_config, expected_result):
         ({'Planet.Jupiter': ['Sun', 'Rings']},
          {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': 'Portland'}}}},
                      'Mars': ['Water', 'Ice'],
+                     'Pluto': [],
                      'Jupiter': ['Sun', 'Rings']}}),
         ({'Planet.Earth.Continent.Australia': ['Sydney', 'Melbourne']},
          {'Planet': {'Earth': {'Continent': {'Australia': ['Sydney', 'Melbourne'],
                                              'North-America': {'USA': {'Oregon': 'Portland'}}}},
-                     'Mars': ['Water', 'Ice']}})
+                     'Mars': ['Water', 'Ice'],
+                     'Pluto': []}})
     ])
 def test_update_plan_new_key_list_value_addition(override_config, expected_result):
     """Test update_plan or adding a new key with value as a list."""
@@ -49,10 +53,16 @@ def test_update_plan_new_key_list_value_addition(override_config, expected_resul
     'override_config,expected_result', [
         ({'Planet.Earth.Continent.North-America.USA.Oregon': 'Salem'},
          {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': 'Salem'}}}},
-                     'Mars': ['Water', 'Ice']}}),
+                     'Mars': ['Water', 'Ice'],
+                     'Pluto': []}}),
         ({'Planet.Mars': 'Moon'},
          {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': 'Portland'}}}},
-                     'Mars': 'Moon'}})
+                     'Mars': 'Moon',
+                     'Pluto': []}}),
+        ({'Planet.Pluto': 'Tiny'},
+         {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': 'Portland'}}}},
+                     'Mars': ['Water', 'Ice'],
+                     'Pluto': 'Tiny'}})
     ])
 def test_update_plan_existing_key_value_updation(override_config, expected_result):
     """Test update_plan for adding a new key value pair."""
@@ -66,17 +76,25 @@ def test_update_plan_existing_key_value_updation(override_config, expected_resul
     'override_config,expected_result', [
         ({'Planet.Mars': ['Water', 'Moon', 'Ice']},
          {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': 'Portland'}}}},
-                     'Mars': ['Water', 'Moon', 'Ice']}}),
+                     'Mars': ['Water', 'Moon', 'Ice'],
+                     'Pluto': []}}),
         ({'Planet.Mars': ['Water']},
          {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': 'Portland'}}}},
-                     'Mars': ['Water']}}),
+                     'Mars': ['Water'],
+                     'Pluto': []}}),
         ({'Planet.Earth.Continent.North-America.USA.Oregon': ['Portland', 'Salem']},
          {'Planet': {'Earth': {'Continent': {'North-America':
                                              {'USA': {'Oregon': ['Portland', 'Salem']}}}},
-                     'Mars': ['Water', 'Ice']}}),
+                     'Mars': ['Water', 'Ice'],
+                     'Pluto': []}}),
         ({'Planet.Earth.Continent.North-America.USA.Oregon': ['Salem']},
          {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': ['Salem']}}}},
-                     'Mars': ['Water', 'Ice']}})
+                     'Mars': ['Water', 'Ice'],
+                     'Pluto': []}}),
+        ({'Planet.Pluto': ['Tiny', 'Far']},
+         {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': 'Portland'}}}},
+                     'Mars': ['Water', 'Ice'],
+                     'Pluto': ['Tiny', 'Far']}})
     ])
 def test_update_plan_existing_key_list_value_updation(override_config, expected_result):
     """Test update_plan or adding a new key with value as a list."""

--- a/tests/openfl/native/test_update_plan.py
+++ b/tests/openfl/native/test_update_plan.py
@@ -1,0 +1,69 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Update plan test module."""
+import pytest
+from pathlib import Path
+
+from openfl.federated import Plan
+from openfl.native import update_plan
+
+
+@pytest.mark.parametrize(
+    'override_config,expected_result', [
+        ({},
+        {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': 'Portland'}}}}}}),
+        ({'Planet.Earth.Continent.Australia': 'Sydney'},
+        {'Planet': {'Earth': {'Continent': {'Australia': 'Sydney',
+                                            'North-America': {'USA': {'Oregon': 'Portland'}}}}}})
+    ])
+def test_update_plan_new_key_value_addition(override_config,expected_result):
+    """Test update_plan for adding a new key value pair."""
+    plan = Plan()
+    plan.config = Plan.load(Path('./base_example.yaml'))
+    result = update_plan(override_config, plan=plan, resolve=False)
+    assert result.config == expected_result
+
+
+@pytest.mark.parametrize(
+    'override_config,expected_result', [
+        ({'Planet.Mars.0': 'Water', 'Planet.Mars.1': 'Ice'},
+        {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': 'Portland'}}}},
+                    'Mars': ['Water', 'Ice']}}),
+        ({'Planet.Earth.Continent.Australia.0': 'Sydney', 'Planet.Earth.Continent.Australia.1': 'Melbourne'},
+        {'Planet': {'Earth': {'Continent': {'Australia': ['Sydney', 'Melbourne'],
+                                            'North-America': {'USA': {'Oregon': 'Portland'}}}}}})
+    ])
+def test_update_plan_new_key_list_value_addition(override_config,expected_result):
+    """Test update_plan or adding a new key with value as a list."""
+    plan = Plan()
+    plan.config = Plan.load(Path('./base_example.yaml'))
+    result = update_plan(override_config, plan=plan, resolve=False)
+    assert result.config == expected_result
+
+
+@pytest.mark.parametrize(
+    'override_config,expected_result', [
+        ({'Planet.Earth.Continent.North-America.USA.Oregon': 'Salem'},
+        {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': 'Salem'}}}}}})
+    ])
+def test_update_plan_existing_key_value_updation(override_config,expected_result):
+    """Test update_plan for adding a new key value pair."""
+    plan = Plan()
+    plan.config = Plan.load(Path('./base_example.yaml'))
+    result = update_plan(override_config, plan=plan, resolve=False)
+    assert result.config == expected_result
+
+
+@pytest.mark.parametrize(
+    'override_config,expected_result', [
+        ({'Planet.Earth.Continent.North-America.USA.Oregon.0': 'Portland', 'Planet.Earth.Continent.North-America.USA.Oregon.1': 'Salem'},
+        {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': ['Portland', 'Salem']}}}}}}),
+        ({'Planet.Earth.Continent.North-America.USA.Oregon.0': 'Portland'},
+        {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': ['Portland']}}}}}})
+    ])
+def test_update_plan_existing_key_list_value_updation(override_config,expected_result):
+    """Test update_plan or adding a new key with value as a list."""
+    plan = Plan()
+    plan.config = Plan.load(Path('./base_example.yaml'))
+    result = update_plan(override_config, plan=plan, resolve=False)
+    assert result.config == expected_result

--- a/tests/openfl/native/test_update_plan.py
+++ b/tests/openfl/native/test_update_plan.py
@@ -11,10 +11,12 @@ from openfl.native import update_plan
 @pytest.mark.parametrize(
     'override_config,expected_result', [
         ({},
-        {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': 'Portland'}}}}}}),
+        {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': 'Portland'}}}},
+                    'Mars': ['Water', 'Ice']}}),
         ({'Planet.Earth.Continent.Australia': 'Sydney'},
         {'Planet': {'Earth': {'Continent': {'Australia': 'Sydney',
-                                            'North-America': {'USA': {'Oregon': 'Portland'}}}}}})
+                                            'North-America': {'USA': {'Oregon': 'Portland'}}}},
+                    'Mars': ['Water', 'Ice']}})
     ])
 def test_update_plan_new_key_value_addition(override_config,expected_result):
     """Test update_plan for adding a new key value pair."""
@@ -26,12 +28,14 @@ def test_update_plan_new_key_value_addition(override_config,expected_result):
 
 @pytest.mark.parametrize(
     'override_config,expected_result', [
-        ({'Planet.Mars.0': 'Water', 'Planet.Mars.1': 'Ice'},
+        ({'Planet.Jupiter': ['Sun', 'Rings']},
         {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': 'Portland'}}}},
-                    'Mars': ['Water', 'Ice']}}),
-        ({'Planet.Earth.Continent.Australia.0': 'Sydney', 'Planet.Earth.Continent.Australia.1': 'Melbourne'},
+                    'Mars': ['Water', 'Ice'],
+                    'Jupiter': ['Sun', 'Rings']}}),
+        ({'Planet.Earth.Continent.Australia': ['Sydney', 'Melbourne']},
         {'Planet': {'Earth': {'Continent': {'Australia': ['Sydney', 'Melbourne'],
-                                            'North-America': {'USA': {'Oregon': 'Portland'}}}}}})
+                                            'North-America': {'USA': {'Oregon': 'Portland'}}}},
+                    'Mars': ['Water', 'Ice']}})
     ])
 def test_update_plan_new_key_list_value_addition(override_config,expected_result):
     """Test update_plan or adding a new key with value as a list."""
@@ -44,7 +48,11 @@ def test_update_plan_new_key_list_value_addition(override_config,expected_result
 @pytest.mark.parametrize(
     'override_config,expected_result', [
         ({'Planet.Earth.Continent.North-America.USA.Oregon': 'Salem'},
-        {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': 'Salem'}}}}}})
+        {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': 'Salem'}}}},
+                    'Mars': ['Water', 'Ice']}}),
+        ({'Planet.Mars': 'Moon'},
+        {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': 'Portland'}}}},
+                    'Mars': 'Moon'}})
     ])
 def test_update_plan_existing_key_value_updation(override_config,expected_result):
     """Test update_plan for adding a new key value pair."""
@@ -56,10 +64,18 @@ def test_update_plan_existing_key_value_updation(override_config,expected_result
 
 @pytest.mark.parametrize(
     'override_config,expected_result', [
-        ({'Planet.Earth.Continent.North-America.USA.Oregon.0': 'Portland', 'Planet.Earth.Continent.North-America.USA.Oregon.1': 'Salem'},
-        {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': ['Portland', 'Salem']}}}}}}),
-        ({'Planet.Earth.Continent.North-America.USA.Oregon.0': 'Portland'},
-        {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': ['Portland']}}}}}})
+        ({'Planet.Mars': ['Water', 'Moon', 'Ice']},
+        {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': 'Portland'}}}},
+                    'Mars': ['Water', 'Moon', 'Ice']}}),
+        ({'Planet.Mars': ['Water']},
+        {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': 'Portland'}}}},
+                    'Mars': ['Water']}}),
+        ({'Planet.Earth.Continent.North-America.USA.Oregon': ['Portland', 'Salem']},
+        {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': ['Portland', 'Salem']}}}},
+                    'Mars': ['Water', 'Ice']}}),
+        ({'Planet.Earth.Continent.North-America.USA.Oregon': ['Salem']},
+        {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': ['Salem']}}}},
+                    'Mars': ['Water', 'Ice']}})
     ])
 def test_update_plan_existing_key_list_value_updation(override_config,expected_result):
     """Test update_plan or adding a new key with value as a list."""

--- a/tests/openfl/native/test_update_plan.py
+++ b/tests/openfl/native/test_update_plan.py
@@ -11,14 +11,14 @@ from openfl.native import update_plan
 @pytest.mark.parametrize(
     'override_config,expected_result', [
         ({},
-        {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': 'Portland'}}}},
-                    'Mars': ['Water', 'Ice']}}),
+         {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': 'Portland'}}}},
+                     'Mars': ['Water', 'Ice']}}),
         ({'Planet.Earth.Continent.Australia': 'Sydney'},
-        {'Planet': {'Earth': {'Continent': {'Australia': 'Sydney',
-                                            'North-America': {'USA': {'Oregon': 'Portland'}}}},
-                    'Mars': ['Water', 'Ice']}})
+         {'Planet': {'Earth': {'Continent': {'Australia': 'Sydney',
+                                             'North-America': {'USA': {'Oregon': 'Portland'}}}},
+                     'Mars': ['Water', 'Ice']}})
     ])
-def test_update_plan_new_key_value_addition(override_config,expected_result):
+def test_update_plan_new_key_value_addition(override_config, expected_result):
     """Test update_plan for adding a new key value pair."""
     plan = Plan()
     plan.config = Plan.load(Path('./tests/openfl/native/base_example.yaml'))
@@ -29,15 +29,15 @@ def test_update_plan_new_key_value_addition(override_config,expected_result):
 @pytest.mark.parametrize(
     'override_config,expected_result', [
         ({'Planet.Jupiter': ['Sun', 'Rings']},
-        {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': 'Portland'}}}},
-                    'Mars': ['Water', 'Ice'],
-                    'Jupiter': ['Sun', 'Rings']}}),
+         {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': 'Portland'}}}},
+                     'Mars': ['Water', 'Ice'],
+                     'Jupiter': ['Sun', 'Rings']}}),
         ({'Planet.Earth.Continent.Australia': ['Sydney', 'Melbourne']},
-        {'Planet': {'Earth': {'Continent': {'Australia': ['Sydney', 'Melbourne'],
-                                            'North-America': {'USA': {'Oregon': 'Portland'}}}},
-                    'Mars': ['Water', 'Ice']}})
+         {'Planet': {'Earth': {'Continent': {'Australia': ['Sydney', 'Melbourne'],
+                                             'North-America': {'USA': {'Oregon': 'Portland'}}}},
+                     'Mars': ['Water', 'Ice']}})
     ])
-def test_update_plan_new_key_list_value_addition(override_config,expected_result):
+def test_update_plan_new_key_list_value_addition(override_config, expected_result):
     """Test update_plan or adding a new key with value as a list."""
     plan = Plan()
     plan.config = Plan.load(Path('./tests/openfl/native/base_example.yaml'))
@@ -48,13 +48,13 @@ def test_update_plan_new_key_list_value_addition(override_config,expected_result
 @pytest.mark.parametrize(
     'override_config,expected_result', [
         ({'Planet.Earth.Continent.North-America.USA.Oregon': 'Salem'},
-        {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': 'Salem'}}}},
-                    'Mars': ['Water', 'Ice']}}),
+         {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': 'Salem'}}}},
+                     'Mars': ['Water', 'Ice']}}),
         ({'Planet.Mars': 'Moon'},
-        {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': 'Portland'}}}},
-                    'Mars': 'Moon'}})
+         {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': 'Portland'}}}},
+                     'Mars': 'Moon'}})
     ])
-def test_update_plan_existing_key_value_updation(override_config,expected_result):
+def test_update_plan_existing_key_value_updation(override_config, expected_result):
     """Test update_plan for adding a new key value pair."""
     plan = Plan()
     plan.config = Plan.load(Path('./tests/openfl/native/base_example.yaml'))
@@ -65,19 +65,20 @@ def test_update_plan_existing_key_value_updation(override_config,expected_result
 @pytest.mark.parametrize(
     'override_config,expected_result', [
         ({'Planet.Mars': ['Water', 'Moon', 'Ice']},
-        {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': 'Portland'}}}},
-                    'Mars': ['Water', 'Moon', 'Ice']}}),
+         {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': 'Portland'}}}},
+                     'Mars': ['Water', 'Moon', 'Ice']}}),
         ({'Planet.Mars': ['Water']},
-        {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': 'Portland'}}}},
-                    'Mars': ['Water']}}),
+         {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': 'Portland'}}}},
+                     'Mars': ['Water']}}),
         ({'Planet.Earth.Continent.North-America.USA.Oregon': ['Portland', 'Salem']},
-        {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': ['Portland', 'Salem']}}}},
-                    'Mars': ['Water', 'Ice']}}),
+         {'Planet': {'Earth': {'Continent': {'North-America':
+                                             {'USA': {'Oregon': ['Portland', 'Salem']}}}},
+                     'Mars': ['Water', 'Ice']}}),
         ({'Planet.Earth.Continent.North-America.USA.Oregon': ['Salem']},
-        {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': ['Salem']}}}},
-                    'Mars': ['Water', 'Ice']}})
+         {'Planet': {'Earth': {'Continent': {'North-America': {'USA': {'Oregon': ['Salem']}}}},
+                     'Mars': ['Water', 'Ice']}})
     ])
-def test_update_plan_existing_key_list_value_updation(override_config,expected_result):
+def test_update_plan_existing_key_list_value_updation(override_config, expected_result):
     """Test update_plan or adding a new key with value as a list."""
     plan = Plan()
     plan.config = Plan.load(Path('./tests/openfl/native/base_example.yaml'))


### PR DESCRIPTION
`flatten_json.flatten_preserve_lists()` isn't smashing hierarchies beyond third nested level. The fix is to use `flatten_json.flatten()` instead and preserve lists while unflatting using `flatten_json.unflatten_list()`