### PR TITLE
Envoys to review plan before experiment starts

### DIFF
--- a/docs/running_the_federation.rst
+++ b/docs/running_the_federation.rst
@@ -64,6 +64,19 @@ Director Manager: Set Up the Director
 
 The *Director manager* sets up the *Director*, which is the central node of the federation.
 
+    - :ref:`plan_agreement_director`
+    - :ref:`optional_step_create_pki_using_step_ca`
+    - :ref:`step0_install_director_prerequisites`
+    - :ref:`step1_start_the_director`
+
+.. _plan_agreement_director:
+
+OPTIONAL STEP: Plan Agreement
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+In order to carry out a secure federation, the Director must approve the FL Plan before starting the experiment. This check could be enforced with the use of the setting :code:`review_experiment: True` in director config. Refer to **director_config_review_exp.yaml** file under **PyTorch_Histology** interactive API example.
+After the Director approves the experiment, it starts the aggregator and sends the experiment archive to all the participanting Envoys for review.
+On the other hand, if the Director rejects the experiment, the experiment is aborted right away, no aggregator is started and the Envoys don't receive the experiment archive at all.
+
 .. _optional_step_create_pki_using_step_ca:
 
 OPTIONAL STEP: Create PKI Certificates Using Step-CA
@@ -122,10 +135,18 @@ Collaborator Manager: Set Up the Envoy
 --------------------------------------
 
 The *Collaborator manager* sets up the *Envoys*, which are long-lived components on collaborator nodes. When started, Envoys will try to connect to the Director. Envoys receive an experiment archive and provide access to local data.
-
+    
+    - :ref:`plan_agreement_envoy`
     - :ref:`optional_step_sign_pki_envoy`
     - :ref:`step0_install_envoy_prerequisites`
     - :ref:`step1_start_the_envoy`
+
+.. _plan_agreement_envoy:
+
+OPTIONAL STEP: Plan Agreement
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+In order to carry out a secure federation, each of the Envoys must approve the experiment before it is started, after the Director's approval. This check could be enforced with the use of the parameter :code:`review_experiment: True` in envoy config. Refer to **envoy_config_review_exp.yaml** file under **PyTorch_Histology** interactive API example.
+If any of the Envoys rejects the experiment, a :code:`set_experiment_failed` request is sent to the Director to stop the aggregator.
 
 .. _optional_step_sign_pki_envoy:
 
@@ -510,6 +531,12 @@ Observe the Experiment Execution
 
 If the experiment was accepted by the *Director*, you can oversee its execution with the :code:`FLexperiment.stream_metrics()` method. This method prints metrics from the FL tasks (and saves TensorBoard logs).
 
+.. _federation_api_get_fl_experiment_status:
+
+Get Experiment Status
+^^^^^^^^^^^^^^^^^^^^^
+
+You can get the current experiment status with the :code:`FLexperiment.get_experiment_status()` method. The status could be pending, in progress, finished, rejected or failed.
 
 .. _federation_api_complete_fl_experiment:
 

--- a/docs/source/openfl/director_envoy.mmd
+++ b/docs/source/openfl/director_envoy.mmd
@@ -22,8 +22,10 @@ sequenceDiagram
             D-->D: Notifies user that <br>the experiment is inconsistent
             D-->D: The experiment ends
         end
+        D->D: Reviews the FL plan
         D->D: Starts an Aggregator
         D-->>E: Sends the experiment archive <br>and the FL plan to envoys
+        E-->E: Reviews the FL Plan
         E-->E: Starts a Collaborator
         D-->D: Fills the model with the final weights <br>and returns to user
     end

--- a/docs/source/openfl/experiment_representation_and_RPCs.mmd
+++ b/docs/source/openfl/experiment_representation_and_RPCs.mmd
@@ -14,6 +14,11 @@ sequenceDiagram
   note over ER,D: Registry can also return <br>an experiment list by user id
   D->>-F: Approves
 
+  F->>+D: Get Experiment Status
+  D->>+ER: Gets the status of the current experiment
+  note over ER,D: Experiment might be pending, in progress, failed or finished
+  D->>-F: Approves
+
   rect rgb(225, 255, 225)
     note over ER,E: Envoys may start awaiting experiments <br>even if the queue is empty
     E-)+D: Wait Experiment *STREAM*
@@ -23,6 +28,7 @@ sequenceDiagram
 
     E->>+D: Get Experiment Data
     D->>ER: Gets experiment archive (by name)
+    D-->D: Reviews the FL Plan
     D->>ER: Sets status to In Progress
     D->>-E: Experiment Data
   end

--- a/openfl-tutorials/interactive_api/PyTorch_Histology/director/director_config_review_exp.yaml
+++ b/openfl-tutorials/interactive_api/PyTorch_Histology/director/director_config_review_exp.yaml
@@ -1,0 +1,6 @@
+settings:
+  listen_host: localhost
+  listen_port: 50051
+  sample_shape: ['150', '150']
+  target_shape: ['1']
+  review_experiment: True

--- a/openfl-tutorials/interactive_api/PyTorch_Histology/envoy/envoy_config_review_exp.yaml
+++ b/openfl-tutorials/interactive_api/PyTorch_Histology/envoy/envoy_config_review_exp.yaml
@@ -1,0 +1,11 @@
+params:
+  cuda_devices: []
+  review_experiment: True
+
+optional_plugin_components: {}
+
+shard_descriptor:
+  template: histology_shard_descriptor.HistologyShardDescriptor
+  params:
+    data_folder: histology_data
+    rank_worldsize: 1,2

--- a/openfl-tutorials/interactive_api/PyTorch_Histology/workspace/pytorch_histology.ipynb
+++ b/openfl-tutorials/interactive_api/PyTorch_Histology/workspace/pytorch_histology.ipynb
@@ -417,7 +417,6 @@
     "    device = torch.device('cuda')\n",
     "    if not torch.cuda.is_available():\n",
     "        device = 'cpu'\n",
-    "        \n",
     "    net_model.eval()\n",
     "    net_model.to(device)\n",
     "    \n",
@@ -478,6 +477,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f3efc78f-57cd-42e0-9398-bdebd596fac5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get status of the current experiment\n",
+    "fl_experiment.get_experiment_status()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "acting-immunology",
    "metadata": {},
    "outputs": [],
@@ -514,11 +524,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.8.13"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "767d51c1340bd893661ea55ea3124f6de3c7a262a8b4abca0554b478b1e2ff90"
-   }
   }
  },
  "nbformat": 4,

--- a/openfl-workspace/default/director.yaml
+++ b/openfl-workspace/default/director.yaml
@@ -13,3 +13,4 @@ settings:
   listen_port: 50051  # listen port
   envoy_health_check_period: 60  # in seconds
   install_requirements: false
+  review_experiment: false

--- a/openfl-workspace/default/envoy_config.yaml
+++ b/openfl-workspace/default/envoy_config.yaml
@@ -20,6 +20,7 @@
 params:
   install_requirements: true
   cuda_devices: []
+  review_experiment: False
 
 optional_plugin_components:
   cuda_device_monitor:

--- a/openfl/component/aggregator/aggregator.py
+++ b/openfl/component/aggregator/aggregator.py
@@ -955,6 +955,13 @@ class Aggregator:
     def stop(self, failed_collaborator: str = None) -> None:
         """Stop aggregator execution."""
         self.logger.info('Force stopping the aggregator execution.')
+        # We imitate quit_job_sent_to the failed collaborator
+        # So the experiment set to a finished state
+        if failed_collaborator:
+            self.quit_job_sent_to.append(failed_collaborator)
+
+        # This code does not actually send `quit` tasks to collaborators,
+        # it just mimics it by filling arrays.
         for collaborator_name in filter(lambda c: c != failed_collaborator, self.authorized_cols):
             self.logger.info(f'Sending signal to collaborator {collaborator_name} to shutdown...')
             self.quit_job_sent_to.append(collaborator_name)

--- a/openfl/component/director/director.py
+++ b/openfl/component/director/director.py
@@ -19,8 +19,6 @@ from .experiment import Status
 
 logger = logging.getLogger(__name__)
 
-ENVOY_HEALTH_CHECK_PERIOD = 60  # in seconds
-
 
 class Director:
     """Director class."""
@@ -34,7 +32,8 @@ class Director:
             sample_shape: list = None,
             target_shape: list = None,
             review_plan_callback: Union[None, Callable] = None,
-            envoy_health_check_period: int = ENVOY_HEALTH_CHECK_PERIOD
+            envoy_health_check_period: int = 60,
+            install_requirements: bool = False
     ) -> None:
         """Initialize a director object."""
         self.sample_shape, self.target_shape = sample_shape, target_shape
@@ -48,6 +47,7 @@ class Director:
         self.col_exp = {}
         self.review_plan_callback = review_plan_callback
         self.envoy_health_check_period = envoy_health_check_period
+        self.install_requirements = install_requirements
 
     def acknowledge_shard(self, shard_info: dict) -> bool:
         """Save shard info to shard registry if it's acceptable."""
@@ -314,7 +314,7 @@ class Director:
                     certificate=self.certificate,
                     private_key=self.private_key,
                     tls=self.tls,
-                    install_requirements=self.settings.get('install_requirements', False),
+                    install_requirements=self.install_requirements,
                 ))
                 # Adding the experiment to collaborators queues
                 for col_name in experiment.collaborators:

--- a/openfl/component/director/experiment.py
+++ b/openfl/component/director/experiment.py
@@ -7,6 +7,7 @@ import asyncio
 import logging
 from contextlib import asynccontextmanager
 from pathlib import Path
+from typing import Callable
 from typing import Iterable
 from typing import List
 from typing import Union
@@ -25,6 +26,7 @@ class Status:
     FINISHED = 'finished'
     IN_PROGRESS = 'in_progress'
     FAILED = 'failed'
+    REJECTED = 'rejected'
 
 
 class Experiment:
@@ -42,18 +44,15 @@ class Experiment:
     ) -> None:
         """Initialize an experiment object."""
         self.name = name
-        if isinstance(archive_path, str):
-            archive_path = Path(archive_path)
-        self.archive_path = archive_path
+        self.archive_path = Path(archive_path).absolute()
         self.collaborators = collaborators
         self.sender = sender
         self.init_tensor_dict = init_tensor_dict
-        if isinstance(plan_path, str):
-            plan_path = Path(plan_path)
-        self.plan_path = plan_path
+        self.plan_path = Path(plan_path)
         self.users = set() if users is None else set(users)
         self.status = Status.PENDING
         self.aggregator = None
+        self.run_aggregator_atask = None
 
     async def start(
             self, *,
@@ -81,14 +80,43 @@ class Experiment:
                     certificate=certificate,
                 )
                 self.aggregator = aggregator_grpc_server.aggregator
-                await self._run_aggregator_grpc_server(
-                    aggregator_grpc_server=aggregator_grpc_server,
+
+                self.run_aggregator_atask = asyncio.create_task(
+                    self._run_aggregator_grpc_server(
+                        aggregator_grpc_server=aggregator_grpc_server,
+                    )
                 )
+                await self.run_aggregator_atask
             self.status = Status.FINISHED
             logger.info(f'Experiment "{self.name}" was finished successfully.')
         except Exception as e:
             self.status = Status.FAILED
-            logger.exception(f'Experiment "{self.name}" was failed with error: {e}.')
+            logger.exception(f'Experiment "{self.name}" failed with error: {e}.')
+
+    async def review_experiment(self, review_plan_callback: Callable) -> bool:
+        """Get plan approve in console."""
+        logger.debug("Experiment Review starts")
+        # Extract the workspace for review (without installing requirements)
+        with ExperimentWorkspace(
+            self.name,
+            self.archive_path,
+            is_install_requirements=False,
+            remove_archive=False
+        ):
+            loop = asyncio.get_event_loop()
+            # Call for a review in a separate thread (server is not blocked)
+            review_approve = await loop.run_in_executor(
+                None,
+                review_plan_callback,
+                self.name, self.plan_path
+            )
+            if not review_approve:
+                self.status = Status.REJECTED
+                self.archive_path.unlink(missing_ok=True)
+                return False
+
+        logger.debug("Experiment Review succeed")
+        return True
 
     def _create_aggregator_grpc_server(
             self, *,
@@ -97,10 +125,10 @@ class Experiment:
             private_key: Union[Path, str] = None,
             certificate: Union[Path, str] = None,
     ) -> AggregatorGRPCServer:
-        plan = Plan.parse(plan_config_path=Path(self.plan_path))
+        plan = Plan.parse(plan_config_path=self.plan_path)
         plan.authorized_cols = list(self.collaborators)
 
-        logger.info('🧿 Starting the Aggregator Service.')
+        logger.info(f'🧿 Created an Aggregator Server for {self.name} experiment.')
         aggregator_grpc_server = plan.interactive_api_get_server(
             tensor_dict=self.init_tensor_dict,
             root_certificate=root_certificate,
@@ -122,6 +150,7 @@ class Experiment:
             while not aggregator_grpc_server.aggregator.all_quit_jobs_sent():
                 # Awaiting quit job sent to collaborators
                 await asyncio.sleep(10)
+            logger.debug('Aggregator sent quit jobs calls to all collaborators')
         except KeyboardInterrupt:
             pass
         finally:

--- a/openfl/component/envoy/envoy.py
+++ b/openfl/component/envoy/envoy.py
@@ -9,11 +9,10 @@ import traceback
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from typing import Callable
 from typing import Optional
 from typing import Type
 from typing import Union
-
-from click import echo
 
 from openfl.federated import Plan
 from openfl.interface.interactive_api.shard_descriptor import ShardDescriptor
@@ -42,6 +41,7 @@ class Envoy:
             install_requirements: bool = True,
             cuda_devices: Union[tuple, list] = (),
             cuda_device_monitor: Optional[Type[CUDADeviceMonitor]] = None,
+            review_plan_callback: Union[None, Callable] = None,
     ) -> None:
         """Initialize a envoy object."""
         self.name = shard_name
@@ -63,6 +63,8 @@ class Envoy:
         self.cuda_devices = tuple(cuda_devices)
         self.install_requirements = install_requirements
 
+        self.review_plan_callback = review_plan_callback
+
         # Optional plugins
         self.cuda_device_monitor = cuda_device_monitor
 
@@ -82,14 +84,29 @@ class Envoy:
                 logger.exception(f'Failed to get experiment: {exc}')
                 time.sleep(DEFAULT_RETRY_TIMEOUT_IN_SECONDS)
                 continue
+
             data_file_path = self._save_data_stream_to_file(data_stream)
-            self.is_experiment_running = True
+
             try:
                 with ExperimentWorkspace(
                         experiment_name=f'{self.name}_{experiment_name}',
                         data_file_path=data_file_path,
                         install_requirements=self.install_requirements
                 ):
+                    # If the callback is passed
+                    if self.review_plan_callback:
+                        # envoy to review the experiment before starting
+                        if not self.review_plan_callback('plan', 'plan/plan.yaml'):
+                            self.director_client.set_experiment_failed(
+                                experiment_name,
+                                error_description='Experiment is rejected'
+                                f' by Envoy "{self.name}" manager.'
+                            )
+                            continue
+                        logger.debug(
+                            f'Experiment "{experiment_name}" was accepted by Envoy manager'
+                        )
+                    self.is_experiment_running = True
                     self._run_collaborator()
             except Exception as exc:
                 logger.exception(f'Collaborator failed with error: {exc}:')
@@ -157,7 +174,7 @@ class Envoy:
         plan = Plan.parse(plan_config_path=Path(plan))
 
         # TODO: Need to restructure data loader config file loader
-        echo(f'Data = {plan.cols_data_paths}')
+        logger.info(f'Data = {plan.cols_data_paths}')
         logger.info('🧿 Starting a Collaborator Service.')
 
         col = plan.get_collaborator(self.name, self.root_certificate, self.private_key,

--- a/openfl/interface/cli.py
+++ b/openfl/interface/cli.py
@@ -5,12 +5,15 @@
 
 from click import argument
 from click import command
+from click import confirm
 from click import echo
 from click import Group
 from click import group
+from click import open_file
 from click import option
 from click import pass_context
 from click import style
+import time
 
 from openfl.utilities import add_log_level
 import sys
@@ -173,6 +176,26 @@ def error_handler(error):
     echo(style('EXCEPTION', fg='red', bold=True)
          + ' : ' + style(f'{error}', fg='red'))
     raise error
+
+
+def review_plan_callback(file_name, file_path):
+    """Review plan callback for Director and Envoy."""
+    echo(style(
+        f'Please review the contents of {file_name} before proceeding...',
+        fg='green',
+        bold=True))
+    # Wait for users to read the question before flashing the contents of the file.
+    time.sleep(3)
+
+    with open_file(file_path, 'r') as f:
+        echo(f.read())
+
+    if confirm(style(f'Do you want to accept the {file_name}?', fg='green', bold=True)):
+        echo(style(f'{file_name} accepted!', fg='green', bold=True))
+        return True
+    else:
+        echo(style(f'EXCEPTION: {file_name} rejected!', fg='red', bold=True))
+        return False
 
 
 def show_header():

--- a/openfl/interface/director.py
+++ b/openfl/interface/director.py
@@ -19,6 +19,7 @@ from openfl.interface.cli_helper import WORKSPACE
 from openfl.transport import DirectorGRPCServer
 from openfl.utilities import merge_configs
 from openfl.utilities.path_check import is_directory_traversal
+from openfl.interface.cli import review_plan_callback
 
 logger = logging.getLogger(__name__)
 
@@ -63,8 +64,9 @@ def start(director_config_path, tls, root_certificate, private_key, certificate)
             Validator('settings.listen_port', default=50051, gte=1024, lte=65535),
             Validator('settings.sample_shape', default=[]),
             Validator('settings.target_shape', default=[]),
-            Validator('settings.envoy_health_check_period', gte=1, lte=24 * 60 * 60),
             Validator('settings.install_requirements', default=False),
+            Validator('settings.envoy_health_check_period', default=60, gte=1, lte=24 * 60 * 60),
+            Validator('settings.review_experiment', default=False),
         ],
         value_transform=[
             ('settings.sample_shape', lambda x: list(map(str, x))),
@@ -86,6 +88,12 @@ def start(director_config_path, tls, root_certificate, private_key, certificate)
     if config.certificate:
         config.certificate = Path(config.certificate).absolute()
 
+    # We pass the `review_experiment` callback only if it is needed.
+    # Otherwise we pass None.
+    overwritten_review_plan_callback = None
+    if config.settings.review_experiment:
+        overwritten_review_plan_callback = review_plan_callback
+
     director_server = DirectorGRPCServer(
         director_cls=Director,
         tls=tls,
@@ -94,9 +102,10 @@ def start(director_config_path, tls, root_certificate, private_key, certificate)
         root_certificate=config.root_certificate,
         private_key=config.private_key,
         certificate=config.certificate,
-        settings=config.settings,
         listen_host=config.settings.listen_host,
         listen_port=config.settings.listen_port,
+        review_plan_callback=overwritten_review_plan_callback,
+        envoy_health_check_period=config.settings.envoy_health_check_period,
     )
     director_server.start()
 

--- a/openfl/interface/director.py
+++ b/openfl/interface/director.py
@@ -65,7 +65,9 @@ def start(director_config_path, tls, root_certificate, private_key, certificate)
             Validator('settings.sample_shape', default=[]),
             Validator('settings.target_shape', default=[]),
             Validator('settings.install_requirements', default=False),
-            Validator('settings.envoy_health_check_period', default=60, gte=1, lte=24 * 60 * 60),
+            Validator('settings.envoy_health_check_period',
+                      default=60,  # in seconds
+                      gte=1, lte=24 * 60 * 60),
             Validator('settings.review_experiment', default=False),
         ],
         value_transform=[
@@ -106,6 +108,7 @@ def start(director_config_path, tls, root_certificate, private_key, certificate)
         listen_port=config.settings.listen_port,
         review_plan_callback=overwritten_review_plan_callback,
         envoy_health_check_period=config.settings.envoy_health_check_period,
+        install_requirements=config.settings.install_requirements
     )
     director_server.start()
 

--- a/openfl/interface/envoy.py
+++ b/openfl/interface/envoy.py
@@ -16,6 +16,7 @@ from click import Path as ClickPath
 from dynaconf import Validator
 
 from openfl.component.envoy.envoy import Envoy
+from openfl.interface.cli import review_plan_callback
 from openfl.interface.cli_helper import WORKSPACE
 from openfl.utilities import click_types
 from openfl.utilities import merge_configs
@@ -67,6 +68,7 @@ def start_(shard_name, director_host, director_port, tls, envoy_config_path,
             Validator('shard_descriptor.template', required=True),
             Validator('params.cuda_devices', default=[]),
             Validator('params.install_requirements', default=True),
+            Validator('params.review_experiment', default=False),
         ],
     )
 
@@ -95,6 +97,13 @@ def start_(shard_name, director_host, director_port, tls, envoy_config_path,
             instance = getattr(module, class_name)(**plugin_params)
             envoy_params[plugin_name] = instance
 
+    # We pass the `review_experiment` callback only if it is needed.
+    # Otherwise we pass None.
+    overwritten_review_plan_callback = None
+    if envoy_params.review_experiment:
+        overwritten_review_plan_callback = review_plan_callback
+    del envoy_params.review_experiment
+
     # Instantiate Shard Descriptor
     shard_descriptor = shard_descriptor_from_config(config.get('shard_descriptor', {}))
     envoy = Envoy(
@@ -106,6 +115,7 @@ def start_(shard_name, director_host, director_port, tls, envoy_config_path,
         root_certificate=config.root_certificate,
         private_key=config.private_key,
         certificate=config.certificate,
+        review_plan_callback=overwritten_review_plan_callback,
         **envoy_params
     )
 

--- a/openfl/interface/interactive_api/experiment.py
+++ b/openfl/interface/interactive_api/experiment.py
@@ -56,7 +56,7 @@ class FLExperiment:
         self.summary_writer = None
         self.serializer_plugin = serializer_plugin
 
-        self.experiment_accepted = False
+        self.experiment_submitted = False
 
         self.is_validate_task_exist = False
 
@@ -78,18 +78,29 @@ class FLExperiment:
 
         self.plan = deepcopy(plan)
 
-    def _assert_experiment_accepted(self):
-        """Assure experiment is sent to director."""
-        if not self.experiment_accepted:
-            self.logger.error('The experiment has not been accepted by director')
+    def _assert_experiment_submitted(self):
+        """Assure experiment is sent to director and accepted."""
+        if not self.experiment_submitted:
+            self.logger.error('The experiment was not submitted to a Director service.')
             self.logger.error(
                 'Report the experiment first: '
                 'use the Experiment.start() method.')
-            raise Exception
+            return False
+        return True
+
+    def get_experiment_status(self):
+        """Returns the current state of the experiment."""
+        if not self._assert_experiment_submitted():
+            return
+        exp_status = self.federation.dir_client.get_experiment_status(
+            experiment_name=self.experiment_name
+        )
+        return exp_status.experiment_status
 
     def get_best_model(self):
         """Retrieve the model with the best score."""
-        self._assert_experiment_accepted()
+        if not self._assert_experiment_submitted():
+            return
         tensor_dict = self.federation.dir_client.get_best_model(
             experiment_name=self.experiment_name)
 
@@ -97,7 +108,8 @@ class FLExperiment:
 
     def get_last_model(self):
         """Retrieve the aggregated model after the last round."""
-        self._assert_experiment_accepted()
+        if not self._assert_experiment_submitted():
+            return
         tensor_dict = self.federation.dir_client.get_last_model(
             experiment_name=self.experiment_name)
 
@@ -126,7 +138,8 @@ class FLExperiment:
 
     def stream_metrics(self, tensorboard_logs: bool = True) -> None:
         """Stream metrics."""
-        self._assert_experiment_accepted()
+        if not self._assert_experiment_submitted():
+            return
         for metric_message_dict in self.federation.dir_client.stream_metrics(self.experiment_name):
             self.logger.metric(
                 f'Round {metric_message_dict["round"]}, '
@@ -148,13 +161,14 @@ class FLExperiment:
 
     def remove_experiment_data(self):
         """Remove experiment data."""
-        self._assert_experiment_accepted()
+        if not self._assert_experiment_submitted():
+            return
         log_message = 'Removing experiment data '
         if self.federation.dir_client.remove_experiment_data(
                 name=self.experiment_name
         ):
             log_message += 'succeed.'
-            self.experiment_accepted = False
+            self.experiment_submitted = False
         else:
             log_message += 'failed.'
 
@@ -242,10 +256,10 @@ class FLExperiment:
             self.remove_workspace_archive()
 
         if response.accepted:
-            self.logger.info('Experiment was accepted and launched.')
-            self.experiment_accepted = True
+            self.logger.info('Experiment was submitted to the director!')
+            self.experiment_submitted = True
         else:
-            self.logger.info('Experiment was not accepted or failed.')
+            self.logger.info('Experiment could not be submitted to the director.')
 
     def define_task_assigner(self, task_keeper, rounds_to_train):
         """Define task assigner by registered tasks."""
@@ -291,7 +305,7 @@ class FLExperiment:
         """Restore accepted experiment object."""
         self.task_runner_stub = self.plan.get_core_task_runner(model_provider=model_provider)
         self.current_model_status = ModelStatus.RESTORED
-        self.experiment_accepted = True
+        self.experiment_submitted = True
 
     @staticmethod
     def _pack_the_workspace():

--- a/openfl/protocols/director.proto
+++ b/openfl/protocols/director.proto
@@ -26,6 +26,7 @@ service Director {
 
   // 2.2 API RPCs
   rpc SetNewExperiment(stream ExperimentInfo) returns (SetNewExperimentResponse) {}
+  rpc GetExperimentStatus(GetExperimentStatusRequest) returns (GetExperimentStatusResponse) {}
   rpc GetDatasetInfo(GetDatasetInfoRequest) returns (GetDatasetInfoResponse) {}
   rpc GetTrainedModel(GetTrainedModelRequest) returns (TrainedModelResponse) {}
   rpc GetMetricStream(GetMetricStreamRequest) returns (stream GetMetricStreamResponse) {}
@@ -139,6 +140,14 @@ message ExperimentInfo {
 
 message SetNewExperimentResponse{
   bool accepted = 1;
+}
+
+message GetExperimentStatusRequest {
+  string experiment_name = 1;
+}
+
+message GetExperimentStatusResponse {
+  string experiment_status = 1;
 }
 
 message GetTrainedModelRequest {

--- a/openfl/transport/grpc/director_client.py
+++ b/openfl/transport/grpc/director_client.py
@@ -229,6 +229,13 @@ class DirectorClient:
                 yield experiment_info
                 chunk = arch.read(max_buffer_size)
 
+    def get_experiment_status(self, experiment_name):
+        """Check if the experiment was accepted by the director"""
+        logger.info('Get Experiment Status')
+        request = director_pb2.GetExperimentStatusRequest(experiment_name=experiment_name)
+        resp = self.stub.GetExperimentStatus(request)
+        return resp
+
     def get_dataset_info(self):
         """Request the dataset info from the director."""
         resp = self.stub.GetDatasetInfo(director_pb2.GetDatasetInfoRequest())

--- a/openfl/transport/grpc/director_server.py
+++ b/openfl/transport/grpc/director_server.py
@@ -7,6 +7,7 @@ import asyncio
 import logging
 import uuid
 from pathlib import Path
+from typing import Callable
 from typing import Optional
 from typing import Union
 
@@ -40,9 +41,11 @@ class DirectorGRPCServer(director_pb2_grpc.DirectorServicer):
             root_certificate: Optional[Union[Path, str]] = None,
             private_key: Optional[Union[Path, str]] = None,
             certificate: Optional[Union[Path, str]] = None,
+            review_plan_callback: Union[None, Callable] = None,
             listen_host: str = '[::]',
             listen_port: int = 50051,
-            **kwargs,
+            envoy_health_check_period: int = 0,
+            **kwargs
     ) -> None:
         """Initialize a director object."""
         # TODO: add working directory
@@ -61,6 +64,8 @@ class DirectorGRPCServer(director_pb2_grpc.DirectorServicer):
             root_certificate=self.root_certificate,
             private_key=self.private_key,
             certificate=self.certificate,
+            review_plan_callback=review_plan_callback,
+            envoy_health_check_period=envoy_health_check_period,
             **kwargs
         )
 
@@ -155,6 +160,17 @@ class DirectorGRPCServer(director_pb2_grpc.DirectorServicer):
 
         logger.info('Send response')
         return director_pb2.SetNewExperimentResponse(accepted=is_accepted)
+
+    async def GetExperimentStatus(self, request, context):
+        """Get experiment status and update if experiment was approved."""
+        logger.info('GetExperimentStatus request received')
+        caller = self.get_caller(context)
+        experiment_status = await self.director.get_experiment_status(
+            experiment_name=request.experiment_name,
+            caller=caller
+        )
+        logger.info('Send response')
+        return director_pb2.GetExperimentStatusResponse(experiment_status=experiment_status)
 
     async def GetTrainedModel(self, request, context):  # NOQA:N802
         """RPC for retrieving trained models."""

--- a/openfl/utilities/workspace.py
+++ b/openfl/utilities/workspace.py
@@ -26,20 +26,22 @@ class ExperimentWorkspace:
             self,
             experiment_name: str,
             data_file_path: Path,
-            install_requirements: bool = False
+            install_requirements: bool = False,
+            remove_archive: bool = True
     ) -> None:
         """Initialize workspace context manager."""
         self.experiment_name = experiment_name
         self.data_file_path = data_file_path
-        self.cwd = os.getcwd()
-        self.experiment_work_dir = f'{self.cwd}/{self.experiment_name}'
         self.install_requirements = install_requirements
+        self.cwd = Path.cwd()
+        self.experiment_work_dir = self.cwd / self.experiment_name
+        self.remove_archive = remove_archive
 
     def _install_requirements(self):
         """Install experiment requirements."""
-        requirements_filename = f'{self.experiment_work_dir}/requirements.txt'
+        requirements_filename = self.experiment_work_dir / 'requirements.txt'
 
-        if os.path.isfile(requirements_filename):
+        if requirements_filename.is_file():
             attempts = 10
             for _ in range(attempts):
                 try:
@@ -58,8 +60,8 @@ class ExperimentWorkspace:
 
     def __enter__(self):
         """Create a collaborator workspace for the experiment."""
-        if os.path.exists(self.experiment_work_dir):
-            shutil.rmtree(self.experiment_work_dir)
+        if self.experiment_work_dir.exists():
+            shutil.rmtree(self.experiment_work_dir, ignore_errors=True)
         os.makedirs(self.experiment_work_dir)
 
         shutil.unpack_archive(self.data_file_path, self.experiment_work_dir, format='zip')
@@ -75,10 +77,17 @@ class ExperimentWorkspace:
     def __exit__(self, exc_type, exc_value, traceback):
         """Remove the workspace."""
         os.chdir(self.cwd)
-        shutil.rmtree(self.experiment_name, ignore_errors=True)
+        shutil.rmtree(self.experiment_work_dir, ignore_errors=True)
         if self.experiment_work_dir in sys.path:
             sys.path.remove(self.experiment_work_dir)
-        os.remove(self.data_file_path)
+
+        if self.remove_archive:
+            logger.debug(
+                'Exiting from the workspace context manager'
+                f' for {self.experiment_name} experiment'
+            )
+            logger.debug(f'Archive still exists: {self.data_file_path.exists()}')
+            self.data_file_path.unlink(missing_ok=False)
 
 
 def dump_requirements_file(

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,3 @@
-pytest==6.1.2
-pytest-mock==3.4.0
+pytest==7.2.0
+pytest-mock==3.10.0
+pytest-asyncio==0.20.2

--- a/tests/openfl/api_layer/test_experiment.py
+++ b/tests/openfl/api_layer/test_experiment.py
@@ -22,11 +22,11 @@ def experiment_object(federation_object):  # NOQA
 
 def test_initialization(experiment_object):
     """Test experimnet object initialization."""
-    assert not experiment_object.experiment_accepted
+    assert not experiment_object.experiment_submitted
     assert experiment_object.serializer_plugin
 
 
 def test_get_best_model(experiment_object):
     """Test get_best_model method."""
-    with pytest.raises(Exception):
-        experiment_object.get_best_model()
+    model = experiment_object.get_best_model()
+    assert model is None

--- a/tests/openfl/component/director/test_experiment_representation.py
+++ b/tests/openfl/component/director/test_experiment_representation.py
@@ -1,0 +1,50 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Experiment representation class tests module."""
+
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from openfl.component.director.experiment import Experiment
+
+
+@pytest.fixture
+@mock.patch('openfl.component.director.experiment.Path')
+def experiment_rep(_):
+    """Initialize an experiment."""
+    experiment = Experiment(
+        name='test_exp',
+        archive_path=mock.MagicMock(spec_set=Path),
+        collaborators=['test_col'],
+        sender='test_user',
+        init_tensor_dict={},
+    )
+    return experiment
+
+
+@pytest.mark.asyncio
+@mock.patch('openfl.component.director.experiment.ExperimentWorkspace')
+@pytest.mark.parametrize('review_result,archive_unlink_call_count,experiment_status',
+                         [(True, 0, 'pending'), (False, 1, 'rejected')]
+                         )
+async def test_review_experiment(
+    ExperimentWorkspace, experiment_rep, review_result,
+    archive_unlink_call_count, experiment_status
+):
+    """Review experiment method test."""
+    review_callback = mock.Mock()
+    review_callback.return_value = review_result
+
+    result = await experiment_rep.review_experiment(review_plan_callback=review_callback)
+
+    assert result is review_callback.return_value
+    ExperimentWorkspace.assert_called_once_with(
+        'test_exp',
+        experiment_rep.archive_path,
+        is_install_requirements=False,
+        remove_archive=False
+    )
+    assert experiment_rep.archive_path.unlink.call_count == archive_unlink_call_count
+    assert experiment_rep.status == experiment_status


### PR DESCRIPTION
Adding logic for the Director and Envoys to review the received FL experiment plan before starting the experiment. Set 'review_experiment: True' under 'params' in your director and envoy configs to enable review.
If Director declines an experiment, it is aborted right away, no aggregator is started and Envoys do not receive this experiment archive at all.
If any of the Envoys rejects the experiment, a set_experiment_failed request is sent to the director to stop the aggregator.
