### PR TITLE
OpenFL-Gramine fixes for SGX execution [reupload]

### DIFF
--- a/openfl-gramine/Dockerfile.gramine
+++ b/openfl-gramine/Dockerfile.gramine
@@ -5,7 +5,8 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN --mount=type=cache,target=/root/.cache/ \
     pip install --upgrade pip && \
-    pip install openfl
+    git clone --single-branch --branch develop https://github.com/intel/openfl.git && \
+    pip install ./openfl
 
 # install gramine
 RUN curl -fsSLo /usr/share/keyrings/gramine-keyring.gpg https://packages.gramineproject.io/gramine-keyring.gpg && \

--- a/openfl-gramine/MANUAL.md
+++ b/openfl-gramine/MANUAL.md
@@ -36,6 +36,10 @@ export TEMPLATE_NAME=torch_cnn_histology
 fx workspace create --prefix $WORKSPACE_NAME --template $TEMPLATE_NAME
 cd $WORKSPACE_NAME
 ```
+Be sure that the Python versions used on the building node and inside the Docker container both support the requirement.txt files of your selected workspace.
+If that is not the case, proceed to manually modify your selected workspace requirement.txt file in the openfl-workspace installation folder to obtain a congruous environment.
+Also, if you are planning to use the SGX support, be sure that that requirements.txt file does not contain any reference to CUDA distributions.
+
 Modify the code and the plan.yaml, set up your training procedure. </br>
 Pay attention to the following: 
 - make sure the data loading code reads data from ./data folder inside the workspace
@@ -47,7 +51,7 @@ Default workspaces (templates) in OpenFL differ in their data downloading proced
 - torch_cnn_histology
 - keras_nlp
 
-Also the other worksapces can be used by taking care of placing the dataset used under a data/ folder.
+Also the other workspaces can be used by taking care of placing the dataset used under a data/ folder and modifying the requirements.txt file so that it does not contain references to CUDA distributions.
 
 2. **Initialize the experiment plan** </br> 
 Find out the FQDN of the **Aggregator machine** and use it for plan initialization.
@@ -71,6 +75,9 @@ openssl genrsa -3 -out $KEY_LOCATION/key.pem 3072
 This key will not be packed into the final Docker image.
 
 4. **Build the Experiment Docker image**
+
+Before building the image, according to your SGX-capable processor, it could be necessary to turn off the logging TensorBoardX logging functionality from the plan.
+This can be done by simply setting `write_logs: false` in the plan/plan.yaml file.
 
 ```
 fx workspace graminize -s $KEY_LOCATION/key.pem
@@ -105,14 +112,14 @@ docker load < WORKSPACE_NAME.tar.gz
 ```
 
 7. **Prepare certificates**
-Certificates exchange is a big separate topic. To run an experiment following OpenFL Aggregator-based workflow, a user must follow the established procedure, please refer to [the docs](https://openfl.readthedocs.io/en/latest/running_the_federation.html#bare-metal-approach) (only Section 2 without the workspace import/export steps).
-Following the above-mentioned procedure, running machines will acquire certificates. Moreover, as the result of this procedure, the aggregator machine will also obtain a `cols.yaml` file (required to start an experiment) with registered collaborators' names, and the collaborator machines will obtain `data.yaml` files.
-Certain already available examples have already defined collaborator names; please double-check that the `cols.yaml` and `data.yaml` files contain only the names of the desired collaborators.
+Certificates exchange is a big separate topic. To run an experiment following OpenFL Aggregator-based workflow, a user must follow the established procedure, please refer to [the docs](https://openfl.readthedocs.io/en/latest/running_the_federation.html#bare-metal-approach) (only Section 2 without the workspace import/export steps). 
+Before starting to create the certificates, create an empty plan/cols.yaml file on the Aggregator node and an empty plan/data.yaml file on each Colleborator node.
+Please double-check that the `cols.yaml` and `data.yaml` files contain only the names of the desired collaborators after the certification procedure.
 
 We recommend replicating the OpenFL workspace folder structure on all the machines and following the usual certifying procedure. Finally, on the aggregator node you should have the following folder structure:
 ```
 workspace/
---save/WORKSPACE_NAME_init.pbuf
+--save/TEMPLATE_NAME_init.pbuf
 --logs/
 --plan/cols.yaml
 --cert/
@@ -229,6 +236,9 @@ Another option is to copy OpenFL source files from an on-disk cloned repo, but i
 - During plan initialization we need data to initialize the model. so at least one collaborator should be in data.yaml and its data should be available. cols.yaml may be empty at first
 During cert sign request generation cols.yaml on collaborators remain empty, data.yaml is extended if needed. On aggregator, cols.yaml are updated during signing procedure, data.yaml remains unmodified
 - `error: Disallowing access to file '/usr/local/lib/python3.8/__pycache__/signal.cpython-38.pyc.3423950304'; file is not protected, trusted or allowed.`
+- The TensorBoardX logging functionality is troublesome; it is better to deactivate the log functionality in the plan.
+- Depending on the Python version inside the Docker container, it could be necessary to manually change the requirement.txt file present in the chosen workspace installation folder.
+- Different OpenFL version used inside and outside the Docker container could lead into issues when running the experiments.
 
  ## TO-DO:
 - [X] import manifest and makefile from OpenFL dist-package 

--- a/openfl-gramine/MANUAL.md
+++ b/openfl-gramine/MANUAL.md
@@ -17,7 +17,7 @@ Building machine:
 - Docker should be installed, user included in Docker group
 
 Machines that will run an Aggregator and Collaborator containers should have the following:
-- OpenFL
+- OpenFL (If used for certification through built-in tooling)
 - FSGSBASE feature and SGX enabled from BIOS
 - Intel SGX driver or Linux 5.11+ driver
 - Intel SGX SDK/PSW

--- a/openfl-gramine/openfl.manifest.template
+++ b/openfl-gramine/openfl.manifest.template
@@ -38,7 +38,7 @@ fs.mount.workspace.type = "chroot"
 fs.mount.workspace.path = "/workspace"
 fs.mount.workspace.uri = "file:/workspace"
 
-fs.mount.tmp.type = "chroot"
+fs.mount.tmp.type = "tmpfs"
 fs.mount.tmp.path = "/tmp"
 fs.mount.tmp.uri = "file:/tmp"
 

--- a/openfl-gramine/openfl.manifest.template
+++ b/openfl-gramine/openfl.manifest.template
@@ -38,6 +38,10 @@ fs.mount.workspace.type = "chroot"
 fs.mount.workspace.path = "/workspace"
 fs.mount.workspace.uri = "file:/workspace"
 
+fs.mount.tmp.type = "chroot"
+fs.mount.tmp.path = "/tmp"
+fs.mount.tmp.uri = "file:/tmp"
+
 sgx.preheat_enclave = false
 
 # Detected a huge manifest, preallocating 64MB of internal memory.

--- a/openfl-gramine/openfl.manifest.template
+++ b/openfl-gramine/openfl.manifest.template
@@ -18,28 +18,15 @@ fs.start_dir="/workspace"
 # .URI - path on host
 # .PATH - pointer inside gramine
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
+fs.mounts = [
+  { uri = "file:{{ gramine.runtimedir() }}", path = "/lib" },
+  { uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },
+  { uri = "file:/usr", path = "/usr" },
+  { uri = "file:/etc", path = "/etc" },
+  { uri = "file:/workspace", path = "/workspace" },
 
-fs.mount.lib2.type = "chroot"
-fs.mount.lib2.path = "{{ arch_libdir }}"
-fs.mount.lib2.uri = "file:{{ arch_libdir }}"
-
-fs.mount.usr.type = "chroot"
-fs.mount.usr.path = "/usr"
-fs.mount.usr.uri = "file:/usr"
-
-fs.mount.etc.type = "chroot"
-fs.mount.etc.path = "/etc"
-fs.mount.etc.uri = "file:/etc"
-
-fs.mount.workspace.type = "chroot"
-fs.mount.workspace.path = "/workspace"
-fs.mount.workspace.uri = "file:/workspace"
-
-fs.mount.tmp.type = "tmpfs"
-fs.mount.tmp.path = "/tmp"
+  { type = "tmpfs", path = "/tmp" },
+]
 
 sgx.preheat_enclave = false
 
@@ -49,7 +36,7 @@ loader.pal_internal_mem_size = "256M"
 
 sgx.debug = false
 sgx.nonpie_binary = true
-sgx.enclave_size = "16G"
+sgx.enclave_size = "{{ enclave_size }}"
 sys.stack.size = "4M"
 sgx.thread_num = 512
 #sys.brk.max_size = "1M"
@@ -71,7 +58,6 @@ sgx.trusted_files = [
 ]
 
 sgx.allowed_files = [
-  "file:/tmp",
   "file:/etc",
   "file:/workspace/save",
   "file:/workspace/logs",

--- a/openfl-gramine/openfl.manifest.template
+++ b/openfl-gramine/openfl.manifest.template
@@ -40,7 +40,6 @@ fs.mount.workspace.uri = "file:/workspace"
 
 fs.mount.tmp.type = "tmpfs"
 fs.mount.tmp.path = "/tmp"
-fs.mount.tmp.uri = "file:/tmp"
 
 sgx.preheat_enclave = false
 

--- a/openfl-gramine/openfl.manifest.template
+++ b/openfl-gramine/openfl.manifest.template
@@ -18,15 +18,28 @@ fs.start_dir="/workspace"
 # .URI - path on host
 # .PATH - pointer inside gramine
 
-fs.mounts = [
-  { uri = "file:{{ gramine.runtimedir() }}", path = "/lib" },
-  { uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },
-  { uri = "file:/usr", path = "/usr" },
-  { uri = "file:/etc", path = "/etc" },
-  { uri = "file:/workspace", path = "/workspace" },
+fs.mount.lib.type = "chroot"
+fs.mount.lib.path = "/lib"
+fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
 
-  { type = "tmpfs", path = "/tmp" },
-]
+fs.mount.lib2.type = "chroot"
+fs.mount.lib2.path = "{{ arch_libdir }}"
+fs.mount.lib2.uri = "file:{{ arch_libdir }}"
+
+fs.mount.usr.type = "chroot"
+fs.mount.usr.path = "/usr"
+fs.mount.usr.uri = "file:/usr"
+
+fs.mount.etc.type = "chroot"
+fs.mount.etc.path = "/etc"
+fs.mount.etc.uri = "file:/etc"
+
+fs.mount.workspace.type = "chroot"
+fs.mount.workspace.path = "/workspace"
+fs.mount.workspace.uri = "file:/workspace"
+
+fs.mount.tmp.type = "tmpfs"
+fs.mount.tmp.path = "/tmp"
 
 sgx.preheat_enclave = false
 
@@ -36,7 +49,7 @@ loader.pal_internal_mem_size = "256M"
 
 sgx.debug = false
 sgx.nonpie_binary = true
-sgx.enclave_size = "{{ enclave_size }}"
+sgx.enclave_size = "16G"
 sys.stack.size = "4M"
 sgx.thread_num = 512
 #sys.brk.max_size = "1M"


### PR DESCRIPTION
[This PR is a copy of a previous one closed by error due to some branching reorganization]

This PR aims to make the OpenFL-Gramine workflow smoother for the user.

I have modified the openfl.manifest.template to include the mount of the /tmp directory since the lack of it was causing errors in the execution of the container.
Furthermore, I have updated the Dockerfile.gramine file so that now it will download and install the last development branch of the OpenFL software. This way, the version of OpenFL installed inside the container will be the same one used for development, and there will be no mismatch between OpenFL versions inside and outside the container. Once a new stable version of OpenFL is released, this will need to be changed to point to the last stable version.
Lastly, I've extended the Manual.md file to include many small things I learned while trying to make the OpenFL-Gramine example work. Now it should be easier for a newbie to run this application.

I have tested all the changes I made, and they are working as they are.
The only difference to this PR is that, in my tests, the Docker image contained my project fork; in this PR I have changed that pointer to the developmental branch of OpenFL so that, if integrated, it will work out-of-the-box.

[Comments]
DL8: "are you sure that's the case? as far as i understand, the docker image is used, so aggregator and collaborators using it don't really need openfl installed"
Answer: "Yes, you're right that the training will be carried out with the Docker container, in which OpenFL will already be present. However, the user will still need the OpenFL functionalities available outside the Docker container to carry out the exchange and validation of the certificates, as reported in step 7 of the actual OpenFL-gramine workflow reported in Manual.md."

DL8: "does gramine support a tmpfs-style mount? if /tmp is used only for temporary files, it may be better to tell gramine that /tmp is in memory, so there will be no leftovers after its execution"
DL8: "i looked in gramine docs and found the tmpfs filesystem type. i believe it can be more appropriate in this context"
Answer: "I've changed the mount type for /tmp from 'chmod' to 'tmpfs'"

igor-davidyuk: "Some manifest updates were done here https://github.com/intel/openfl/pull/537"