### PR TITLE
Fix log metric callback settings

### DIFF
--- a/openfl/component/aggregator/aggregator.py
+++ b/openfl/component/aggregator/aggregator.py
@@ -52,6 +52,7 @@ class Aggregator:
                  compression_pipeline=None,
                  db_store_rounds=1,
                  write_logs=False,
+                 log_metric_callback=None,
                  **kwargs):
         """Initialize."""
         self.round_number = 0
@@ -83,10 +84,16 @@ class Aggregator:
         self.db_store_rounds = db_store_rounds
 
         # Gathered together logging-related objects
+        self.logger = getLogger(__name__)
         self.write_logs = write_logs
+        self.log_metric_callback = log_metric_callback
+
         if self.write_logs:
             self.log_metric = write_metric
-        self.logger = getLogger(__name__)
+            if self.log_metric_callback:
+                self.log_metric = log_metric_callback
+                self.logger.info(f'Using custom log metric: {self.log_metric}')
+        
         self.best_model_score = None
         self.metric_queue = queue.Queue()
 


### PR DESCRIPTION
This PR fixes a current bug w.r.t custom log metric callback function: Earlier, only tensorboard logging was enabled in the aggregator settings, overriding the log settings in plan. With this fix, users should be able to define a custom log metric callback function and that would be reflected in the aggregator settings.