### PR TITLE
Add flake8 extensions to linter CI workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 
+        pip install -r requirements-linters.txt 
         pip install .
     - name: Lint with flake8
       run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,4 @@ jobs:
         pip install .
     - name: Lint with flake8
       run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        flake8 --show-source

--- a/openfl-tutorials/interactive_api/PyTorch_MedMNIST_2D/envoy/medmnist_shard_descriptor.py
+++ b/openfl-tutorials/interactive_api/PyTorch_MedMNIST_2D/envoy/medmnist_shard_descriptor.py
@@ -5,7 +5,7 @@
 
 import logging
 import os
-from typing import Any, Dict, List, Tuple
+from typing import Any, List, Tuple
 from medmnist.info import INFO, HOMEPAGE
 
 import numpy as np
@@ -48,11 +48,11 @@ class MedMNISTShardDescriptor(ShardDescriptor):
     ) -> None:
         """Initialize MedMNISTShardDescriptor."""
         self.rank, self.worldsize = tuple(int(num) for num in rank_worldsize.split(','))
-        
+
         self.datapath = datapath
-        self.dataset_name = dataname;
+        self.dataset_name = dataname
         self.info = INFO[self.dataset_name]
-        
+
         (x_train, y_train), (x_test, y_test) = self.load_data()
         self.data_by_type = {
             'train': (x_train, y_train),
@@ -75,14 +75,14 @@ class MedMNISTShardDescriptor(ShardDescriptor):
         )
 
     @property
-    def sample_shape(self) -> List[str] :
+    def sample_shape(self) -> List[str]:
         """Return the sample shape info."""
         return ['28', '28', '3']
 
     @property
-    def target_shape(self) -> List[str] :
+    def target_shape(self) -> List[str]:
         """Return the target shape info."""
-        return ['1','1']
+        return ['1', '1']
 
     @property
     def dataset_description(self) -> str:
@@ -90,8 +90,8 @@ class MedMNISTShardDescriptor(ShardDescriptor):
         return (f'MedMNIST dataset, shard number {self.rank}'
                 f' out of {self.worldsize}')
 
-    def download_data(datapath: str = 'data/', 
-                      dataname: str = 'bloodmnist', 
+    def download_data(datapath: str = 'data/',
+                      dataname: str = 'bloodmnist',
                       info: dict = {}) -> None:
 
         logger.info(f"{datapath}\n{dataname}\n{info}")
@@ -101,31 +101,28 @@ class MedMNISTShardDescriptor(ShardDescriptor):
                          root=datapath,
                          filename=dataname,
                          md5=info["MD5"])
-        except:
-            raise RuntimeError('Something went wrong when downloading! ' +
-                               'Go to the homepage to download manually. ' +
-                               HOMEPAGE)
-
+        except Exception:
+            raise RuntimeError('Something went wrong when downloading! '
+                               + 'Go to the homepage to download manually. '
+                               + HOMEPAGE)
 
     def load_data(self) -> Tuple[Tuple[Any, Any], Tuple[Any, Any]]:
         """Download prepared dataset."""
-        
+
         dataname = self.dataset_name + '.npz'
         dataset = os.path.join(self.datapath, dataname)
-        
+
         if not os.path.isfile(dataset):
             logger.info(f"Dataset {dataname} not found at:{self.datapath}.\n\tDownloading...")
             MedMNISTShardDescriptor.download_data(self.datapath, dataname, self.info)
-            logger.info(f"DONE!")
+            logger.info("DONE!")
 
         data = np.load(dataset)
-        
+
         x_train = data["train_images"]
         x_test = data["test_images"]
-        
-        y_train=data["train_labels"]
-        y_test=data["test_labels"]
+
+        y_train = data["train_labels"]
+        y_test = data["test_labels"]
         logger.info('MedMNIST data was loaded!')
         return (x_train, y_train), (x_test, y_test)
-        
-        

--- a/openfl-tutorials/interactive_api/PyTorch_MedMNIST_3D/envoy/medmnist_shard_descriptor.py
+++ b/openfl-tutorials/interactive_api/PyTorch_MedMNIST_3D/envoy/medmnist_shard_descriptor.py
@@ -5,7 +5,7 @@
 
 import logging
 import os
-from typing import Any, Dict, List, Tuple
+from typing import Any, List, Tuple
 from medmnist.info import INFO, HOMEPAGE
 
 import numpy as np
@@ -48,11 +48,11 @@ class MedMNISTShardDescriptor(ShardDescriptor):
     ) -> None:
         """Initialize MedMNISTShardDescriptor."""
         self.rank, self.worldsize = tuple(int(num) for num in rank_worldsize.split(','))
-        
+
         self.datapath = datapath
-        self.dataset_name = dataname;
+        self.dataset_name = dataname
         self.info = INFO[self.dataset_name]
-        
+
         (x_train, y_train), (x_test, y_test) = self.load_data()
         self.data_by_type = {
             'train': (x_train, y_train),
@@ -75,16 +75,14 @@ class MedMNISTShardDescriptor(ShardDescriptor):
         )
 
     @property
-    def sample_shape(self) -> List[str] :
+    def sample_shape(self) -> List[str]:
         """Return the sample shape info."""
-        #return data_by_type['train'][0][0].shape
         return ['28', '28', '28']
 
     @property
-    def target_shape(self) -> List[str] :
+    def target_shape(self) -> List[str]:
         """Return the target shape info."""
-        #return data_by_type['train'][1][0].shape
-        return ['1','1']
+        return ['1', '1']
 
     @property
     def dataset_description(self) -> str:
@@ -92,8 +90,8 @@ class MedMNISTShardDescriptor(ShardDescriptor):
         return (f'MedMNIST dataset, shard number {self.rank}'
                 f' out of {self.worldsize}')
 
-    def download_data(datapath: str = 'data/', 
-                      dataname: str = 'bloodmnist', 
+    def download_data(datapath: str = 'data/',
+                      dataname: str = 'bloodmnist',
                       info: dict = {}) -> None:
 
         logger.info(f"{datapath}\n{dataname}\n{info}")
@@ -103,31 +101,28 @@ class MedMNISTShardDescriptor(ShardDescriptor):
                          root=datapath,
                          filename=dataname,
                          md5=info["MD5"])
-        except:
-            raise RuntimeError('Something went wrong when downloading! ' +
-                               'Go to the homepage to download manually. ' +
-                               HOMEPAGE)
-
+        except Exception:
+            raise RuntimeError('Something went wrong when downloading! '
+                               + 'Go to the homepage to download manually. '
+                               + HOMEPAGE)
 
     def load_data(self) -> Tuple[Tuple[Any, Any], Tuple[Any, Any]]:
         """Download prepared dataset."""
-        
+
         dataname = self.dataset_name + '.npz'
         dataset = os.path.join(self.datapath, dataname)
-        
+
         if not os.path.isfile(dataset):
             logger.info(f"Dataset {dataname} not found at:{self.datapath}.\n\tDownloading...")
             MedMNISTShardDescriptor.download_data(self.datapath, dataname, self.info)
-            logger.info(f"DONE!")
+            logger.info("DONE!")
 
         data = np.load(dataset)
-        
+
         x_train = data["train_images"]
         x_test = data["test_images"]
-        
-        y_train=data["train_labels"]
-        y_test=data["test_labels"]
+
+        y_train = data["train_labels"]
+        y_test = data["test_labels"]
         logger.info('MedMNIST data was loaded!')
         return (x_train, y_train), (x_test, y_test)
-        
-        

--- a/openfl-tutorials/interactive_api/PyTorch_MedMNIST_3D/workspace/wspace_utils/__init__.py
+++ b/openfl-tutorials/interactive_api/PyTorch_MedMNIST_3D/workspace/wspace_utils/__init__.py
@@ -1,2 +1,7 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from .utils import Transform3D
 from .utils import model_to_syncbn
+
+__all__ = ["Transform3D", "model_to_syncbn"]

--- a/openfl-tutorials/interactive_api/PyTorch_MedMNIST_3D/workspace/wspace_utils/comm.py
+++ b/openfl-tutorials/interactive_api/PyTorch_MedMNIST_3D/workspace/wspace_utils/comm.py
@@ -1,9 +1,12 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 # -*- coding: utf-8 -*-
-# File   : comm.py
-# Author : Jiayuan Mao
-# Email  : maojiayuan@gmail.com
-# Date   : 27/01/2018
-# 
+# File    comm.py
+# Author  Jiayuan Mao
+# Email   maojiayuan@gmail.com
+# Date    27/01/2018
+#
 # This file is part of Synchronized-BatchNorm-PyTorch.
 # https://github.com/vacancy/Synchronized-BatchNorm-PyTorch
 # Distributed under MIT License.
@@ -56,19 +59,21 @@ class SlavePipe(_SlavePipeBase):
 class SyncMaster(object):
     """An abstract `SyncMaster` object.
 
-    - During the replication, as the data parallel will trigger an callback of each module, all slave devices should
-    call `register(id)` and obtain an `SlavePipe` to communicate with the master.
-    - During the forward pass, master device invokes `run_master`, all messages from slave devices will be collected,
-    and passed to a registered callback.
-    - After receiving the messages, the master device should gather the information and determine to message passed
-    back to each slave devices.
+    - During the replication, as the data parallel will trigger an callback of each module,
+    all slave devices should call `register(id)` and obtain an `SlavePipe`
+    to communicate with the master.
+    - During the forward pass, master device invokes `run_master`,
+    all messages from slave devices will be collected, and passed to a registered callback.
+    - After receiving the messages, the master device should gather the information
+    and determine to message passed back to each slave devices.
     """
 
     def __init__(self, master_callback):
         """
 
         Args:
-            master_callback: a callback to be invoked after having collected messages from slave devices.
+            master_callback: a callback to be invoked
+                             after having collected messages from slave devices.
         """
         self._master_callback = master_callback
         self._queue = queue.Queue()
@@ -107,8 +112,9 @@ class SyncMaster(object):
         (including the master device).
 
         Args:
-            master_msg: the message that the master want to send to itself. This will be placed as the first
-            message when calling `master_callback`. For detailed usage, see `_SynchronizedBatchNorm` for an example.
+            master_msg: the message that the master want to send to itself.
+                        This will be placed as the first message when calling `master_callback`.
+                        For detailed usage, see `_SynchronizedBatchNorm` for an example.
 
         Returns: the message to be sent back to the master device.
 

--- a/openfl-tutorials/interactive_api/PyTorch_MedMNIST_3D/workspace/wspace_utils/replicate.py
+++ b/openfl-tutorials/interactive_api/PyTorch_MedMNIST_3D/workspace/wspace_utils/replicate.py
@@ -1,9 +1,12 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 # -*- coding: utf-8 -*-
-# File   : replicate.py
-# Author : Jiayuan Mao
-# Email  : maojiayuan@gmail.com
-# Date   : 27/01/2018
-# 
+# File    replicate.py
+# Author  Jiayuan Mao
+# Email   maojiayuan@gmail.com
+# Date    27/01/2018
+#
 # This file is part of Synchronized-BatchNorm-PyTorch.
 # https://github.com/vacancy/Synchronized-BatchNorm-PyTorch
 # Distributed under MIT License.
@@ -26,7 +29,8 @@ class CallbackContext(object):
 
 def execute_replication_callbacks(modules):
     """
-    Execute an replication callback `__data_parallel_replicate__` on each module created by original replication.
+    Execute an replication callback `__data_parallel_replicate__`
+    on each module created by original replication.
 
     The callback will be invoked with arguments `__data_parallel_replicate__(ctx, copy_id)`
 
@@ -34,8 +38,8 @@ def execute_replication_callbacks(modules):
     (shared among multiple copies of this module on different devices).
     Through this context, different copies can share some information.
 
-    We guarantee that the callback on the master copy (the first copy) will be called ahead of calling the callback
-    of any slave copies.
+    We guarantee that the callback on the master copy (the first copy)
+    will be called ahead of calling the callback of any slave copies.
     """
     master_copy = modules[0]
     nr_modules = len(list(master_copy.modules()))
@@ -51,8 +55,8 @@ class DataParallelWithCallback(DataParallel):
     """
     Data Parallel with a replication callback.
 
-    An replication callback `__data_parallel_replicate__` of each module will be invoked after being created by
-    original `replicate` function.
+    An replication callback `__data_parallel_replicate__` of each module
+    will be invoked after being created by original `replicate` function.
     The callback will be invoked with arguments `__data_parallel_replicate__(ctx, copy_id)`
 
     Examples:

--- a/openfl-tutorials/interactive_api/PyTorch_MedMNIST_3D/workspace/wspace_utils/utils.py
+++ b/openfl-tutorials/interactive_api/PyTorch_MedMNIST_3D/workspace/wspace_utils/utils.py
@@ -1,6 +1,9 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import torch.nn as nn
 import numpy as np
-from .batchnorm import SynchronizedBatchNorm3d, SynchronizedBatchNorm2d
+
 
 class Transform3D:
 
@@ -8,12 +11,12 @@ class Transform3D:
         self.mul = mul
 
     def __call__(self, voxel):
-   
+
         if self.mul == '0.5':
             voxel = voxel * 0.5
         elif self.mul == 'random':
             voxel = voxel * np.random.uniform()
-        
+
         return voxel.astype(np.float32)
 
 
@@ -25,10 +28,12 @@ def model_to_syncbn(model):
 
 
 def _convert_module_from_bn_to_syncbn(module):
-    for child_name, child in module.named_children(): 
-        if hasattr(nn, child.__class__.__name__) and \
-            'batchnorm' in child.__class__.__name__.lower():
-            TargetClass = globals()['Synchronized'+child.__class__.__name__]
+    for child_name, child in module.named_children():
+        if (
+            hasattr(nn, child.__class__.__name__)
+            and 'batchnorm' in child.__class__.__name__.lower()
+        ):
+            TargetClass = globals()['Synchronized' + child.__class__.__name__]
             arguments = TargetClass.__init__.__code__.co_varnames[1:]
             kwargs = {k: getattr(child, k) for k in arguments}
             setattr(module, child_name, TargetClass(**kwargs))

--- a/openfl-tutorials/interactive_api/Tensorflow_CIFAR_tfdata/envoy/cifar10_shard_descriptor.py
+++ b/openfl-tutorials/interactive_api/Tensorflow_CIFAR_tfdata/envoy/cifar10_shard_descriptor.py
@@ -31,7 +31,10 @@ class CIFAR10ShardDescriptor(ShardDescriptor):
         self.rank, self.worldsize = tuple(int(num) for num in rank_worldsize.split(','))
 
         # Load dataset
-        train_ds, valid_ds = self._download_and_prepare_dataset(rank=self.rank, worldsize=self.worldsize)
+        train_ds, valid_ds = self._download_and_prepare_dataset(
+            rank=self.rank,
+            worldsize=self.worldsize
+        )
 
         # Set attributes
         self._sample_shape = train_ds.element_spec[0].shape
@@ -53,8 +56,8 @@ class CIFAR10ShardDescriptor(ShardDescriptor):
         (x_train, y_train), (x_test, y_test) = tf.keras.datasets.cifar10.load_data()
 
         # Split
-        x_train, y_train = x_train[rank-1::worldsize], y_train[rank-1::worldsize]
-        x_test, y_test = x_test[rank-1::worldsize], y_test[rank-1::worldsize]
+        x_train, y_train = x_train[rank - 1::worldsize], y_train[rank - 1::worldsize]
+        x_test, y_test = x_test[rank - 1::worldsize], y_test[rank - 1::worldsize]
 
         train_ds = tf.data.Dataset.from_tensor_slices((x_train, y_train))
         test_ds = tf.data.Dataset.from_tensor_slices((x_test, y_test))

--- a/openfl-tutorials/interactive_api/jax_linear_regression/envoy/regression_shard_descriptor.py
+++ b/openfl-tutorials/interactive_api/jax_linear_regression/envoy/regression_shard_descriptor.py
@@ -10,6 +10,7 @@ from sklearn.model_selection import train_test_split
 
 from openfl.interface.interactive_api.shard_descriptor import ShardDescriptor
 
+
 class RegressionShardDescriptor(ShardDescriptor):
     """Regression Shard descriptor class."""
 
@@ -21,7 +22,7 @@ class RegressionShardDescriptor(ShardDescriptor):
         using make_regression method from sklearn.datasets.
         Shards data across participants using rank and world size.
         """
-        
+
         self.rank, self.worldsize = tuple(int(num) for num in rank_worldsize.split(','))
         X_train, y_train, X_test, y_test = self.generate_data()
         self.data_by_type = {

--- a/openfl/component/aggregator/aggregator.py
+++ b/openfl/component/aggregator/aggregator.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2020-2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-"""Aggregator module.""" 
+"""Aggregator module."""
 import time
 import queue
 from logging import getLogger
@@ -64,7 +64,8 @@ class Aggregator:
             # Cleaner solution?
             self.single_col_cert_common_name = ''
 
-        self.straggler_handling_policy = straggler_handling_policy or CutoffTimeBasedStragglerHandling()
+        self.straggler_handling_policy = straggler_handling_policy \
+            or CutoffTimeBasedStragglerHandling()
         self._end_of_round_check_done = [False] * rounds_to_train
         self.stragglers_for_task = {}
 
@@ -383,7 +384,7 @@ class Aggregator:
         nparray = self.tensor_db.get_tensor_from_cache(agg_tensor_key)
 
         start_retrieving_time = time.time()
-        while(nparray is None):
+        while (nparray is None):
             self.logger.debug(f'Waiting for tensor_key {agg_tensor_key}')
             time.sleep(5)
             nparray = self.tensor_db.get_tensor_from_cache(agg_tensor_key)
@@ -501,14 +502,15 @@ class Aggregator:
         """
         if self._time_to_quit() or self._is_task_done(task_name):
             self.logger.warning(
-                f'STRAGGLER: Collaborator {collaborator_name} is reporting results after task {task_name} has finished.'
+                f'STRAGGLER: Collaborator {collaborator_name} is reporting results '
+                'after task {task_name} has finished.'
             )
             return
 
         if self.round_number != round_number:
             self.logger.warning(
-                f'Collaborator {collaborator_name} is reporting results for the wrong round: {round_number}.'
-                f' Ignoring...'
+                f'Collaborator {collaborator_name} is reporting results'
+                f' for the wrong round: {round_number}. Ignoring...'
             )
             return
 
@@ -903,23 +905,24 @@ class Aggregator:
         all_collaborators = self.assigner.get_collaborators_for_task(
             task_name, self.round_number
         )
-        
+
         collaborators_done = []
         for c in all_collaborators:
             if self._collaborator_task_completed(
-                c, task_name, self.round_number):
+                c, task_name, self.round_number
+            ):
                 collaborators_done.append(c)
-        
+
         straggler_check = self.straggler_handling_policy.straggler_cutoff_check(
             len(collaborators_done), all_collaborators)
-        
+
         stragglers = []
         if straggler_check:
             for c in all_collaborators:
                 if c not in collaborators_done:
                     stragglers.append(c)
-            self.logger.info('\tEnding task {} early due to straggler cutoff policy'.format(task_name))
-            self.logger.warning('\tIdentified stragglers: {} for task {}'.format(stragglers, task_name))
+            self.logger.info(f'\tEnding task {task_name} early due to straggler cutoff policy')
+            self.logger.warning(f'\tIdentified stragglers: {stragglers} for task {task_name}')
             self.stragglers_for_task[task_name] = stragglers
 
         # all are done or straggler policy calls for early round end.

--- a/openfl/component/straggler_handling_functions/cutoff_time_based_straggler_handling.py
+++ b/openfl/component/straggler_handling_functions/cutoff_time_based_straggler_handling.py
@@ -14,7 +14,8 @@ class CutoffTimeBasedStragglerHandling(StragglerHandlingFunction):
         round_start_time=None,
         straggler_cutoff_time=np.inf,
         minimum_reporting=1,
-        **kwargs):
+        **kwargs
+    ):
         self.round_start_time = round_start_time
         self.straggler_cutoff_time = straggler_cutoff_time
         self.minimum_reporting = minimum_reporting

--- a/openfl/component/straggler_handling_functions/percentage_based_straggler_handling.py
+++ b/openfl/component/straggler_handling_functions/percentage_based_straggler_handling.py
@@ -10,7 +10,8 @@ class PercentageBasedStragglerHandling(StragglerHandlingFunction):
         self,
         percent_collaborators_needed=1.0,
         minimum_reporting=1,
-        **kwargs):
+        **kwargs
+    ):
         self.percent_collaborators_needed = percent_collaborators_needed
         self.minimum_reporting = minimum_reporting
 

--- a/openfl/cryptography/io.py
+++ b/openfl/cryptography/io.py
@@ -30,7 +30,8 @@ def read_key(path: Path) -> RSAPrivateKey:
         pem_data = f.read()
 
     signing_key = load_pem_private_key(pem_data, password=None)
-    assert(isinstance(signing_key, rsa.RSAPrivateKey))
+    # TODO: replace assert with exception / sys.exit
+    assert (isinstance(signing_key, rsa.RSAPrivateKey))
     return signing_key
 
 
@@ -65,7 +66,8 @@ def read_crt(path: Path) -> Certificate:
         pem_data = f.read()
 
     certificate = x509.load_pem_x509_certificate(pem_data)
-    assert(isinstance(certificate, x509.Certificate))
+    # TODO: replace assert with exception / sys.exit
+    assert (isinstance(certificate, x509.Certificate))
     return certificate
 
 
@@ -102,5 +104,6 @@ def read_csr(path: Path) -> Tuple[CertificateSigningRequest, str]:
         hasher.update(pem_data)
 
     csr = x509.load_pem_x509_csr(pem_data)
-    assert(isinstance(csr, x509.CertificateSigningRequest))
+    # TODO: replace assert with exception / sys.exit
+    assert (isinstance(csr, x509.CertificateSigningRequest))
     return csr, hasher.hexdigest()

--- a/openfl/databases/tensor_db.py
+++ b/openfl/databases/tensor_db.py
@@ -16,7 +16,7 @@ from openfl.interface.aggregation_functions import AggregationFunction
 from openfl.utilities import change_tags
 from openfl.utilities import LocalTensor
 from openfl.utilities import TensorKey
-from openfl.databases.utilities import _search,_store,_retrieve, ROUND_PLACEHOLDER
+from openfl.databases.utilities import _search, _store, _retrieve, ROUND_PLACEHOLDER
 
 
 class TensorDB:
@@ -34,11 +34,12 @@ class TensorDB:
             'tensor_name', 'origin', 'round', 'report', 'tags', 'nparray'
         ])
         self._bind_convenience_methods()
-        
+
         self.mutex = Lock()
 
     def _bind_convenience_methods(self):
-        # Bind convenience methods for TensorDB dataframe to make storage, retrieval, and search easier
+        # Bind convenience methods for TensorDB dataframe
+        # to make storage, retrieval, and search easier
         if not hasattr(self.tensor_db, 'store'):
             self.tensor_db.store = MethodType(_store, self.tensor_db)
         if not hasattr(self.tensor_db, 'retrieve'):
@@ -55,7 +56,6 @@ class TensorDB:
     def __str__(self) -> str:
         """Printable string representation."""
         return self.__repr__()
-        
 
     def clean_up(self, remove_older_than: int = 1) -> None:
         """Remove old entries from database preventing the db from becoming too large and slow."""
@@ -66,8 +66,8 @@ class TensorDB:
         if current_round == ROUND_PLACEHOLDER:
             current_round = np.sort(self.tensor_db['round'].astype(int).unique())[-2]
         self.tensor_db = self.tensor_db[
-            (self.tensor_db['round'].astype(int) > current_round - remove_older_than) |
-            (self.tensor_db['report'] == True)
+            (self.tensor_db['round'].astype(int) > current_round - remove_older_than)
+            | self.tensor_db['report']
         ].reset_index(drop=True)
 
     def cache_tensor(self, tensor_key_dict: Dict[TensorKey, np.ndarray]) -> None:
@@ -183,11 +183,8 @@ class TensorDB:
                          for col_name in collaborator_names]
 
         if hasattr(aggregation_function, '_privileged'):
-            if(aggregation_function._privileged):
+            if aggregation_function._privileged:
                 with self.mutex:
-                    #self.tensor_db.store = MethodType(_store, self.tensor_db)
-                    #self.tensor_db.retrieve = MethodType(_retrieve, self.tensor_db)
-                    #self.tensor_db.search = MethodType(_search, self.tensor_db)
                     self._bind_convenience_methods()
                     agg_nparray = aggregation_function(local_tensors,
                                                        self.tensor_db,

--- a/openfl/databases/utilities/__init__.py
+++ b/openfl/databases/utilities/__init__.py
@@ -3,7 +3,7 @@
 
 """Database Utilities."""
 
-from .dataframe import _search,_store,_retrieve,ROUND_PLACEHOLDER,ROUND_PLACEHOLDER
+from .dataframe import _search, _store, _retrieve, ROUND_PLACEHOLDER
 
 __all__ = [
     '_search',

--- a/openfl/databases/utilities/dataframe.py
+++ b/openfl/databases/utilities/dataframe.py
@@ -3,15 +3,14 @@
 
 """Convenience Utilities for DataFrame."""
 
-from types import MethodType
-
 import numpy as np
 import pandas as pd
-from typing import Optional, Union
+from typing import Optional
 
 ROUND_PLACEHOLDER = 1000000
 
-def _search(self, tensor_name: str = None, origin: str = None, 
+
+def _search(self, tensor_name: str = None, origin: str = None,
             fl_round: int = None, metric: bool = None, tags: tuple = None
             ) -> pd.DataFrame:
     """
@@ -32,7 +31,7 @@ def _search(self, tensor_name: str = None, origin: str = None,
             tags:        Tuple of unstructured tags associated with the tensor
 
         Returns:
-            pd.DataFrame : New dataframe that matches the search query from 
+            pd.DataFrame : New dataframe that matches the search query from
                            the tensor_db dataframe
     """
     df = None
@@ -62,8 +61,8 @@ def _search(self, tensor_name: str = None, origin: str = None,
 
 
 def _store(self, tensor_name: str = '_', origin: str = '_',
-           fl_round: int = ROUND_PLACEHOLDER, metric: bool = False, 
-           tags: tuple = ('_',), nparray: np.array = None, 
+           fl_round: int = ROUND_PLACEHOLDER, metric: bool = False,
+           tags: tuple = ('_',), nparray: np.array = None,
            overwrite: bool = True) -> None:
     """
         Convenience method to store a new tensor in the dataframe.
@@ -72,10 +71,11 @@ def _store(self, tensor_name: str = '_', origin: str = '_',
             tensor_name [ optional ] : The name of the tensor (or metric) to be saved
             origin      [ optional ] : Origin of the tensor
             fl_round    [ optional ] : Round the tensor is associated with
-            metric:     [ optional ] : Is the tensor a metric?
-            tags:       [ optional ] : Tuple of unstructured tags associated with the tensor
-            np.array    [ required ] : Value to store associated with the other included information (i.e. TensorKey info)
-            overwrite:  [ optional ] : If the tensor is already present in the dataframe
+            metric      [ optional ] : Is the tensor a metric?
+            tags        [ optional ] : Tuple of unstructured tags associated with the tensor
+            nparray     [ required ] : Value to store associated with the other
+                                       included information (i.e. TensorKey info)
+            overwrite   [ optional ] : If the tensor is already present in the dataframe
                                        should it be overwritten?
 
         Returns:
@@ -100,7 +100,7 @@ def _store(self, tensor_name: str = '_', origin: str = '_',
 
 
 def _retrieve(self, tensor_name: str = '_', origin: str = '_',
-              fl_round: int = ROUND_PLACEHOLDER, metric: bool = False, 
+              fl_round: int = ROUND_PLACEHOLDER, metric: bool = False,
               tags: tuple = ('_',)) -> Optional[np.array]:
     """
         Convenience method to retrieve tensor from the dataframe.
@@ -118,14 +118,12 @@ def _retrieve(self, tensor_name: str = '_', origin: str = '_',
     """
 
     df = self[(self['tensor_name'] == tensor_name)
-                & (self['origin'] == origin)
-                & (self['round'] == str(fl_round))
-                & (self['report'] == metric)
-                & (self['tags'] == tags)]['nparray']
+              & (self['origin'] == origin)
+              & (self['round'] == str(fl_round))
+              & (self['report'] == metric)
+              & (self['tags'] == tags)]['nparray']
 
     if len(df) > 0:
         return df.iloc[0]
     else:
         return None
-
-

--- a/openfl/federated/data/loader_fets_challenge.py
+++ b/openfl/federated/data/loader_fets_challenge.py
@@ -2,11 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """PyTorchDataLoader module."""
-
-from math import ceil, fabs
-
-import numpy as np
-
 from .loader import DataLoader
 
 

--- a/openfl/federated/plan/plan.py
+++ b/openfl/federated/plan/plan.py
@@ -15,8 +15,6 @@ from yaml import SafeDumper
 from openfl.interface.aggregation_functions import AggregationFunction
 from openfl.interface.aggregation_functions import WeightedAverage
 from openfl.component.assigner.custom_assigner import Assigner
-from openfl.component.straggler_handling_functions import CutoffTimeBasedStragglerHandling
-from openfl.component.straggler_handling_functions import StragglerHandlingFunction
 from openfl.interface.cli_helper import WORKSPACE
 from openfl.transport import AggregatorGRPCClient
 from openfl.transport import AggregatorGRPCServer
@@ -305,7 +303,8 @@ class Plan:
                     aggregation_type[SETTINGS] = {}
                 aggregation_type = Plan.build(**aggregation_type)
                 if not isinstance(aggregation_type, AggregationFunction):
-                    raise NotImplementedError(f'''{task} task aggregation type does not implement an interface:
+                    raise NotImplementedError(
+                        f'''{task} task aggregation type does not implement an interface:
     openfl.interface.aggregation_functions.AggregationFunction
     ''')
             tasks[task]['aggregation_type'] = aggregation_type
@@ -357,14 +356,15 @@ class Plan:
 
     def get_straggler_handling_policy(self):
         """Get straggler handling policy."""
+        template = 'openfl.component.straggler_handling_functions.CutoffTimeBasedStragglerHandling'
         defaults = self.config.get(
             'straggler_handling_policy',
             {
-                TEMPLATE: 'openfl.component.straggler_handling_functions.CutoffTimeBasedStragglerHandling',
+                TEMPLATE: template,
                 SETTINGS: {}
             }
         )
-        
+
         if self.straggler_policy_ is None:
             self.straggler_policy_ = Plan.build(**defaults)
 

--- a/openfl/interface/aggregation_functions/core/interface.py
+++ b/openfl/interface/aggregation_functions/core/interface.py
@@ -5,7 +5,6 @@ from abc import abstractmethod
 from typing import Iterator
 from typing import List
 from typing import Tuple
-from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -19,7 +18,7 @@ class AggregationFunction(metaclass=SingletonABCMeta):
 
     def __init__(self):
         """Initialize common AggregationFunction params
-        
+
            Default: Read only access to TensorDB
         """
         self._privileged = False
@@ -66,4 +65,3 @@ class AggregationFunction(metaclass=SingletonABCMeta):
                  tags):
         """Use magic function for ease."""
         return self.call(local_tensors, db_iterator, tensor_name, fl_round, tags)
-

--- a/openfl/interface/aggregation_functions/experimental/__init__.py
+++ b/openfl/interface/aggregation_functions/experimental/__init__.py
@@ -5,4 +5,4 @@
 
 from .privileged_aggregation import PrivilegedAggregationFunction
 
-__all__ = ['PrivilegedAggregationFunction',]
+__all__ = ['PrivilegedAggregationFunction']

--- a/openfl/interface/aggregation_functions/experimental/privileged_aggregation.py
+++ b/openfl/interface/aggregation_functions/experimental/privileged_aggregation.py
@@ -2,10 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Aggregation function interface module."""
 from abc import abstractmethod
-from typing import Iterator
 from typing import List
 from typing import Tuple
-from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -60,4 +58,3 @@ class PrivilegedAggregationFunction(AggregationFunction):
             np.ndarray: aggregated tensor
         """
         raise NotImplementedError
-

--- a/openfl/interface/interactive_api/experiment.py
+++ b/openfl/interface/interactive_api/experiment.py
@@ -65,7 +65,6 @@ class FLExperiment:
 
         self._initialize_plan()
 
-
     def _initialize_plan(self):
         """Setup plan from base plan interactive api."""
         # Create a folder to store plans
@@ -78,7 +77,7 @@ class FLExperiment:
         plan.name = 'plan.yaml'
 
         self.plan = deepcopy(plan)
-    
+
     def _assert_experiment_accepted(self):
         """Assure experiment is sent to director."""
         if not self.experiment_accepted:

--- a/openfl/interface/workspace.py
+++ b/openfl/interface/workspace.py
@@ -437,7 +437,8 @@ def dockerize_(context, base_image, save):
         )
 @option('-e', '--enclave_size', required=False,
         type=str, default='16G',
-        help='Memory size of the enclave, defined as number with size suffix. Must be a power-of-2.\n'
+        help='Memory size of the enclave, defined as number with size suffix. '
+             'Must be a power-of-2.\n'
              'Default is 16G.'
         )
 @option('-o', '--pip-install-options', required=False,

--- a/openfl/pipelines/__init__.py
+++ b/openfl/pipelines/__init__.py
@@ -1,4 +1,6 @@
 # Copyright (C) 2020-2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 # Copyright 2022 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 """openfl.pipelines module."""

--- a/openfl/pipelines/eden_pipeline.py
+++ b/openfl/pipelines/eden_pipeline.py
@@ -1,18 +1,23 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 # Copyright 2022 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+
 """
 @author: Shay Vargaftik (VMware Research), shayv@vmware.com; vargaftik@gmail.com
 @author: Yaniv Ben-Itzhak (VMware Research), ybenitzhak@vmware.com; yaniv.benizhak@gmail.com
-"""
 
-"""EdenPipeline module."""
 
-"""
-EDEN is an unbiased lossy compression method that uses a random rotation followed by deterministic quantization and scaling. 
-EDEN provides strong theoretical guarantees, as described in the following ICML 2022 paper: 
+EdenPipeline module.
 
-"EDEN: Communication-Efficient and Robust Distributed Mean Estimation for Federated Learning" 
-Shay Vargaftik, Ran Ben Basat, Amit Portnoy, Gal Mendelson, Yaniv Ben Itzhak, Michael Mitzenmacher, 
+
+EDEN is an unbiased lossy compression method that uses a random rotation
+    followed by deterministic quantization and scaling.
+EDEN provides strong theoretical guarantees, as described in the following ICML 2022 paper:
+
+"EDEN: Communication-Efficient and Robust Distributed Mean Estimation for Federated Learning"
+Shay Vargaftik, Ran Ben Basat, Amit Portnoy, Gal Mendelson, Yaniv Ben Itzhak, Michael Mitzenmacher,
 Proceedings of the 39th International Conference on Machine Learning, PMLR 162:21984-22014, 2022.
 
 https://proceedings.mlr.press/v162/vargaftik22a.html
@@ -20,14 +25,15 @@ https://proceedings.mlr.press/v162/vargaftik22a.html
 ------------------------------------------------------------------------------------------------------------------------
 
 In order to use and configure EDEN use the following lines in plan.yaml:
- 
+
 compression_pipeline :
   defaults : plan/defaults/compression_pipeline.yaml
   template : openfl.pipelines.EdenPipeline
   settings :
     n_bits : <number of bits per coordinate>
     device: <cpu|cuda:0|cuda:1|...>
-    dim_threshold: 1000 #EDEN compresses layers that their dimension is above the dim_threshold, use 1000 as default
+    dim_threshold: 1000 #EDEN compresses layers that their dimension is above the dim_threshold,
+                   use 1000 as default
 """
 
 import torch
@@ -38,196 +44,266 @@ from .pipeline import TransformationPipeline
 from .pipeline import Transformer
 from .pipeline import Float32NumpyArrayToBytes
 
+
 class Eden:
-    
-    
+
     def __init__(self, nbits=8, device='cpu'):
-        
+
         def gen_normal_centroids_and_boundaries(device):
-            
-            ### half-normal lloyd-max centroids
+
+            # half-normal lloyd-max centroids
             centroids = {}
             centroids[1] = [0.7978845608028654]
             centroids[2] = [0.4527800398860679, 1.5104176087114887]
-            centroids[3] = [0.24509416307340598, 0.7560052489539643, 1.3439092613750225, 2.151945669890335]
-            centroids[4] = [0.12839501671105813, 0.38804823445328507, 0.6567589957631145, 0.9423402689122875, 1.2562309480263467, 1.6180460517130526, 2.069016730231837, 2.732588804065177]
-            centroids[5] = [0.06588962234909321, 0.1980516892038791, 0.3313780514298761, 0.4666991751197207, 0.6049331689395434, 0.7471351317890572, 0.89456439585444, 1.0487823813655852, 1.2118032120324, 1.3863389353626248, 1.576226389073775, 1.7872312118858462, 2.0287259913633036, 2.3177364021261493, 2.69111557955431, 3.260726295605043]
-            centroids[6] = [0.0334094558802581, 0.1002781217139195, 0.16729660990171974, 0.23456656976873475, 0.3021922894403614, 0.37028193328115516, 0.4389488009177737, 0.5083127587538033, 0.5785018460645791, 0.6496542452315348, 0.7219204720694183, 0.7954660529025513, 0.870474868055092, 0.9471530930156288, 1.0257343133937524, 1.1064859596918581, 1.1897175711327463, 1.2757916223519965, 1.3651378971823598, 1.458272959944728, 1.5558274659528346, 1.6585847114298427, 1.7675371481292605, 1.8839718992293555, 2.009604894545278, 2.146803022259123, 2.2989727412973995, 2.471294740528467, 2.6722617014102585, 2.91739146530985, 3.2404166403241677, 3.7440690236964755]
-            centroids[7] = [0.016828143177728235, 0.05049075396896167, 0.08417241989671888, 0.11788596825032507, 0.1516442630131618, 0.18546025708680833, 0.21934708340331643, 0.25331807190834565, 0.2873868062260947, 0.32156710392315796, 0.355873075050329, 0.39031926330596733, 0.4249205523979007, 0.4596922300454219, 0.49465018161031576, 0.5298108436256188, 0.565191195643323, 0.600808970989236, 0.6366826613981411, 0.6728315674936343, 0.7092759460939766, 0.746037126679468, 0.7831375375631398, 0.8206007832455021, 0.858451939611374, 0.896717615963322, 0.9354260757626341, 0.9746074842160436, 1.0142940678300427, 1.054520418037026, 1.0953237719213182, 1.1367442623434032, 1.1788252655205043, 1.2216138763870124, 1.26516137869917, 1.309523700469555, 1.3547621051156036, 1.4009441065262136, 1.448144252238147, 1.4964451375010575, 1.5459387008934842, 1.596727786313424, 1.6489283062238074, 1.7026711624156725, 1.7581051606756466, 1.8154009933798645, 1.8747553268072956, 1.9363967204122827, 2.0005932433837565, 2.0676621538384503, 2.1379832427349696, 2.212016460501213, 2.2903268704925304, 2.3736203164211713, 2.4627959084523208, 2.5590234991374485, 2.663867022558051, 2.7794919110540777, 2.909021527386642, 3.0572161028423737, 3.231896182843021, 3.4473810105937095, 3.7348571053691555, 4.1895219330235225]
-            centroids[8] = [0.008445974137017219, 0.025338726226901278, 0.042233889994651476, 0.05913307399220878, 0.07603788791797023, 0.09294994306815242, 0.10987089037069565, 0.12680234584461386, 0.1437459285205906, 0.16070326074968388, 0.1776760066764216, 0.19466583496246115, 0.21167441946986007, 0.22870343946322488, 0.24575458029044564, 0.2628295721769575, 0.2799301528634766, 0.29705806782573063, 0.3142150709211129, 0.3314029639954903, 0.34862355883476864, 0.3658786774238477, 0.3831701926964899, 0.40049998943716425, 0.4178699650069057, 0.4352820704086704, 0.45273827097956804, 0.4702405882876, 0.48779106011037887, 0.505391740756901, 0.5230447441905988, 0.5407522460590347, 0.558516486141511, 0.5763396823538222, 0.5942241184949506, 0.6121721459546814, 0.6301861414640443, 0.6482685527755422, 0.6664219019236218, 0.684648787627676, 0.7029517931200633, 0.7213336286470308, 0.7397970881081071, 0.7583450032075904, 0.7769802937007926, 0.7957059197645721, 0.8145249861674053, 0.8334407494351099, 0.8524564651728141, 0.8715754936480047, 0.8908013031010308, 0.9101374749919184, 0.9295877653215154, 0.9491559977740125, 0.9688461234581733, 0.9886622867721733, 1.0086087121824747, 1.028689768268861, 1.0489101021225093, 1.0692743940997251, 1.0897875553561465, 1.1104547388972044, 1.1312812154370708, 1.1522725891384287, 1.173434599389649, 1.1947731980672593, 1.2162947131430126, 1.238005717146854, 1.2599130381874064, 1.2820237696510286, 1.304345369166531, 1.3268857708606756, 1.349653145284911, 1.3726560932224416, 1.3959037693197867, 1.419405726021264, 1.4431719292973744, 1.4672129964566984, 1.4915401336751468, 1.5161650628244996, 1.541100284490976, 1.5663591473033147, 1.5919556551358922, 1.6179046397057497, 1.6442219553485078, 1.6709244249695359, 1.6980300628044107, 1.7255580190748743, 1.7535288357430767, 1.7819645728459763, 1.81088895442524, 1.8403273195729115, 1.870306964218662, 1.9008577747790962, 1.9320118435829472, 1.9638039107009146, 1.9962716117712092, 2.0294560760505993, 2.0634026367482017, 2.0981611002741527, 2.133785932225919, 2.170336784741086, 2.2078803102947337, 2.2464908293749546, 2.286250990303635, 2.327254033532845, 2.369604977942217, 2.4134218838650208, 2.458840003415269, 2.506014300608167, 2.5551242195294983, 2.6063787537827645, 2.660023038604595, 2.716347847697055, 2.7757011083910723, 2.838504606698991, 2.9052776685316117, 2.976670770545963, 3.0535115393558603, 3.136880130166507, 3.2282236667414654, 3.3295406612081644, 3.443713971315384, 3.5751595986789093, 3.7311414987004117, 3.9249650523739246, 4.185630113705256, 4.601871059539151]
-                           
-            ### normal centroids
+            centroids[3] = [
+                0.24509416307340598, 0.7560052489539643, 1.3439092613750225, 2.151945669890335
+            ]
+            centroids[4] = [
+                0.12839501671105813, 0.38804823445328507, 0.6567589957631145, 0.9423402689122875,
+                1.2562309480263467, 1.6180460517130526, 2.069016730231837, 2.732588804065177
+            ]
+            centroids[5] = [
+                0.06588962234909321, 0.1980516892038791, 0.3313780514298761, 0.4666991751197207,
+                0.6049331689395434, 0.7471351317890572, 0.89456439585444, 1.0487823813655852,
+                1.2118032120324, 1.3863389353626248, 1.576226389073775, 1.7872312118858462,
+                2.0287259913633036, 2.3177364021261493, 2.69111557955431, 3.260726295605043
+            ]
+            centroids[6] = [
+                0.0334094558802581, 0.1002781217139195, 0.16729660990171974, 0.23456656976873475,
+                0.3021922894403614, 0.37028193328115516, 0.4389488009177737, 0.5083127587538033,
+                0.5785018460645791, 0.6496542452315348, 0.7219204720694183, 0.7954660529025513,
+                0.870474868055092, 0.9471530930156288, 1.0257343133937524, 1.1064859596918581,
+                1.1897175711327463, 1.2757916223519965, 1.3651378971823598, 1.458272959944728,
+                1.5558274659528346, 1.6585847114298427, 1.7675371481292605, 1.8839718992293555,
+                2.009604894545278, 2.146803022259123, 2.2989727412973995, 2.471294740528467,
+                2.6722617014102585, 2.91739146530985, 3.2404166403241677, 3.7440690236964755
+            ]
+            centroids[7] = [
+                0.016828143177728235, 0.05049075396896167, 0.08417241989671888,
+                0.11788596825032507, 0.1516442630131618, 0.18546025708680833, 0.21934708340331643,
+                0.25331807190834565, 0.2873868062260947, 0.32156710392315796, 0.355873075050329,
+                0.39031926330596733, 0.4249205523979007, 0.4596922300454219, 0.49465018161031576,
+                0.5298108436256188, 0.565191195643323, 0.600808970989236, 0.6366826613981411,
+                0.6728315674936343, 0.7092759460939766, 0.746037126679468, 0.7831375375631398,
+                0.8206007832455021, 0.858451939611374, 0.896717615963322, 0.9354260757626341,
+                0.9746074842160436, 1.0142940678300427, 1.054520418037026, 1.0953237719213182,
+                1.1367442623434032, 1.1788252655205043, 1.2216138763870124, 1.26516137869917,
+                1.309523700469555, 1.3547621051156036, 1.4009441065262136, 1.448144252238147,
+                1.4964451375010575, 1.5459387008934842, 1.596727786313424, 1.6489283062238074,
+                1.7026711624156725, 1.7581051606756466, 1.8154009933798645, 1.8747553268072956,
+                1.9363967204122827, 2.0005932433837565, 2.0676621538384503, 2.1379832427349696,
+                2.212016460501213, 2.2903268704925304, 2.3736203164211713, 2.4627959084523208,
+                2.5590234991374485, 2.663867022558051, 2.7794919110540777, 2.909021527386642,
+                3.0572161028423737, 3.231896182843021, 3.4473810105937095, 3.7348571053691555,
+                4.1895219330235225
+            ]
+            centroids[8] = [
+                0.008445974137017219, 0.025338726226901278, 0.042233889994651476,
+                0.05913307399220878, 0.07603788791797023, 0.09294994306815242, 0.10987089037069565,
+                0.12680234584461386, 0.1437459285205906, 0.16070326074968388, 0.1776760066764216,
+                0.19466583496246115, 0.21167441946986007, 0.22870343946322488, 0.24575458029044564,
+                0.2628295721769575, 0.2799301528634766, 0.29705806782573063, 0.3142150709211129,
+                0.3314029639954903, 0.34862355883476864, 0.3658786774238477, 0.3831701926964899,
+                0.40049998943716425, 0.4178699650069057, 0.4352820704086704, 0.45273827097956804,
+                0.4702405882876, 0.48779106011037887, 0.505391740756901, 0.5230447441905988,
+                0.5407522460590347, 0.558516486141511, 0.5763396823538222, 0.5942241184949506,
+                0.6121721459546814, 0.6301861414640443, 0.6482685527755422, 0.6664219019236218,
+                0.684648787627676, 0.7029517931200633, 0.7213336286470308, 0.7397970881081071,
+                0.7583450032075904, 0.7769802937007926, 0.7957059197645721, 0.8145249861674053,
+                0.8334407494351099, 0.8524564651728141, 0.8715754936480047, 0.8908013031010308,
+                0.9101374749919184, 0.9295877653215154, 0.9491559977740125, 0.9688461234581733,
+                0.9886622867721733, 1.0086087121824747, 1.028689768268861, 1.0489101021225093,
+                1.0692743940997251, 1.0897875553561465, 1.1104547388972044, 1.1312812154370708,
+                1.1522725891384287, 1.173434599389649, 1.1947731980672593, 1.2162947131430126,
+                1.238005717146854, 1.2599130381874064, 1.2820237696510286, 1.304345369166531,
+                1.3268857708606756, 1.349653145284911, 1.3726560932224416, 1.3959037693197867,
+                1.419405726021264, 1.4431719292973744, 1.4672129964566984, 1.4915401336751468,
+                1.5161650628244996, 1.541100284490976, 1.5663591473033147, 1.5919556551358922,
+                1.6179046397057497, 1.6442219553485078, 1.6709244249695359, 1.6980300628044107,
+                1.7255580190748743, 1.7535288357430767, 1.7819645728459763, 1.81088895442524,
+                1.8403273195729115, 1.870306964218662, 1.9008577747790962, 1.9320118435829472,
+                1.9638039107009146, 1.9962716117712092, 2.0294560760505993, 2.0634026367482017,
+                2.0981611002741527, 2.133785932225919, 2.170336784741086, 2.2078803102947337,
+                2.2464908293749546, 2.286250990303635, 2.327254033532845, 2.369604977942217,
+                2.4134218838650208, 2.458840003415269, 2.506014300608167, 2.5551242195294983,
+                2.6063787537827645, 2.660023038604595, 2.716347847697055, 2.7757011083910723,
+                2.838504606698991, 2.9052776685316117, 2.976670770545963, 3.0535115393558603,
+                3.136880130166507, 3.2282236667414654, 3.3295406612081644, 3.443713971315384,
+                3.5751595986789093, 3.7311414987004117, 3.9249650523739246, 4.185630113705256,
+                4.601871059539151
+            ]
+
+            # normal centroids
             for i in centroids:
-                centroids[i] = torch.Tensor([-j for j in centroids[i][::-1]] + centroids[i]).to(device)
-            
-            ### centroids to bin boundaries
+                centroids[i] = torch.Tensor([-j for j in centroids[i][::-1]] + centroids[i])\
+                    .to(device)
+
+            # centroids to bin boundaries
             def gen_boundaries(centroids):
                 return [(a + b) / 2 for a, b in zip(centroids[:-1], centroids[1:])]
-        
-            ### bin boundaries
+
+            # bin boundaries
             boundaries = {}
             for i in centroids:
                 boundaries[i] = torch.Tensor(gen_boundaries(centroids[i])).to(device)
-                    
+
             return centroids, boundaries
 
-        # device ('cpu' or 'cuda')
+        # device - 'cpu' or 'cuda'
         self.device = device
-        
+
         # generate metadata for compression
         self.centroids, self.boundaries = gen_normal_centroids_and_boundaries(self.device)
 
         # bits per coordinate
-        if nbits not in [1,2,3,4,5,6,7,8]:
+        if nbits not in [1, 2, 3, 4, 5, 6, 7, 8]:
             raise Exception("nbits value is not supported")
         self.nbits = int(nbits)
-        
+
         # shared randomness
         self.sender_prng = torch.Generator(device=device)
         self.receiver_prng = torch.Generator(device=device)
 
         # number of hadamard transforms to employ
-        self.num_hadamard = 2 # TODO: add as a configurable parameter to YAML? 2 is default and always works, but 1 can be used for non-adversarial inputs and thus run faster
-        
-        
-    def hadamard(self, vec):
-        
-        d = vec.numel()
-        if d & (d-1) != 0:
-            raise Exception("input numel must be a power of 2")
-          
-        h = 2
-        while h <= d:        
-            hf = h//2
-            vec = vec.view(d//h,h)
-            vec[:,:hf]  = vec[:,:hf] + vec[:,hf:2*hf]
-            vec[:,hf:2*hf] = vec[:,:hf] - 2*vec[:,hf:2*hf]
-            h *= 2   
-        vec /= np.sqrt(d)
-        
-        return vec.view(-1)
+        self.num_hadamard = 2
+        # TODO: add as a configurable parameter to YAML?
+        # 2 is default and always works,
+        # but 1 can be used for non-adversarial inputs and thus run faster
 
+    def hadamard(self, vec):
+
+        d = vec.numel()
+        if d & (d - 1) != 0:
+            raise Exception("input numel must be a power of 2")
+
+        h = 2
+        while h <= d:
+            hf = h // 2
+            vec = vec.view(d // h, h)
+            vec[:, :hf] = vec[:, :hf] + vec[:, hf:2 * hf]
+            vec[:, hf:2 * hf] = vec[:, :hf] - 2 * vec[:, hf:2 * hf]
+            h *= 2
+        vec /= np.sqrt(d)
+
+        return vec.view(-1)
 
     # randomized Hadamard transform
     def rht(self, vec, seed):
-        
+
         self.sender_prng.manual_seed(seed)
-        
-        vec = vec * (2 * torch.bernoulli(torch.ones(vec.numel(), device=vec.device) / 2, generator=self.sender_prng) - 1)
+        ones = torch.ones(vec.numel(), device=vec.device)
+        vec = vec * (2 * torch.bernoulli(ones / 2, generator=self.sender_prng) - 1)
         vec = self.hadamard(vec)
-        
+
         return vec
 
     # inverse randomized Hadamard transform
     def irht(self, vec, seed):
-        
+
         self.receiver_prng.manual_seed(seed)
-        
+
         vec = self.hadamard(vec)
-        vec = vec * (2 * torch.bernoulli(torch.ones(vec.numel(), device=vec.device) / 2, generator=self.receiver_prng) - 1)
-        
-        return vec    
-    
-    
+        ones = torch.ones(vec.numel(), device=vec.device)
+        vec = vec * (2 * torch.bernoulli(ones / 2, generator=self.receiver_prng) - 1)
+
+        return vec
+
     def quantize(self, vec):
-        
-        vec_norm = torch.norm(vec,2)
-        
+
+        vec_norm = torch.norm(vec, 2)
+
         if vec_norm > 0:
-        
-            bins = torch.bucketize(vec * (vec.numel()**0.5) / vec_norm, self.boundaries[self.nbits])
+
+            normalized = vec * (vec.numel()**0.5) / vec_norm
+            bins = torch.bucketize(normalized, self.boundaries[self.nbits])
             scale = vec_norm**2 / torch.dot(torch.take(self.centroids[self.nbits], bins), vec)
-            
+
             if not torch.isnan(scale):
-                return bins, scale              
-        
+                return bins, scale
+
         return torch.zeros(vec.numel(), device=vec.device), torch.tensor([0])
 
-
     def compress(self, vec, seed):
-        
-        vec = torch.Tensor(vec.flatten()).to(self.device)   
+
+        vec = torch.Tensor(vec.flatten()).to(self.device)
         dim = vec.numel()
 
         if not dim & (dim - 1) == 0 or dim < 8:
-            
+
             padded_dim = max(int(2**(np.ceil(np.log2(dim)))), 8)
             padded_vec = torch.zeros(padded_dim, device=self.device)
             padded_vec[:dim] = vec
-            
+
             vec = self.rht(padded_vec, seed)
             for i in range(1, self.num_hadamard):
-                vec = self.rht(vec, seed+i)
-                
+                vec = self.rht(vec, seed + i)
+
         else:
-            
+
             for i in range(self.num_hadamard):
-                vec = self.rht(vec, seed+i)
-            
+                vec = self.rht(vec, seed + i)
+
         bins, scale = self.quantize(vec)
         bins = self.toBits(bins)
 
         return bins.cpu().numpy(), float(scale.cpu().numpy()), dim
-    
 
     def decompress(self, bins, scale, dim, seed):
-        
+
         bins = self.fromBits(torch.Tensor(bins).to(self.device)).long()
         vec = torch.take(self.centroids[self.nbits], bins)
-        
+
         for i in range(self.num_hadamard):
-            vec = self.irht(vec, int(seed+(self.num_hadamard-1)-i))
-        
+            vec = self.irht(vec, int(seed + (self.num_hadamard - 1) - i))
+
         return (scale * vec)[:int(dim)].cpu().numpy()
- 
-    
+
     # packing the quantization values to bytes
     def toBits(self, intBoolVec):
-        
+
         def toBits_h(ibv):
-            
-            n = ibv.numel()  
+
+            n = ibv.numel()
             ibv = ibv.view(n // 8, 8).int()
-            
+
             bv = torch.zeros(n // 8, dtype=torch.uint8, device=ibv.device)
             for i in range(8):
                 bv += ibv[:, i] * (2**i)
 
             return bv
-        
-        Lunit =  intBoolVec.numel() // 8       
-        bitVec = torch.zeros(Lunit * self.nbits, dtype=torch.uint8)
-        
-        for i in range(self.nbits):
-            bitVec[Lunit*i:Lunit*(i+1)] = toBits_h((intBoolVec % 2 != 0).int())
-            intBoolVec = torch.div(intBoolVec, 2, rounding_mode='floor')
-        
-        return bitVec
-    
 
-    # unpacking bytes to quantization values       
+        Lunit = intBoolVec.numel() // 8
+        bitVec = torch.zeros(Lunit * self.nbits, dtype=torch.uint8)
+
+        for i in range(self.nbits):
+            bitVec[Lunit * i:Lunit * (i + 1)] = toBits_h((intBoolVec % 2 != 0).int())
+            intBoolVec = torch.div(intBoolVec, 2, rounding_mode='floor')
+
+        return bitVec
+
+    # unpacking bytes to quantization values
     def fromBits(self, bitVec):
-    
+
         def fromBits_h(bv, device):
-            
+
             n = bv.numel()
-            
+
             iv = torch.zeros((8, n)).to(device)
             for i in range(8):
                 temp = bv.clone()
                 iv[i] = (torch.div(temp, 2 ** i, rounding_mode='floor') % 2 != 0).int()
 
-            return iv.T.reshape(-1)  
-        
+            return iv.T.reshape(-1)
+
         bitVec = bitVec.view(self.nbits, bitVec.numel() // self.nbits).to(self.device)
         intVecs = torch.zeros(bitVec.numel() // self.nbits * 8).to(self.device)
-        
+
         for i in range(self.nbits):
             intVecs += 2**i * fromBits_h(bitVec[i], self.device)
-        
-        return intVecs.reshape(1, -1) 
 
-    
+        return intVecs.reshape(1, -1)
+
+
 class EdenTransformer(Transformer):
     """Eden transformer class to quantize input data."""
 
@@ -237,34 +313,34 @@ class EdenTransformer(Transformer):
         self.lossy = True
         self.eden = Eden(nbits=n_bits, device=device)
 
-        print('*** Using EdenTransformer with params: {} bits, dim_threshold: {}, {} device ***'.format(n_bits, dim_threshold, device))
-        
+        print(f'*** Using EdenTransformer with params: {n_bits} bits,'
+              f'dim_threshold: {dim_threshold}, {device} device ***')
+
         self.dim_threshold = dim_threshold
         self.no_comp = Float32NumpyArrayToBytes()
-        
 
     def forward(self, data, **kwargs):
         """
         Quantize data.
         """
-        
-        seed = (hash(sum(data.flatten())*13+7)+np.random.randint(1,2**16))%(2**16) #TODO: can be simplified if have access to a unique feature of the participant (e.g., ID)
+        # TODO: can be simplified if have access to a unique feature of the participant (e.g., ID)
+        seed = (hash(sum(data.flatten()) * 13 + 7) + np.random.randint(1, 2**16)) % (2**16)
         seed = int(float(seed))
         metadata = {'int_list': list(data.shape)}
-        
+
         if data.size > self.dim_threshold:
             int_array, scale, dim = self.eden.compress(data, seed)
-            metadata['int_to_float'] = {0 : scale, 1 : float(dim), 2 : float(seed)} #TODO: workaround: using the int to float dictionary to pass eden's metadata
+            # TODO: workaround: using the int to float dictionary to pass eden's metadata
+            metadata['int_to_float'] = {0: scale, 1: float(dim), 2: float(seed)}
 
             return_values = int_array.astype(np.uint8).tobytes(), metadata
 
         else:
 
             no_comp_data, metadata = self.no_comp.forward(data)
-            return_values =  no_comp_data, metadata
+            return_values = no_comp_data, metadata
 
         return return_values
-
 
     def backward(self, data, metadata, **kwargs):
         """Recover data array back to the original numerical type and the shape.
@@ -276,14 +352,16 @@ class EdenTransformer(Transformer):
         Returns:
             data: Numpy array with original numerical type and shape
         """
-        
-        if np.prod(metadata['int_list']) >= self.dim_threshold: # compressed data
+
+        if np.prod(metadata['int_list']) >= self.dim_threshold:  # compressed data
             data = np.frombuffer(data, dtype=np.uint8)
             data = co.deepcopy(data)
-            data = self.eden.decompress(data,
-                                    metadata['int_to_float'][0], 
-                                    metadata['int_to_float'][1], 
-                                    metadata['int_to_float'][2])
+            data = self.eden.decompress(
+                data,
+                metadata['int_to_float'][0],
+                metadata['int_to_float'][1],
+                metadata['int_to_float'][2]
+            )
             data_shape = list(metadata['int_list'])
             data = data.reshape(data_shape)
         else:
@@ -302,7 +380,8 @@ class EdenPipeline(TransformationPipeline):
         Args:
             n_bits (int): Number of bits per coordinate (1-8 bits are supported)
             dim_threshold (int): Layers with less than dim_threshold params are not compressed
-            device: Device for executing the compression and decompression (e.g., 'cpu', 'cuda:0', 'cuda:1')
+            device: Device for executing the compression and decompression
+                    (e.g., 'cpu', 'cuda:0', 'cuda:1')
 
         Return:
             Transformer class object

--- a/openfl/plugins/frameworks_adapters/keras_adapter.py
+++ b/openfl/plugins/frameworks_adapters/keras_adapter.py
@@ -6,6 +6,8 @@ from logging import getLogger
 from .framework_adapter_interface import FrameworkAdapterPluginInterface
 
 logger = getLogger(__name__)
+
+
 class FrameworkAdapterPlugin(FrameworkAdapterPluginInterface):
     """Framework adapter plugin class."""
 
@@ -50,8 +52,8 @@ class FrameworkAdapterPlugin(FrameworkAdapterPluginInterface):
 
         # Run the function
         if tf.__version__ <= '2.7.1':
-            logger.warn(f'Applying hotfix for model serialization.'
-            'Please consider updating to tensorflow>=2.8 to silence this warning.')
+            logger.warn('Applying hotfix for model serialization.'
+                        'Please consider updating to tensorflow>=2.8 to silence this warning.')
             make_keras_picklable()
 
     @staticmethod

--- a/openfl/transport/grpc/grpc_channel_options.py
+++ b/openfl/transport/grpc/grpc_channel_options.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 max_metadata_size = 32 * 2 ** 20
 max_message_length = 2 ** 30
 

--- a/tests/openfl/utilities/optimizers/test_numpy_optimizers.py
+++ b/tests/openfl/utilities/optimizers/test_numpy_optimizers.py
@@ -8,8 +8,8 @@ import pytest
 from openfl.utilities.optimizers.numpy.adagrad_optimizer import NumPyAdagrad
 from openfl.utilities.optimizers.numpy.adam_optimizer import NumPyAdam
 from openfl.utilities.optimizers.numpy.yogi_optimizer import NumPyYogi
-from.func_for_optimization import mc_cormick_func
-from.func_for_optimization import rosenbrock_func
+from .func_for_optimization import mc_cormick_func
+from .func_for_optimization import rosenbrock_func
 
 EPS = 5e-5
 


### PR DESCRIPTION
This pull request contains:
 - Including installation of flake8 extensions
 - Making linter workflow fail on any non-ignored (see setup.cfg) error.
 - Removing linter rules specified directly in workflow code. All rules have already been specified in setup.cfg file in the repository root.
 - Fixing all linter errors 

Tested the behavior locally via [act](https://github.com/nektos/act).