### PR TITLE
Fix loader entrypoint to be compatible with Gramine v1.2

### DIFF
--- a/openfl-gramine/openfl.manifest.template
+++ b/openfl-gramine/openfl.manifest.template
@@ -1,4 +1,4 @@
-loader.preload = "file:{{ gramine.libos }}"
+loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "/usr/local/bin/python3.8"
 loader.log_level = "{{ log_level }}"
 


### PR DESCRIPTION
In Gramine v1.2, the manifest entry point syntax was changed from 'loader.preload' to 'loader.entrypoint'.
To be compatible with that change, it should be implemented in openfl-gramine manifest template.