### PR TITLE
[Windows] UnicodeDecodeError

### DIFF
--- a/openfl-tutorials/interactive_api/MXNet_landmarks/envoy/landmark_shard_descriptor.py
+++ b/openfl-tutorials/interactive_api/MXNet_landmarks/envoy/landmark_shard_descriptor.py
@@ -140,14 +140,14 @@ class LandmarkShardDescriptor(ShardDescriptor):
     def save_all_md5(self) -> None:
         """Save dataset hash."""
         all_md5 = self.calc_all_md5()
-        with open(self.data_folder / 'dataset.json', 'w') as f:
+        with open(self.data_folder / 'dataset.json', 'w', encoding='utf-8') as f:
             json.dump(all_md5, f)
 
     def is_dataset_complete(self) -> bool:
         """Check dataset integrity."""
         dataset_md5_path = self.data_folder / 'dataset.json'
         if dataset_md5_path.exists():
-            with open(dataset_md5_path, 'r') as f:
+            with open(dataset_md5_path, 'r', encoding='utf-8') as f:
                 old_md5 = json.load(f)
             new_md5 = self.calc_all_md5()
             return new_md5 == old_md5

--- a/openfl-tutorials/interactive_api/PyTorch_DogsCats_ViT/envoy/dogs_cats_shard_descriptor.py
+++ b/openfl-tutorials/interactive_api/PyTorch_DogsCats_ViT/envoy/dogs_cats_shard_descriptor.py
@@ -152,14 +152,14 @@ class DogsCatsShardDescriptor(ShardDescriptor):
     def save_all_md5(self):
         """Save dataset hash."""
         all_md5 = self.calc_all_md5()
-        with open(os.path.join(self.data_folder, 'dataset.json'), 'w') as f:
+        with open(os.path.join(self.data_folder, 'dataset.json'), 'w', encoding='utf-8') as f:
             json.dump(all_md5, f)
 
     def is_dataset_complete(self):
         """Check dataset integrity."""
         new_md5 = self.calc_all_md5()
         try:
-            with open(os.path.join(self.data_folder, 'dataset.json'), 'r') as f:
+            with open(os.path.join(self.data_folder, 'dataset.json'), 'r', encoding='utf-8') as f:
                 old_md5 = json.load(f)
         except FileNotFoundError:
             return False

--- a/openfl-tutorials/interactive_api/PyTorch_TinyImageNet/envoy/tinyimagenet_shard_descriptor.py
+++ b/openfl-tutorials/interactive_api/PyTorch_TinyImageNet/envoy/tinyimagenet_shard_descriptor.py
@@ -35,7 +35,8 @@ class TinyImageNetDataset(ShardDataset):
                 recursive=True
             )
         )[rank - 1::worldsize]
-        with open(os.path.join(self._common_data_folder, 'wnids.txt'), 'r') as fp:
+        wnids_path = os.path.join(self._common_data_folder, 'wnids.txt')
+        with open(wnids_path, 'r', encoding='utf-8') as fp:
             self.label_texts = sorted([text.strip() for text in fp.readlines()])
         self.label_text_to_number = {text: i for i, text in enumerate(self.label_texts)}
         self.fill_labels()
@@ -62,7 +63,8 @@ class TinyImageNetDataset(ShardDataset):
                 for cnt in range(self.NUM_IMAGES_PER_CLASS):
                     self.labels[f'{label_text}_{cnt}.JPEG'] = i
         elif self.data_type == 'val':
-            with open(os.path.join(self._data_folder, 'val_annotations.txt'), 'r') as fp:
+            val_annotations_path = os.path.join(self._data_folder, 'val_annotations.txt')
+            with open(val_annotations_path, 'r', encoding='utf-8') as fp:
                 for line in fp.readlines():
                     terms = line.split('\t')
                     file_name, label_text = terms[0], terms[1]

--- a/openfl/component/ca/ca.py
+++ b/openfl/component/ca/ca.py
@@ -238,7 +238,7 @@ def _create_ca(ca_path: Path, ca_url: str, password: str):
     pki_dir.mkdir(parents=True, exist_ok=True)
     step_config_dir.mkdir(parents=True, exist_ok=True)
 
-    with open(f'{pki_dir}/pass_file', 'w') as f:
+    with open(f'{pki_dir}/pass_file', 'w', encoding='utf-8') as f:
         f.write(password)
     os.chmod(f'{pki_dir}/pass_file', 0o600)
     step_path, step_ca_path = get_ca_bin_paths(ca_path)
@@ -263,7 +263,7 @@ def _create_ca(ca_path: Path, ca_url: str, password: str):
 
 def _configure(step_config_dir):
     conf_file = step_config_dir / CA_CONFIG_JSON
-    with open(conf_file, 'r+') as f:
+    with open(conf_file, 'r+', encoding='utf-8') as f:
         data = json.load(f)
         data.setdefault('authority', {}).setdefault('claims', {})
         data['authority']['claims']['maxTLSCertDuration'] = f'{365 * 24}h'

--- a/openfl/interface/aggregator.py
+++ b/openfl/interface/aggregator.py
@@ -100,7 +100,7 @@ def generate_cert_request(fqdn):
 def find_certificate_name(file_name):
     """Search the CRT for the actual aggregator name."""
     # This loop looks for the collaborator name in the key
-    with open(file_name, 'r') as f:
+    with open(file_name, 'r', encoding='utf-8') as f:
         for line in f:
             if 'Subject: CN=' in line:
                 col_name = line.split('=')[-1].strip()

--- a/openfl/interface/cli.py
+++ b/openfl/interface/cli.py
@@ -13,6 +13,7 @@ from click import pass_context
 from click import style
 
 from openfl.utilities import add_log_level
+import sys
 
 
 def setup_logging(level='info', log_file=None):
@@ -137,6 +138,7 @@ def cli(context, log_level):
 
     log_file = os.getenv('LOG_FILE')
     setup_logging(log_level, log_file)
+    sys.stdout.reconfigure(encoding='utf-8')
 
 
 @cli.result_callback()

--- a/openfl/interface/cli_helper.py
+++ b/openfl/interface/cli_helper.py
@@ -164,7 +164,7 @@ def get_workspace_parameter(name):
     # Update the .workspace file to show the current workspace plan
     workspace_file = '.workspace'
 
-    with open(workspace_file, 'r') as f:
+    with open(workspace_file, 'r', encoding='utf-8') as f:
         doc = load(f, Loader=FullLoader)
 
     if not doc:  # YAML is not correctly formatted
@@ -203,7 +203,7 @@ def get_fx_path(curr_path=''):
 
 def remove_line_from_file(pkg, filename):
     """Remove line that contains `pkg` from the `filename` file."""
-    with open(filename, 'r+') as f:
+    with open(filename, 'r+', encoding='utf-8') as f:
         d = f.readlines()
         f.seek(0)
         for i in d:
@@ -214,7 +214,7 @@ def remove_line_from_file(pkg, filename):
 
 def replace_line_in_file(line, line_num_to_replace, filename):
     """Replace line at `line_num_to_replace` with `line`."""
-    with open(filename, 'r+') as f:
+    with open(filename, 'r+', encoding='utf-8') as f:
         d = f.readlines()
         f.seek(0)
         for idx, i in enumerate(d):

--- a/openfl/interface/collaborator.py
+++ b/openfl/interface/collaborator.py
@@ -93,7 +93,7 @@ def register_data_path(collaborator_name, data_path=None, silent=False):
     data_yaml = 'plan/data.yaml'
     separator = ','
     if isfile(data_yaml):
-        with open(data_yaml, 'r') as f:
+        with open(data_yaml, 'r', encoding='utf-8') as f:
             for line in f:
                 if separator in line:
                     key, val = line.split(separator, maxsplit=1)
@@ -102,7 +102,7 @@ def register_data_path(collaborator_name, data_path=None, silent=False):
     d[collaborator_name] = dir_path
 
     # Write the data.yaml
-    with open(data_yaml, 'w') as f:
+    with open(data_yaml, 'w', encoding='utf-8') as f:
         for key, val in d.items():
             f.write(f'{key}{separator}{val}\n')
 
@@ -217,7 +217,7 @@ def register_collaborator(file_name):
 
     if not isfile(cols_file):
         cols_file.touch()
-    with open(cols_file, 'r') as f:
+    with open(cols_file, 'r', encoding='utf-8') as f:
         doc = load(f, Loader=FullLoader)
 
     if not doc:  # YAML is not correctly formatted
@@ -237,7 +237,7 @@ def register_collaborator(file_name):
     else:
 
         doc['collaborators'].append(col_name)
-        with open(cols_file, 'w') as f:
+        with open(cols_file, 'w', encoding='utf-8') as f:
             dump(doc, f)
 
         echo('\nRegistering '

--- a/openfl/interface/collaborator.py
+++ b/openfl/interface/collaborator.py
@@ -3,6 +3,7 @@
 """Collaborator module."""
 
 import sys
+import os
 from logging import getLogger
 
 from click import echo
@@ -194,7 +195,7 @@ def generate_cert_request(collaborator_name, data_path, silent, skip_package):
 
 def find_certificate_name(file_name):
     """Parse the collaborator name."""
-    col_name = str(file_name).split('/')[-1].split('.')[0][4:]
+    col_name = str(file_name).split(os.sep)[-1].split('.')[0][4:]
     return col_name
 
 

--- a/openfl/interface/plan.py
+++ b/openfl/interface/plan.py
@@ -179,7 +179,7 @@ def switch_plan(name):
         # Update the .workspace file to show the current workspace plan
         workspace_file = '.workspace'
 
-        with open(workspace_file, 'r') as f:
+        with open(workspace_file, 'r', encoding='utf-8') as f:
             doc = load(f, Loader=FullLoader)
 
         if not doc:  # YAML is not correctly formatted
@@ -188,7 +188,7 @@ def switch_plan(name):
         doc['current_plan_name'] = f'{name}'  # Switch with new plan name
 
         # Rewrite updated workspace file
-        with open(workspace_file, 'w') as f:
+        with open(workspace_file, 'w', encoding='utf-8') as f:
             dump(doc, f)
 
     else:

--- a/openfl/interface/tutorial.py
+++ b/openfl/interface/tutorial.py
@@ -29,13 +29,14 @@ def tutorial(context):
 def start(ip, port):
     """Start the Jupyter Lab from the tutorials directory."""
     from os import environ
+    from os import sep
     from subprocess import check_call
     from sys import executable
 
     from openfl.interface.cli_helper import TUTORIALS
 
     if 'VIRTUAL_ENV' in environ:
-        venv = environ['VIRTUAL_ENV'].split('/')[-1]
+        venv = environ['VIRTUAL_ENV'].split(sep)[-1]
         check_call([
             executable, '-m', 'ipykernel', 'install',
             '--user', '--name', f'{venv}'

--- a/openfl/interface/workspace.py
+++ b/openfl/interface/workspace.py
@@ -105,7 +105,7 @@ def create(prefix, template):
     else:
         echo('No additional requirements for workspace defined. Skipping...')
     prefix_hash = _get_dir_hash(str(prefix.absolute()))
-    with open(OPENFL_USERDIR / f'requirements.{prefix_hash}.txt', 'w') as f:
+    with open(OPENFL_USERDIR / f'requirements.{prefix_hash}.txt', 'w', encoding='utf-8') as f:
         check_call([executable, '-m', 'pip', 'freeze'], shell=False, stdout=f)
 
     print_tree(prefix, level=3)
@@ -238,14 +238,14 @@ def certify():
 
     echo('1.2 Create Database')
 
-    with open(CERT_DIR / 'ca/root-ca/db/root-ca.db', 'w') as f:
+    with open(CERT_DIR / 'ca/root-ca/db/root-ca.db', 'w', encoding='utf-8') as f:
         pass  # write empty file
-    with open(CERT_DIR / 'ca/root-ca/db/root-ca.db.attr', 'w') as f:
+    with open(CERT_DIR / 'ca/root-ca/db/root-ca.db.attr', 'w', encoding='utf-8') as f:
         pass  # write empty file
 
-    with open(CERT_DIR / 'ca/root-ca/db/root-ca.crt.srl', 'w') as f:
+    with open(CERT_DIR / 'ca/root-ca/db/root-ca.crt.srl', 'w', encoding='utf-8') as f:
         f.write('01')  # write file with '01'
-    with open(CERT_DIR / 'ca/root-ca/db/root-ca.crl.srl', 'w') as f:
+    with open(CERT_DIR / 'ca/root-ca/db/root-ca.crl.srl', 'w', encoding='utf-8') as f:
         f.write('01')  # write file with '01'
 
     echo('1.3 Create CA Request and Certificate')
@@ -277,14 +277,14 @@ def certify():
 
     echo('2.2 Create Database')
 
-    with open(CERT_DIR / 'ca/signing-ca/db/signing-ca.db', 'w') as f:
+    with open(CERT_DIR / 'ca/signing-ca/db/signing-ca.db', 'w', encoding='utf-8') as f:
         pass  # write empty file
-    with open(CERT_DIR / 'ca/signing-ca/db/signing-ca.db.attr', 'w') as f:
+    with open(CERT_DIR / 'ca/signing-ca/db/signing-ca.db.attr', 'w', encoding='utf-8') as f:
         pass  # write empty file
 
-    with open(CERT_DIR / 'ca/signing-ca/db/signing-ca.crt.srl', 'w') as f:
+    with open(CERT_DIR / 'ca/signing-ca/db/signing-ca.crt.srl', 'w', encoding='utf-8') as f:
         f.write('01')  # write file with '01'
-    with open(CERT_DIR / 'ca/signing-ca/db/signing-ca.crl.srl', 'w') as f:
+    with open(CERT_DIR / 'ca/signing-ca/db/signing-ca.crl.srl', 'w', encoding='utf-8') as f:
         f.write('01')  # write file with '01'
 
     echo('2.3 Create Signing Certificate CSR')
@@ -320,8 +320,8 @@ def certify():
     echo('3   Create Certificate Chain')
 
     # create certificate chain file by combining root-ca and signing-ca
-    with open(CERT_DIR / 'cert_chain.crt', 'w') as d:
-        with open(CERT_DIR / 'ca/root-ca.crt') as s:
+    with open(CERT_DIR / 'cert_chain.crt', 'w', encoding='utf-8') as d:
+        with open(CERT_DIR / 'ca/root-ca.crt', encoding='utf-8') as s:
             d.write(s.read())
         with open(CERT_DIR / 'ca/signing-ca.crt') as s:
             d.write(s.read())
@@ -330,7 +330,7 @@ def certify():
 
 
 def _get_requirements_dict(txtfile):
-    with open(txtfile, 'r') as snapshot:
+    with open(txtfile, 'r', encoding='utf-8') as snapshot:
         snapshot_dict = {}
         for line in snapshot:
             try:

--- a/openfl/utilities/ca.py
+++ b/openfl/utilities/ca.py
@@ -10,9 +10,9 @@ def get_credentials(folder_path):
     if os.path.exists(folder_path):
         for f in os.listdir(folder_path):
             if '.key' in f:
-                key = folder_path + '/' + f
+                key = folder_path + os.sep + f
             if '.crt' in f and 'root_ca' not in f:
-                cert = folder_path + '/' + f
+                cert = folder_path + os.sep + f
             if 'root_ca' in f:
-                root_ca = folder_path + '/' + f
+                root_ca = folder_path + os.sep + f
     return root_ca, key, cert

--- a/openfl/utilities/workspace.py
+++ b/openfl/utilities/workspace.py
@@ -102,7 +102,7 @@ def dump_requirements_file(
     # We expect that all the prefixes in a requirement file
     # are placed at the top
     if keep_original_prefixes and path.is_file():
-        with open(path) as f:
+        with open(path, encoding='utf-8') as f:
             for line in f:
                 if line == '\n':
                     continue
@@ -112,7 +112,7 @@ def dump_requirements_file(
                     break
 
     requirements_generator = freeze.freeze()
-    with open(path, 'w') as f:
+    with open(path, 'w', encoding='utf-8') as f:
         for prefix in prefixes:
             f.write(prefix + '\n')
 

--- a/tests/github/interactive_api_director/voc_shard_descriptor.py
+++ b/tests/github/interactive_api_director/voc_shard_descriptor.py
@@ -80,7 +80,7 @@ class VOCDataset_SD(ShardDescriptor):
     @staticmethod
     def _read_image_ids(image_sets_file):
         ids = []
-        with open(image_sets_file) as f:
+        with open(image_sets_file, encoding='utf-8') as f:
             for line in f:
                 ids.append(line.split(' ')[0])
         return ids

--- a/tests/openfl/utilities/test_dump_requirements.py
+++ b/tests/openfl/utilities/test_dump_requirements.py
@@ -23,7 +23,7 @@ NEW_PREFIXES_OVERLAP = [p + '\n' for p in PREFIXES_OVERLAP]
 def requirements_file():
     """Prepare test requirements file."""
     path = Path('./test_requirements.txt').absolute()
-    with open(path, 'w') as f:
+    with open(path, 'w', encoding='utf-8') as f:
         f.writelines(LINES)
     yield path
     path.unlink()
@@ -47,7 +47,7 @@ def test_dump(requirements_file, monkeypatch,
                            keep_original_prefixes=keep_original_prefixes,
                            prefixes=prefixes)
 
-    with open(requirements_file) as f:
+    with open(requirements_file, encoding='utf-8') as f:
         read_lines = f.readlines()
 
     read_options = []
@@ -100,7 +100,7 @@ def test_dump_empty_original_list(
                                keep_original_prefixes=keep_original_prefixes,
                                prefixes=prefixes)
 
-        with open(requirements_file) as f:
+        with open(requirements_file, encoding='utf-8') as f:
             read_lines = f.readlines()
     finally:
         requirements_file.unlink(missing_ok=True)


### PR DESCRIPTION
This is a fix for Windows that has default CP1252 encoding for I/O operations. We have some lines with Unicode characters that are written in `stdout`. The fix is enforcing UTF-8 encoding to all non-byte I/O operations.

The issue was found in #587: https://github.com/intel/openfl/actions/runs/3508716155/jobs/5877315977#step:5:211

I have tested it on Windows using `.github/workflows/taskrunner.yml` and `tests/github/test_hello_federation.py` from #587. ([Job result](https://github.com/intel/openfl/actions/runs/3539363355/jobs/5941173807))

In addition, I have replaced Linux-based separators with `os.sep` to use the correct paths on Windows systems.