### PR TITLE
Tutorials fixes

### DIFF
--- a/openfl-tutorials/Federated_PyTorch_UNET_Tutorial.ipynb
+++ b/openfl-tutorials/Federated_PyTorch_UNET_Tutorial.ipynb
@@ -76,8 +76,8 @@
    "outputs": [],
    "source": [
     "!wget 'https://datasets.simula.no/downloads/hyper-kvasir/hyper-kvasir-segmented-images.zip' -O kvasir.zip\n",
-    "ZIP_SHA384 = 'e30d18a772c6520476e55b610a4db457237f151e'\\\n",
-    "    '19182849d54b49ae24699881c1e18e0961f77642be900450ef8b22e7'\n",
+    "ZIP_SHA384 = ('66cd659d0e8afd8c83408174'\n",
+    "            '1ade2b75dada8d4648b816f2533c8748b1658efa3d49e205415d4116faade2c5810e241e')\n",
     "validate_file_hash('./kvasir.zip', ZIP_SHA384)\n",
     "!unzip -n kvasir.zip -d ./data"
    ]
@@ -525,8 +525,19 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.8.10 64-bit",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "name": "python",
+   "version": "3.8.10"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "916dbcbb3f70747c44a77c7bcd40155683ae19c65e1c03b4aa3499c5328201f1"
+   }
   }
  },
  "nbformat": 4,

--- a/openfl-tutorials/interactive_api/PyTorch_Kvasir_UNet/envoy/kvasir_shard_descriptor.py
+++ b/openfl-tutorials/interactive_api/PyTorch_Kvasir_UNet/envoy/kvasir_shard_descriptor.py
@@ -100,8 +100,8 @@ class KvasirShardDescriptor(ShardDescriptor):
             "hyper-kvasir/hyper-kvasir-segmented-images.zip'"
             f' -O {zip_file_path.relative_to(Path.cwd())}'
         )
-        zip_sha384 = ('e30d18a772c6520476e55b610a4db457237f151e'
-                      '19182849d54b49ae24699881c1e18e0961f77642be900450ef8b22e7')
+        zip_sha384 = ('66cd659d0e8afd8c83408174'
+                      '1ade2b75dada8d4648b816f2533c8748b1658efa3d49e205415d4116faade2c5810e241e')
         validate_file_hash(zip_file_path, zip_sha384)
         os.system(f'unzip -n {zip_file_path.relative_to(Path.cwd())}'
                   f' -d {data_folder.relative_to(Path.cwd())}')

--- a/openfl-tutorials/interactive_api/PyTorch_Kvasir_UNet/envoy/kvasir_shard_descriptor_with_data_splitter.py
+++ b/openfl-tutorials/interactive_api/PyTorch_Kvasir_UNet/envoy/kvasir_shard_descriptor_with_data_splitter.py
@@ -97,8 +97,8 @@ class KvasirShardDescriptor(ShardDescriptor):
                   " 'https://datasets.simula.no/downloads/hyper-kvasir/"
                   "hyper-kvasir-segmented-images.zip'"
                   f' -O {zip_file_path.relative_to(Path.cwd())}')
-        zip_sha384 = ('e30d18a772c6520476e55b610a4db457237f151e'
-                      '19182849d54b49ae24699881c1e18e0961f77642be900450ef8b22e7')
+        zip_sha384 = ('66cd659d0e8afd8c83408174'
+                      '1ade2b75dada8d4648b816f2533c8748b1658efa3d49e205415d4116faade2c5810e241e')
         validate_file_hash(zip_file_path, zip_sha384)
         os.system(f'unzip -n {zip_file_path.relative_to(Path.cwd())}'
                   f' -d {data_folder.relative_to(Path.cwd())}')

--- a/openfl-workspace/torch_unet_kvasir/src/data_loader.py
+++ b/openfl-workspace/torch_unet_kvasir/src/data_loader.py
@@ -32,7 +32,7 @@ def read_data(image_path, mask_path):
 
     """
     img = io.imread(image_path)
-    assert(img.shape[2] == 3)
+    assert (img.shape[2] == 3)
     mask = io.imread(mask_path)
     return (img, mask[:, :, 0].astype(np.uint8))
 
@@ -59,7 +59,7 @@ class KvasirDataset(Dataset):
 
         self.images_names = self.images_names[shard_num:: collaborator_count]
         self.is_validation = is_validation
-        assert(len(self.images_names) > 8)
+        assert (len(self.images_names) > 8)
         validation_size = len(self.images_names) // 8
 
         if is_validation:
@@ -92,8 +92,8 @@ class KvasirDataset(Dataset):
 
 def load_kvasir_dataset():
     """Load and unzip kvasir dataset."""
-    zip_sha384 = ('e30d18a772c6520476e55b610a4db457237f151e'
-                  '19182849d54b49ae24699881c1e18e0961f77642be900450ef8b22e7')
+    zip_sha384 = ('66cd659d0e8afd8c83408174'
+                  '1ade2b75dada8d4648b816f2533c8748b1658efa3d49e205415d4116faade2c5810e241e')
     data_url = ('https://datasets.simula.no/downloads/'
                 'hyper-kvasir/hyper-kvasir-segmented-images.zip')
     filename = 'kvasir.zip'

--- a/openfl-workspace/torch_unet_kvasir_gramine_ready/src/data_loader.py
+++ b/openfl-workspace/torch_unet_kvasir_gramine_ready/src/data_loader.py
@@ -32,7 +32,7 @@ def read_data(image_path, mask_path):
 
     """
     img = io.imread(image_path)
-    assert(img.shape[2] == 3)
+    assert (img.shape[2] == 3)
     mask = io.imread(mask_path)
     return (img, mask[:, :, 0].astype(np.uint8))
 
@@ -59,7 +59,7 @@ class KvasirDataset(Dataset):
 
         self.images_names = self.images_names[shard_num:: collaborator_count]
         self.is_validation = is_validation
-        assert(len(self.images_names) > 8)
+        assert (len(self.images_names) > 8)
         validation_size = len(self.images_names) // 8
 
         if is_validation:
@@ -92,8 +92,8 @@ class KvasirDataset(Dataset):
 
 def load_kvasir_dataset():
     """Load and unzip kvasir dataset."""
-    zip_sha384 = ('e30d18a772c6520476e55b610a4db457237f151e'
-                  '19182849d54b49ae24699881c1e18e0961f77642be900450ef8b22e7')
+    zip_sha384 = ('66cd659d0e8afd8c83408174'
+                  '1ade2b75dada8d4648b816f2533c8748b1658efa3d49e205415d4116faade2c5810e241e')
     data_url = ('https://datasets.simula.no/downloads/'
                 'hyper-kvasir/hyper-kvasir-segmented-images.zip')
     filename = 'kvasir.zip'

--- a/tests/github/interactive_api_director/experiments/pytorch_kvasir_unet/data_loader.py
+++ b/tests/github/interactive_api_director/experiments/pytorch_kvasir_unet/data_loader.py
@@ -8,8 +8,8 @@ def load_data():
     os.makedirs('data', exist_ok=True)
     os.system("wget -nc 'https://datasets.simula.no/downloads/hyper-kvasir/hyper-kvasir-segmented-images.zip'"
               " -O ./data/kvasir.zip")
-    zip_sha384 = 'e30d18a772c6520476e55b610a4db457237f151e' \
-                 '19182849d54b49ae24699881c1e18e0961f77642be900450ef8b22e7'
+    zip_sha384 = ('66cd659d0e8afd8c83408174'
+                  '1ade2b75dada8d4648b816f2533c8748b1658efa3d49e205415d4116faade2c5810e241e')
     validate_file_hash('./data/kvasir.zip', zip_sha384)
     os.system('unzip -n ./data/kvasir.zip -d ./data')
 

--- a/tests/github/interactive_api_director/experiments/pytorch_kvasir_unet/envoy/kvasir_shard_descriptor.py
+++ b/tests/github/interactive_api_director/experiments/pytorch_kvasir_unet/envoy/kvasir_shard_descriptor.py
@@ -97,8 +97,8 @@ class KvasirShardDescriptor(ShardDescriptor):
         os.system('wget -nc'
                   " 'https://datasets.simula.no/downloads/hyper-kvasir/hyper-kvasir-segmented-images.zip'"
                   f' -O {zip_file_path.relative_to(Path.cwd())}')
-        zip_sha384 = ('e30d18a772c6520476e55b610a4db457237f151e'
-                      '19182849d54b49ae24699881c1e18e0961f77642be900450ef8b22e7')
+        zip_sha384 = ('66cd659d0e8afd8c83408174'
+                      '1ade2b75dada8d4648b816f2533c8748b1658efa3d49e205415d4116faade2c5810e241e')
         validate_file_hash(zip_file_path, zip_sha384)
         os.system(f'unzip -n {zip_file_path.relative_to(Path.cwd())}'
                   f' -d {data_folder.relative_to(Path.cwd())}')


### PR DESCRIPTION
This PR fixes broken tutorials.
In particular, the Kvasir dataset archive now has a new hash, which is strange as their website states the dataset has not changed since 2020. This change affects several tutorials and workspaces.

closes #505 