### PR TITLE
Configurable enclave size

### DIFF
--- a/openfl-gramine/Dockerfile.graminized.workspace
+++ b/openfl-gramine/Dockerfile.graminized.workspace
@@ -14,8 +14,9 @@ RUN cp /usr/local/lib/python3.8/site-packages/openfl-gramine/openfl.manifest.tem
     cp /usr/local/lib/python3.8/site-packages/openfl-gramine/start_process.sh .
 
 ARG SGX_BUILD=1
+ARG SGX_ENCLAVE_SIZE=16G
 RUN --mount=type=secret,id=signer-key,dst=/key.pem \
-    make clean && make SGX=${SGX_BUILD} SGX_SIGNER_KEY=/key.pem
+    make clean && make SGX=${SGX_BUILD} SGX_ENCLAVE_SIZE=${SGX_ENCLAVE_SIZE} SGX_SIGNER_KEY=/key.pem
 
 ENV GRAMINE_EXECUTABLE=gramine-sgx
 ENTRYPOINT ["/bin/bash", "start_process.sh"]

--- a/openfl-gramine/Makefile
+++ b/openfl-gramine/Makefile
@@ -3,6 +3,7 @@ ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 # Enclave attributes to the manifest
 SGX_ISVPRODID ?= 0
 SGX_ISVSVN ?= 0
+SGX_ENCLAVE_SIZE ?= 16G
 
 # This is a signer key on the BUILDING machine
 SGX_SIGNER_KEY ?= /key.pem
@@ -26,6 +27,7 @@ openfl.manifest: openfl.manifest.template
 		-Darch_libdir=$(ARCH_LIBDIR) \
 		-Disvprodid=$(SGX_ISVPRODID) \
 		-Disvsvn=$(SGX_ISVSVN) \
+		-Denclave_size=$(SGX_ENCLAVE_SIZE) \
 		-Dno_proxy=$(no_proxy) \
 		-Dhttp_proxy=$(http_proxy) \
 		-Dhttps_proxy=$(https_proxy) \

--- a/openfl-gramine/openfl.manifest.template
+++ b/openfl-gramine/openfl.manifest.template
@@ -46,7 +46,7 @@ loader.pal_internal_mem_size = "256M"
 
 sgx.debug = false
 sgx.nonpie_binary = true
-sgx.enclave_size = "16G"
+sgx.enclave_size = "{{ enclave_size }}"
 sys.stack.size = "4M"
 sgx.thread_num = 512
 #sys.brk.max_size = "1M"

--- a/openfl/interface/workspace.py
+++ b/openfl/interface/workspace.py
@@ -435,6 +435,11 @@ def dockerize_(context, base_image, save):
              'In option is ignored this command will build an image that can only run '
              'with gramine-direct (not in enclave).',
         )
+@option('-e', '--enclave_size', required=False,
+        type=str, default='16G',
+        help='Memory size of the enclave, defined as number with size suffix. Must be a power-of-2.\n'
+             'Default is 16G.'
+        )
 @option('-o', '--pip-install-options', required=False,
         type=str, multiple=True, default=tuple,
         help='Options for remote pip install. '
@@ -445,7 +450,7 @@ def dockerize_(context, base_image, save):
         help='Dump the Docker image to an archive')
 @option('--rebuild', help='Build images with `--no-cache`', is_flag=True)
 @pass_context
-def graminize_(context, signing_key: Path, pip_install_options: Tuple[str],
+def graminize_(context, signing_key: Path, enclave_size: str, pip_install_options: Tuple[str],
                save: bool, rebuild: bool) -> None:
     """
     Build gramine app inside a docker image.
@@ -504,6 +509,7 @@ def graminize_(context, signing_key: Path, pip_install_options: Tuple[str],
         f'docker build -t {workspace_name} {rebuild_option} '
         '--build-arg BASE_IMAGE=gramine_openfl '
         f'--build-arg WORKSPACE_ARCHIVE={workspace_archive.relative_to(workspace_path)} '
+        f'--build-arg SGX_ENCLAVE_SIZE={enclave_size} '
         f'--build-arg SGX_BUILD={int(sgx_build)} '
         f'{signing_key}'
         f'-f {grainized_ws_dockerfile} {workspace_path}')


### PR DESCRIPTION
Currently OpenFL enclave size is hardcoded to 16G. Add option to
configure it in build time:
Add the "-e" argument to "fx workspace graminize", to allow setting
the size of the enclave that will be used in the image. This setting
propagates as a Docker build argument to the makefile in openfl-gramine,
which eventually becomes an argument in the generated manifest.
Default size is 16G, to maintain backwards compatibility.

Fixes #568