### PR TITLE
Add ISV product ID and ISV SVN fields to manifest

### DIFF
--- a/openfl-gramine/Makefile
+++ b/openfl-gramine/Makefile
@@ -1,5 +1,9 @@
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
+# Enclave attributes to the manifest
+SGX_ISVPRODID ?= 0
+SGX_ISVSVN ?= 0
+
 # This is a signer key on the BUILDING machine
 SGX_SIGNER_KEY ?= /key.pem
 
@@ -20,6 +24,8 @@ openfl.manifest: openfl.manifest.template
 	gramine-manifest \
 		-Dlog_level=$(GRAMINE_LOG_LEVEL) \
 		-Darch_libdir=$(ARCH_LIBDIR) \
+		-Disvprodid=$(SGX_ISVPRODID) \
+		-Disvsvn=$(SGX_ISVSVN) \
 		-Dno_proxy=$(no_proxy) \
 		-Dhttp_proxy=$(http_proxy) \
 		-Dhttps_proxy=$(https_proxy) \

--- a/openfl-gramine/openfl.manifest.template
+++ b/openfl-gramine/openfl.manifest.template
@@ -51,6 +51,9 @@ sys.stack.size = "4M"
 sgx.thread_num = 512
 #sys.brk.max_size = "1M"
 
+sgx.isvprodid = {{ isvprodid }}
+sgx.isvsvn = {{ isvsvn }}
+
 sgx.trusted_files = [
   "file:/usr/local/bin/python3.8",
   "file:{{ gramine.runtimedir() }}/",


### PR DESCRIPTION
ISV product ID and ISV SVN fields are defined and signed in SIGSTRUCT. In Gramine, they are defined in the manifest and then used on enclave signing in enclave build flow. Add the option to configure them in OpenFL manifest with new flags to the makefile: SGX_ISVPRODID and SGX_ISVSVN. Their default values are 0, to maintain backwards compatibility.

Currently ISV SVN is configurable in build time, but this is not necessarily the desired behavior. Required behavior is open for discussion and should be updated once a decision is made.

Related issue: #501 