### PR TITLE
Support Python 3.9 and 3.10

### DIFF
--- a/.github/workflows/taskrunner_python_3.10.yml
+++ b/.github/workflows/taskrunner_python_3.10.yml
@@ -1,0 +1,32 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: TaskRunner (Python 3.10)
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .
+    - name: Test TaskRunner API
+      run: |
+        bash tests/github/test_hello_federation.sh keras_cnn_mnist aggregator col1 col2 $(hostname --all-fqdns | awk '{print $1}') --rounds-to-train 3

--- a/.github/workflows/taskrunner_python_3.9.yml
+++ b/.github/workflows/taskrunner_python_3.9.yml
@@ -1,0 +1,32 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: TaskRunner (Python 3.9)
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.9"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .
+    - name: Test TaskRunner API
+      run: |
+        bash tests/github/test_hello_federation.sh keras_cnn_mnist aggregator col1 col2 $(hostname --all-fqdns | awk '{print $1}') --rounds-to-train 3

--- a/openfl-tutorials/interactive_api/Tensorflow_Word_Prediction/workspace/requirements.txt
+++ b/openfl-tutorials/interactive_api/Tensorflow_Word_Prediction/workspace/requirements.txt
@@ -1,2 +1,2 @@
-tensorflow==2.7.4
+tensorflow==2.8.3
 numpy==1.22.2

--- a/openfl-tutorials/interactive_api/Tensorflow_Word_Prediction/workspace/requirements.txt
+++ b/openfl-tutorials/interactive_api/Tensorflow_Word_Prediction/workspace/requirements.txt
@@ -1,2 +1,2 @@
-tensorflow==2.7.2
+tensorflow==2.7.4
 numpy==1.22.2

--- a/openfl-workspace/fe_tf_adversarial_cifar/requirements.txt
+++ b/openfl-workspace/fe_tf_adversarial_cifar/requirements.txt
@@ -1,4 +1,4 @@
 torch==1.6
-tensorflow==2.7.4
+tensorflow==2.8.3
 fastestimator==1.1.1
 albumentations==0.5.2

--- a/openfl-workspace/fe_tf_adversarial_cifar/requirements.txt
+++ b/openfl-workspace/fe_tf_adversarial_cifar/requirements.txt
@@ -1,4 +1,4 @@
 torch==1.6
-tensorflow==2.7.2
+tensorflow==2.7.4
 fastestimator==1.1.1
 albumentations==0.5.2

--- a/openfl-workspace/fe_torch_adversarial_cifar/requirements.txt
+++ b/openfl-workspace/fe_torch_adversarial_cifar/requirements.txt
@@ -1,4 +1,4 @@
 torch==1.6
-tensorflow==2.7.4
+tensorflow==2.8.3
 fastestimator==1.1.1
 albumentations==0.5.2

--- a/openfl-workspace/fe_torch_adversarial_cifar/requirements.txt
+++ b/openfl-workspace/fe_torch_adversarial_cifar/requirements.txt
@@ -1,4 +1,4 @@
 torch==1.6
-tensorflow==2.7.2
+tensorflow==2.7.4
 fastestimator==1.1.1
 albumentations==0.5.2

--- a/openfl-workspace/keras_cnn_mnist/requirements.txt
+++ b/openfl-workspace/keras_cnn_mnist/requirements.txt
@@ -1,1 +1,1 @@
-tensorflow==2.7.4
+tensorflow==2.8.3

--- a/openfl-workspace/keras_cnn_mnist/requirements.txt
+++ b/openfl-workspace/keras_cnn_mnist/requirements.txt
@@ -1,1 +1,1 @@
-tensorflow==2.7.2
+tensorflow==2.7.4

--- a/openfl-workspace/keras_cnn_with_compression/requirements.txt
+++ b/openfl-workspace/keras_cnn_with_compression/requirements.txt
@@ -1,1 +1,1 @@
-tensorflow==2.7.4
+tensorflow==2.8.3

--- a/openfl-workspace/keras_cnn_with_compression/requirements.txt
+++ b/openfl-workspace/keras_cnn_with_compression/requirements.txt
@@ -1,1 +1,1 @@
-tensorflow==2.7.2
+tensorflow==2.7.4

--- a/openfl-workspace/keras_nlp/requirements.txt
+++ b/openfl-workspace/keras_nlp/requirements.txt
@@ -1,1 +1,1 @@
-tensorflow==2.7.4
+tensorflow==2.8.3

--- a/openfl-workspace/keras_nlp/requirements.txt
+++ b/openfl-workspace/keras_nlp/requirements.txt
@@ -1,1 +1,1 @@
-tensorflow==2.7.2
+tensorflow==2.7.4

--- a/openfl-workspace/keras_nlp_gramine_ready/requirements.txt
+++ b/openfl-workspace/keras_nlp_gramine_ready/requirements.txt
@@ -1,1 +1,1 @@
-tensorflow-cpu==2.7.2
+tensorflow-cpu==2.7.4

--- a/openfl-workspace/keras_nlp_gramine_ready/requirements.txt
+++ b/openfl-workspace/keras_nlp_gramine_ready/requirements.txt
@@ -1,1 +1,1 @@
-tensorflow-cpu==2.7.4
+tensorflow-cpu==2.8.3

--- a/openfl-workspace/tf_2dunet/requirements.txt
+++ b/openfl-workspace/tf_2dunet/requirements.txt
@@ -1,2 +1,2 @@
 nibabel
-tensorflow==2.7.4
+tensorflow==2.8.3

--- a/openfl-workspace/tf_2dunet/requirements.txt
+++ b/openfl-workspace/tf_2dunet/requirements.txt
@@ -1,2 +1,2 @@
 nibabel
-tensorflow==2.7.2
+tensorflow==2.7.4

--- a/openfl-workspace/tf_cnn_histology/requirements.txt
+++ b/openfl-workspace/tf_cnn_histology/requirements.txt
@@ -1,3 +1,3 @@
 pillow
-tensorflow==2.7.4
+tensorflow==2.8.3
 tensorflow-datasets

--- a/openfl-workspace/tf_cnn_histology/requirements.txt
+++ b/openfl-workspace/tf_cnn_histology/requirements.txt
@@ -1,3 +1,3 @@
 pillow
-tensorflow==2.7.2
+tensorflow==2.7.4
 tensorflow-datasets

--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,7 @@ setup(
         'docker',
         'dynaconf==3.1.7',
         'flatten_json',
-        'grpcio~=1.34.0',
+        'grpcio~=1.48.2',
         'ipykernel',
         'jupyterlab',
         'numpy',
@@ -151,8 +151,8 @@ setup(
         'tensorboardX',
         'tqdm',
     ],
-    setup_requires=['grpcio-tools~=1.34.0'],
-    python_requires='>=3.6, <3.9',
+    setup_requires=['grpcio-tools~=1.48.2'],
+    python_requires='>=3.6, <3.11',
     project_urls={
         'Bug Tracker': 'https://github.com/intel/openfl/issues',
         'Documentation': 'https://openfl.readthedocs.io/en/stable/',
@@ -176,6 +176,10 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+
+
     ],
     entry_points={
         'console_scripts': ['fx=openfl.interface.cli:entry']


### PR DESCRIPTION
Addresses https://github.com/intel/openfl/issues/522

This PR:
- Adds CI Tests for Python 3.9 and 3.10 (TaskRunner only so far)
- Removes dependence on grpcio 1.34.0, which is not supported by 3.10