### PR TITLE
WIP: Testing communication resilience 

### DIFF
--- a/openfl-docker/Dockerfile.workspace
+++ b/openfl-docker/Dockerfile.workspace
@@ -12,7 +12,7 @@ WORKDIR /home/user
 # Allow user to work in home dir
 RUN chmod -R a+rw .
 # Allow pip to work with existing packages (?)
-RUN chmod -R a+rwx /usr/local
+# RUN chmod -R a+rwx /usr/local
 USER user
 
 ARG WORKSPACE_NAME
@@ -22,4 +22,5 @@ RUN fx workspace import --archive ${WORKSPACE_NAME}.zip
 # Unifying the workspace folder name
 RUN mv ${WORKSPACE_NAME} workspace
 WORKDIR /home/user/workspace
-RUN pip install -r requirements.txt
+
+# RUN pip install -r requirements.txt

--- a/tests/github/docker_disconnecting_test.sh
+++ b/tests/github/docker_disconnecting_test.sh
@@ -7,8 +7,8 @@ set -e
 # 3 - Certify federation, choose any number of collaborators; 4 - run existing containers
 
 STAGE=${1:-1}  
-TEMPLATE=${2:-'keras_cnn_mnist'}  # ['torch_cnn_mnist', 'keras_cnn_mnist']
-NUMBER_OF_COLS=${3:-1}  
+NUMBER_OF_COLS=${2:-1}  
+TEMPLATE=${3:-'keras_cnn_mnist'}  # ['torch_cnn_mnist', 'keras_cnn_mnist']
 
 BASE_IMAGE_TAG='openfl'
 

--- a/tests/github/docker_disconnecting_test.sh
+++ b/tests/github/docker_disconnecting_test.sh
@@ -47,7 +47,7 @@ if [ $STAGE -le 2 ]; then
 fi
 
 if [ $STAGE -le 3 ]; then
-        echo "CERTIFYING ACTORS"
+        echo "CERTIFICATION STAGE"
         cd ${FED_WORKSPACE} || true
         # 3. Generate certificates for the aggregator and the collaborator
 
@@ -106,7 +106,6 @@ process_stream() {
                         echo $line >> triggers.log
                         sleep $RECONNECTION_TIMEOUT && docker network connect ${FED_WORKSPACE} ${COL_NAME} &
                 fi
-                # echo $line
         done
 }
 
@@ -126,8 +125,7 @@ if [ $STAGE -le 4 ]; then
                 -e "CONTAINER_TYPE=aggregator" \
                 --name ${FQDN} \
                 ${WORSPACE_IMAGE_NAME} \
-                bash /openfl/openfl-docker/start_actor_in_container.sh &
-                # --add-host ${FQDN}:127.0.0.1 \ adding this mapping to the aggregator container is not required somehow
+                bash /openfl/openfl-docker/start_actor_in_container.sh | tee aggregator.log &
 
         # Start the collaborator
         for ((i=1; i<=$NUMBER_OF_COLS; i++)); do
@@ -140,7 +138,7 @@ if [ $STAGE -le 4 ]; then
                         -e "COL=${COL_NAME}" \
                         --name ${COL_NAME} \
                         ${WORSPACE_IMAGE_NAME} \
-                        bash /openfl/openfl-docker/start_actor_in_container.sh | tee /dev/tty | process_stream "$CUT_ON_LOG" $RECONNECTION_TIMEOUT
+                        bash /openfl/openfl-docker/start_actor_in_container.sh | tee >(process_stream "$CUT_ON_LOG" $RECONNECTION_TIMEOUT)
         done
 fi
 

--- a/tests/github/docker_disconnecting_test.sh
+++ b/tests/github/docker_disconnecting_test.sh
@@ -1,116 +1,132 @@
 #!/bin/bash
 set -e
 
-# 1. Create the workspace
+# PREREQUISITES: you should have openfl installed + this script should be run from the openfl repo base folder
 
-TEMPLATE=${1:-'keras_cnn_mnist'}  # ['torch_cnn_mnist', 'keras_cnn_mnist']
-FED_WORKSPACE=${2:-'fed_work12345alpha81671'}   # This can be whatever unique directory name you want
-COL=${3:-'col1'}  # This can be any unique label (lowercase)
-DATA_PATH=${4:-1}
-BASE_IMAGE_TAG=${5:-'openfl'}
+# 1 - Start from building the base image; 2 - start from creating a new workspace and dockerizing it;
+# 3 - Certify federation, choose any number of collaborators; 4 - run existing containers
+
+STAGE=${1:-1}  
+TEMPLATE=${2:-'keras_cnn_mnist'}  # ['torch_cnn_mnist', 'keras_cnn_mnist']
+NUMBER_OF_COLS=${3:-1}  
+
+BASE_IMAGE_TAG='openfl'
 
 # If an aggregator container will run on another machine
 # a relevant FQDN should be provided
 FQDN='agg'
-
-# Build base image
-bash ./scripts/build_base_docker_image.sh ${BASE_IMAGE_TAG}
-
-# Create FL workspace
-rm -rf ${FED_WORKSPACE}
-fx workspace create --prefix ${FED_WORKSPACE} --template ${TEMPLATE}
-cd ${FED_WORKSPACE}
-FED_DIRECTORY=`pwd`  # Get the absolute directory path for the workspace
-
-# Initialize FL plan
-fx plan initialize -a ${FQDN}
-
-# 2. Build the workspace image and save it to a tarball
-
-# This commant builds an image tagged $FED_WORKSPACE
-# Then it saves it to a ${FED_WORKSPACE}_image.tar
-fx workspace dockerize --base_image ${BASE_IMAGE_TAG} --no-save
-
-# We remove the base OpenFL image as well
-# as built workspace image to simulate starting 
-# on another machine
+FED_WORKSPACE='test-federation'   # This can be whatever unique directory name you want
 WORSPACE_IMAGE_NAME=${FED_WORKSPACE}
-# docker image rm -f ${BASE_IMAGE_TAG} ${WORSPACE_IMAGE_NAME}
-
-
-# 3. Generate certificates for the aggregator and the collaborator
-
-# Create certificate authority for the workspace
-fx workspace certify
-
-# We do certs exchage for all participants in a single workspace
-# to speed up this test run.
-# Do not do this in real experiments
-# in untrusted environments
-create_signed_cert_for_collaborator() {
-        COL_NAME=$1
-        DATA_PATH=$2
-        echo "certifying collaborator $COL_NAME with data path $DATA_PATH"
-        # Create collaborator certificate request
-        fx collaborator generate-cert-request -d ${DATA_PATH} -n ${COL_NAME} --silent
-        # Sign collaborator certificate 
-        fx collaborator certify --request-pkg col_${COL_NAME}_to_agg_cert_request.zip --silent
-
-        # Pack the collaborators private key and the signed cert
-        # as well as it's data.yaml to a tarball
-        tar -cf cert_col_${COL_NAME}.tar plan/data.yaml \
-                cert/client/*key agg_to_col_${COL_NAME}_signed_cert.zip --remove-files 
-
-        # Remove request archive
-        rm -rf col_${COL_NAME}_to_agg_cert_request.zip
-}
-
-# Prepare a tarball with the collab's private key, the singed cert,
-# and data.yaml for collaborator container
-# This step can be repeated for each collaborator
-create_signed_cert_for_collaborator ${COL} ${DATA_PATH} 
-
-# Also perform certificate generation for the aggregator.
-# Create aggregator certificate
-fx aggregator generate-cert-request --fqdn ${FQDN}
-# Sign aggregator certificate
-fx aggregator certify --fqdn ${FQDN} --silent # Remove '--silent' if you run this manually
-
-# Pack all files that aggregator need to start training
 AGGREGATOR_REQUIRED_FILES='cert_agg.tar'
-tar -cf ${AGGREGATOR_REQUIRED_FILES} plan/ cert/ save/ --remove-files 
+
+if [ $STAGE -le 1 ]; then
+        echo "BUILDING OPENFL BASE IMAGE"
+        # 1. Build base image
+        bash ./scripts/build_base_docker_image.sh ${BASE_IMAGE_TAG}
+fi
+
+if [ $STAGE -le 2 ]; then
+        echo "CREATING EXPERIMENT WORKSPACE"
+        # 2. Create the workspace
+        # Create FL workspace
+        rm -rf ${FED_WORKSPACE}
+        fx workspace create --prefix ${FED_WORKSPACE} --template ${TEMPLATE}
+        cd ${FED_WORKSPACE}
+        FED_DIRECTORY=`pwd`  # Get the absolute directory path for the workspace
+
+        # Initialize FL plan
+        fx plan initialize -a ${FQDN}
+
+        # Build the workspace image and save it to a tarball
+
+        # This commant builds an image tagged $FED_WORKSPACE
+        # Then it saves it to a ${FED_WORKSPACE}_image.tar
+        fx workspace dockerize --base_image ${BASE_IMAGE_TAG} --no-save
+fi
+
+if [ $STAGE -le 3 ]; then
+        echo "CERTIFYING ACTORS"
+        cd ${FED_WORKSPACE} || true
+        # 3. Generate certificates for the aggregator and the collaborator
+
+        # Create certificate authority for the workspace
+        fx workspace certify
+
+        # We do certs exchage for all participants in a single workspace
+        # to speed up this test run.
+        # Do not do this in real experiments
+        # in untrusted environments
+        create_signed_cert_for_collaborator() {
+                COL_NAME=$1
+                DATA_PATH=$2
+                echo "certifying collaborator $COL_NAME with data path $DATA_PATH"
+                # Create collaborator certificate request
+                fx collaborator generate-cert-request -d ${DATA_PATH} -n ${COL_NAME} --silent
+                # Sign collaborator certificate 
+                fx collaborator certify --request-pkg col_${COL_NAME}_to_agg_cert_request.zip --silent
+
+                # Pack the collaborators private key and the signed cert
+                # as well as it's data.yaml to a tarball
+                tar -cf cert_col_${COL_NAME}.tar plan/data.yaml \
+                        cert/client/*key agg_to_col_${COL_NAME}_signed_cert.zip --remove-files 
+
+                # Remove request archive
+                rm -rf col_${COL_NAME}_to_agg_cert_request.zip
+        }
+
+        # Prepare a tarball with the collab's private key, the singed cert,
+        # and data.yaml for collaborator container
+        # This step can be repeated for each collaborator
+        for ((i=1; i<=$NUMBER_OF_COLS; i++)); do
+                COL_NAME="col$i"
+                DATA_PATH=$i
+                create_signed_cert_for_collaborator ${COL_NAME} ${DATA_PATH} 
+        done
+
+        # Also perform certificate generation for the aggregator.
+        # Create aggregator certificate
+        fx aggregator generate-cert-request --fqdn ${FQDN}
+        # Sign aggregator certificate
+        fx aggregator certify --fqdn ${FQDN} --silent # Remove '--silent' if you run this manually
+
+        # Pack all files that aggregator need to start training
+        tar -cf ${AGGREGATOR_REQUIRED_FILES} plan/ cert/ save/
+fi
 
 
-# 4. Load the image
-# IMAGE_TAR=${FED_WORKSPACE}_image.tar
-# docker load --input $IMAGE_TAR
+if [ $STAGE -le 4 ]; then
+        echo "RUNNING FEDERATION IN DOCKER CONTAINERS"
+        # 4. Start federation in containers
+        cd ${FED_WORKSPACE} || true
+
+        # Create a docker network
+        docker network create ${FED_WORKSPACE} || true
 
 
-# 5. Start federation in containers
+        # Start the aggregator
+        docker run --rm \
+                --network ${FED_WORKSPACE} \
+                -v $(pwd)/${AGGREGATOR_REQUIRED_FILES}:/certs.tar \
+                -e "CONTAINER_TYPE=aggregator" \
+                --name ${FQDN} \
+                ${WORSPACE_IMAGE_NAME} \
+                bash /openfl/openfl-docker/start_actor_in_container.sh &
+                # --add-host ${FQDN}:127.0.0.1 \ adding this mapping to the aggregator container is not required somehow
 
-# Create a docker network
-docker network create ${FED_WORKSPACE} || true
-
-# Start the aggregator
-docker run --rm \
-        --network ${FED_WORKSPACE} \
-        -v $(pwd)/${AGGREGATOR_REQUIRED_FILES}:/certs.tar \
-        -e "CONTAINER_TYPE=aggregator" \
-        --name ${FQDN} \
-        ${WORSPACE_IMAGE_NAME} \
-        bash /openfl/openfl-docker/start_actor_in_container.sh &
-        # --add-host ${FQDN}:127.0.0.1 \ adding this mapping to the aggregator container is not required somehow
-
-# Start the collaborator
-docker run --rm \
-        --network ${FED_WORKSPACE} \
-        -v $(pwd)/cert_col_${COL_NAME}.tar:/certs.tar \
-        -e "CONTAINER_TYPE=collaborator" \
-        -e "no_proxy=${FQDN}" \
-        -e "COL=${COL_NAME}" \
-        --name ${COL_NAME} \
-        ${WORSPACE_IMAGE_NAME} \
-        bash /openfl/openfl-docker/start_actor_in_container.sh  &
+        # Start the collaborator
+        for ((i=1; i<=$NUMBER_OF_COLS; i++)); do
+                COL_NAME='col'$i
+                docker run --rm \
+                        --network ${FED_WORKSPACE} \
+                        -v $(pwd)/cert_col_${COL_NAME}.tar:/certs.tar \
+                        -e "CONTAINER_TYPE=collaborator" \
+                        -e "no_proxy=${FQDN}" \
+                        -e "COL=${COL_NAME}" \
+                        --name ${COL_NAME} \
+                        ${WORSPACE_IMAGE_NAME} \
+                        bash /openfl/openfl-docker/start_actor_in_container.sh  &
+        done
+fi
 
 
 sleep 20

--- a/tests/github/docker_disconnecting_test.sh
+++ b/tests/github/docker_disconnecting_test.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+set -e
+
+# 1. Create the workspace
+
+TEMPLATE=${1:-'keras_cnn_mnist'}  # ['torch_cnn_mnist', 'keras_cnn_mnist']
+FED_WORKSPACE=${2:-'fed_work12345alpha81671'}   # This can be whatever unique directory name you want
+COL=${3:-'col1'}  # This can be any unique label (lowercase)
+DATA_PATH=${4:-1}
+BASE_IMAGE_TAG=${5:-'openfl'}
+
+# If an aggregator container will run on another machine
+# a relevant FQDN should be provided
+FQDN='agg'
+
+# Build base image
+bash ./scripts/build_base_docker_image.sh ${BASE_IMAGE_TAG}
+
+# Create FL workspace
+rm -rf ${FED_WORKSPACE}
+fx workspace create --prefix ${FED_WORKSPACE} --template ${TEMPLATE}
+cd ${FED_WORKSPACE}
+FED_DIRECTORY=`pwd`  # Get the absolute directory path for the workspace
+
+# Initialize FL plan
+fx plan initialize -a ${FQDN}
+
+# 2. Build the workspace image and save it to a tarball
+
+# This commant builds an image tagged $FED_WORKSPACE
+# Then it saves it to a ${FED_WORKSPACE}_image.tar
+fx workspace dockerize --base_image ${BASE_IMAGE_TAG} --no-save
+
+# We remove the base OpenFL image as well
+# as built workspace image to simulate starting 
+# on another machine
+WORSPACE_IMAGE_NAME=${FED_WORKSPACE}
+# docker image rm -f ${BASE_IMAGE_TAG} ${WORSPACE_IMAGE_NAME}
+
+
+# 3. Generate certificates for the aggregator and the collaborator
+
+# Create certificate authority for the workspace
+fx workspace certify
+
+# We do certs exchage for all participants in a single workspace
+# to speed up this test run.
+# Do not do this in real experiments
+# in untrusted environments
+create_signed_cert_for_collaborator() {
+        COL_NAME=$1
+        DATA_PATH=$2
+        echo "certifying collaborator $COL_NAME with data path $DATA_PATH"
+        # Create collaborator certificate request
+        fx collaborator generate-cert-request -d ${DATA_PATH} -n ${COL_NAME} --silent
+        # Sign collaborator certificate 
+        fx collaborator certify --request-pkg col_${COL_NAME}_to_agg_cert_request.zip --silent
+
+        # Pack the collaborators private key and the signed cert
+        # as well as it's data.yaml to a tarball
+        tar -cf cert_col_${COL_NAME}.tar plan/data.yaml \
+                cert/client/*key agg_to_col_${COL_NAME}_signed_cert.zip --remove-files 
+
+        # Remove request archive
+        rm -rf col_${COL_NAME}_to_agg_cert_request.zip
+}
+
+# Prepare a tarball with the collab's private key, the singed cert,
+# and data.yaml for collaborator container
+# This step can be repeated for each collaborator
+create_signed_cert_for_collaborator ${COL} ${DATA_PATH} 
+
+# Also perform certificate generation for the aggregator.
+# Create aggregator certificate
+fx aggregator generate-cert-request --fqdn ${FQDN}
+# Sign aggregator certificate
+fx aggregator certify --fqdn ${FQDN} --silent # Remove '--silent' if you run this manually
+
+# Pack all files that aggregator need to start training
+AGGREGATOR_REQUIRED_FILES='cert_agg.tar'
+tar -cf ${AGGREGATOR_REQUIRED_FILES} plan/ cert/ save/ --remove-files 
+
+
+# 4. Load the image
+# IMAGE_TAR=${FED_WORKSPACE}_image.tar
+# docker load --input $IMAGE_TAR
+
+
+# 5. Start federation in containers
+
+# Start the aggregator
+docker run --rm \
+        --network host \
+        -v $(pwd)/${AGGREGATOR_REQUIRED_FILES}:/certs.tar \
+        -e "CONTAINER_TYPE=aggregator" \
+        --name "agg" \
+        ${WORSPACE_IMAGE_NAME} \
+        bash /openfl/openfl-docker/start_actor_in_container.sh &
+
+# docker run --rm --network host -v $(pwd)/'fed_work12345alpha81671/cert_agg.tar':/certs.tar -e "CONTAINER_TYPE=aggregator" --name "agg" 'fed_work12345alpha81671' bash /openfl/openfl-docker/start_actor_in_container.sh &
+# docker run --rm --publish-all -v $(pwd)/'fed_work12345alpha81671/cert_agg.tar':/certs.tar -e "CONTAINER_TYPE=aggregator" --name "agg" 'fed_work12345alpha81671' bash /openfl/openfl-docker/start_actor_in_container.sh &
+
+# Start the collaborator
+docker run --rm \
+        --network host \
+        -v $(pwd)/cert_col_${COL_NAME}.tar:/certs.tar \
+        -e "CONTAINER_TYPE=collaborator" \
+        --name ${COL_NAME} \
+        -e "COL=${COL_NAME}" \
+        ${WORSPACE_IMAGE_NAME} \
+        bash /openfl/openfl-docker/start_actor_in_container.sh 
+
+# COL_NAME=col1 && docker run --rm --network host -v $(pwd)/fed_work12345alpha81671/cert_col_${COL_NAME}.tar:/certs.tar -e "CONTAINER_TYPE=collaborator" -e "COL=${COL_NAME}" --name ${COL_NAME} 'fed_work12345alpha81671' bash /openfl/openfl-docker/start_actor_in_container.sh &
+# COL_NAME=col1 && docker run --rm -v $(pwd)/fed_work12345alpha81671/cert_col_${COL_NAME}.tar:/certs.tar -e "CONTAINER_TYPE=collaborator" -e "COL=${COL_NAME}" --name ${COL_NAME} 'fed_work12345alpha81671' bash /openfl/openfl-docker/start_actor_in_container.sh &
+
+
+# If containers are started but collaborator will fail to 
+# conect the aggregator, the pipeline will go to the infinite loop

--- a/tests/github/test_connection_resilience.py
+++ b/tests/github/test_connection_resilience.py
@@ -1,0 +1,164 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from argparse import ArgumentParser
+import socket
+from subprocess import check_call
+import shutil
+import os
+from pathlib import Path
+import tarfile
+import time
+from concurrent.futures import ProcessPoolExecutor
+
+from tests.github.utils import edit_plan_yaml
+from tests.github.utils import create_signed_cert_for_collaborator
+
+ROUNDS_TO_TRAIN = 2
+DATA_REDUCTION_FACTOR = 10
+
+if __name__ == '__main__':
+    # 1. Create the workspace
+    parser = ArgumentParser()
+    workspace_choice = []
+    with os.scandir('openfl-workspace') as iterator:
+        for entry in iterator:
+            if entry.name not in ['__init__.py', 'workspace', 'default']:
+                workspace_choice.append(entry.name)
+    parser.add_argument('--template', default='torch_unet_kvasir_gramine_ready',
+                        choices=workspace_choice)
+    parser.add_argument('--fed_workspace', default='test_federation')
+    parser.add_argument('--reconnection_timeout', default='10', help='in seconds')
+    parser.add_argument('--number_of_collaborators', type=int, default='1')
+    parser.add_argument('--start_stage', type=int, default=1,
+                        help='1 - start from building a base OpenFL image \n' +
+                        '2 - start from creating a workspace \n' +
+                        '3 - start from building a dockerized workspace image \n' +
+                        '4 - run Federation')
+    args = parser.parse_args()
+    fed_workspace = args.fed_workspace
+    workspace_image_name = fed_workspace
+    reconnection_timeout = args.reconnection_timeout
+    n_cols = args.number_of_collaborators
+    stage = args.start_stage
+    col_names = [f'col_{i+1}' for i in range(n_cols)]
+    col_data_paths = [str(i) for i in range(1, n_cols + 1)]
+    base_image_tag = 'openfl'
+    aggregator_container_name = 'aggregatorContainer'
+    # collaborator_container_base_name = f'{fed_workspace}_collaborator_container'
+
+    # FQDN here is the name of Aggregator container
+    fqdn = aggregator_container_name
+
+    # Get the absolute directory path for the workspace
+    fed_directory = Path().resolve() / fed_workspace
+
+    if stage == 1:
+        # Build base image
+        check_call([
+            'docker', 'build', '-t', base_image_tag, '-f', 'openfl-docker/Dockerfile.base', '.'
+        ])
+
+    if stage <= 2:
+        # Create FL workspace
+        shutil.rmtree(fed_directory, ignore_errors=True)
+        check_call([
+            'fx', 'workspace', 'create', '--prefix', fed_workspace, '--template', args.template
+        ])
+        os.chdir(fed_directory)
+
+        # Chenging experiment settings
+        plan_path = fed_directory / 'plan' / 'plan.yaml'
+        settings_dict = {
+            'aggregator.settings.rounds_to_train': ROUNDS_TO_TRAIN,
+            'data_loader.settings.collaborator_count': n_cols * DATA_REDUCTION_FACTOR,
+        }
+        edit_plan_yaml(plan_path, settings_dict)
+
+        # Initialize FL plan
+        check_call(['fx', 'plan', 'initialize', '-a', fqdn])
+
+    if stage <= 3:
+        os.chdir(fed_directory)
+        # 2. Build the workspace image
+        # This commant builds an image tagged $fed_workspace
+        check_call(['fx', 'workspace', 'dockerize', '--base_image', base_image_tag, '--no-save'])
+
+    if stage <= 4:
+        # 3. Generate certificates for the aggregator and the collaborator
+
+        os.chdir(fed_directory)
+        # Create certificate authority for the workspace
+        check_call(['fx', 'workspace', 'certify'])
+
+        # Then perform certificate generation for the aggregator.
+        # Create aggregator certificate
+        check_call(['fx', 'aggregator', 'generate-cert-request', '--fqdn', fqdn])
+        # Sign aggregator certificate
+        # Remove '--silent' if you run this manually
+        check_call(['fx', 'aggregator', 'certify', '--fqdn', fqdn, '--silent'])
+        # Pack all files that aggregator need to start training
+
+        collaborator_required_files = []
+        for i in range(n_cols):
+            # Prepare a tarball with the collab's private key, the singed cert,
+            # and data.yaml for collaborator container
+            # This step can be repeated for each collaborator
+            path_ = create_signed_cert_for_collaborator(col_names[i], col_data_paths[i])
+            collaborator_required_files.append(path_)
+
+        aggregator_required_files = fed_directory / 'cert_agg.tar'
+        with tarfile.open(aggregator_required_files, 'w') as f:
+            for d in ['plan', 'cert', 'save']:
+                f.add(d)
+                # shutil.rmtree(d)
+
+        # 4. Run the Federation
+        try:
+            # Create a Docker Network
+            docker_network_name = f'{fed_workspace}_network'
+            check_call(f'docker network create {docker_network_name} || true', shell=True)
+
+            def start_aggregator_command():
+                check_call(
+                    'docker run --rm '
+                    f'--network {docker_network_name} '
+                    f'-v {aggregator_required_files}:/certs.tar '
+                    '-e \"CONTAINER_TYPE=aggregator\" '
+                    f'--name {aggregator_container_name} '
+                    f'{workspace_image_name} '
+                    'bash /openfl/openfl-docker/start_actor_in_container.sh',
+                    shell=True)
+
+            def start_collaborator_command(index):
+                check_call(
+                    'docker run --rm '
+                    f'--network {docker_network_name} '
+                    f'-v {collaborator_required_files[index]}:/certs.tar '
+                    '-e \"CONTAINER_TYPE=collaborator\" '
+                    f'-e \"no_proxy={aggregator_container_name}\" '
+                    f'-e \"COL={col_names[index]}\" '
+                    f'--name {col_names[index]} '
+                    f'{workspace_image_name} '
+                    'bash /openfl/openfl-docker/start_actor_in_container.sh',
+                    shell=True)
+
+            with ProcessPoolExecutor(max_workers=n_cols + 1) as executor:
+                executor.submit(
+                    start_aggregator_command
+                )
+                time.sleep(3)
+                for i in range(n_cols):
+                    executor.submit(
+                        start_collaborator_command, i
+                    )
+        except Exception as e:
+            print(e)
+        finally:
+            check_call(
+                f'docker stop {aggregator_container_name} {" ".join(col_names)} || true',
+                shell=True)
+            check_call(f'docker network rm {docker_network_name}', shell=True)
+
+        # If containers are started but collaborator will fail to
+        # conect the aggregator, the pipeline will go to the infinite loop


### PR DESCRIPTION
This PR introduces a bash script that emulates cutting a network connection of one or several FL actors.
All the actors run in docker containers and are connected to a docker network, disconnection may be triggered by certain log output in a container's stdout.

There are several experiments, that may be conducted to test Collaborator's tolerance to network breakage:
A. cut it off when it is CPU bound, performing some calculations
B. cut it off when it is waiting for an Aggregators response
C. cut it off when it is sending a message
D. cut it off when it is receiving a message

Luckily, Collaborator's gRPC client features exactly 3 RPCs: `get_tasks`, `get_aggregated_tensor`, and `send_local_task_results`.
There is a peculiarity regarding Collaborator's gRPC client implementation: fetching an aggregated model from the collaborator happens on a tensor per tensor basis while a local model is sent in one piece, in a stream. Therefore it would be easier to catch A collaborator sending data than receiving.

How to use:
1. You need a clean supported Python virtual environment + upgraded pip + openfl installed.
2. Source the script itself with desired parameters, it will create all the required artifacts.
3. `test-federation` will contain logs for all the actors you can analyze.

Please note that our tests still require a lot of intervention to the script, thus treat it as just a base layer.
The script accepts the following parameters:
- `STAGE`- integer. 1 - Start by building the base image; 2 - Start by creating a new workspace and dockerizing it;  3 - Certify federation, choose any number of collaborators; 4 - Run the existing image 
 - `NUMBER_OF_COLS` - integer. You can start as many collaborators as you want, but the script will disconnect only the last one!
 - `RECONNECTION_TIMEOUT` - integer, seconds. Timeout to connect the last collaborator back to the network.
 - `MAXIMUM_DISCONNECTIONS` - integer. In case you want to limit the number of disconnections throughout the experiment.
 - `CUT_ON_LOG` - string. A pattern in logs that will trigger disconnections. In the script, wildcards are used to detect the pattern.
 - `TEMPLATE` - string. OpenFL template to use.

## Returning back to the experiments.

### A: cut it off when it is CPU bound, performing some calculations.
We can use the `Run 0 epoch of N round` log message in the `keras_cnn_mnist` experiment to trigger disconnection while the collaborator does computations with the command:
`bash tests/github/docker_disconnecting_test.sh 1 2 20 1 "Run 0 epoch of 1 round"`
It will disconnect the second collaborator when training for the first round starts. 20 seconds of disconnection is enough in this case. The collaborator will be affected once it tries to send the task results. It recovers, seemingly thanks to #465, that resends task results if we get `grpc.StatusCode.UNKNOWN` error code on the client side. Logs are attached
[A_aggregator.log](https://github.com/intel/openfl/files/9526054/A_aggregator.log)
[A_collaborator1.log](https://github.com/intel/openfl/files/9526056/A_collaborator1.log)
[A_collaborator2.log](https://github.com/intel/openfl/files/9526055/A_collaborator2.log)

### B: cut it off when it is waiting for an Aggregators response

### C: cut it off when it is sending a message.
We can use  `send_local_task_results` RPC to drop the connection while sending task results.
Here is the exact command that I used. "Setting stream chunks with size 10" is a debug message inside the RPC, 10 is a number specific to the default `keras_cnn_mnist` experiment.
`bash tests/github/docker_disconnecting_test.sh 4 2 20 2 "Setting stream chunks with size 10"`
Logs are attached, TLDR: the disconnected collaborator never recovers after reconnection.
[C_aggregator.log](https://github.com/intel/openfl/files/9525941/C_aggregator.log)
[C_collaborator1.log](https://github.com/intel/openfl/files/9525943/C_collaborator1.log)
[C_collaborator2.log](https://github.com/intel/openfl/files/9525942/C_collaborator2.log)