### PR TITLE
For gramine set write logs to false

### DIFF
--- a/openfl-workspace/keras_nlp_gramine_ready/plan/plan.yaml
+++ b/openfl-workspace/keras_nlp_gramine_ready/plan/plan.yaml
@@ -9,6 +9,7 @@ aggregator :
     best_state_path : save/keras_nlp_best.pbuf
     last_state_path : save/keras_nlp_last.pbuf
     rounds_to_train : 10
+    write_logs : false
 
 collaborator :
   defaults : plan/defaults/collaborator.yaml

--- a/openfl-workspace/torch_cnn_histology_gramine_ready/plan/plan.yaml
+++ b/openfl-workspace/torch_cnn_histology_gramine_ready/plan/plan.yaml
@@ -9,6 +9,7 @@ aggregator :
     best_state_path : save/torch_cnn_histology_best.pbuf
     last_state_path : save/torch_cnn_histology_last.pbuf
     rounds_to_train : 20
+    write_logs : false
 
 collaborator :
   defaults : plan/defaults/collaborator.yaml

--- a/openfl-workspace/torch_unet_kvasir_gramine_ready/plan/plan.yaml
+++ b/openfl-workspace/torch_unet_kvasir_gramine_ready/plan/plan.yaml
@@ -9,6 +9,7 @@ aggregator :
     best_state_path : save/torch_unet_kvasir_best.pbuf
     last_state_path : save/torch_unet_kvasir_last.pbuf
     rounds_to_train : 40
+    write_logs : false
 
 collaborator :
   defaults : plan/defaults/collaborator.yaml


### PR DESCRIPTION
Gramine doesn't support the use of POSIX semaphores, which is required by Python's `multiprocessing` package. By default, tensorboard logging is enabled which [invokes multiprocessing internally](https://github.com/intel/openfl/issues/503#issuecomment-1253563578) to write logs. Hence, `write_logs` should be disabled for `gramine_ready` workspaces.
Another solution might be to create a custom logging function that doesn't use multiprocessing but since we are using Gramine that has it's own way of logging through `log_level` in manifest, we might as well disable `write_logs` in plan.