### PR TITLE
Handling envoy disconnections on getting experiment.

### DIFF
--- a/openfl/component/director/director.py
+++ b/openfl/component/director/director.py
@@ -112,6 +112,14 @@ class Director:
 
     async def wait_experiment(self, envoy_name: str) -> str:
         """Wait an experiment."""
+        experiment_name = self.col_exp.get(envoy_name)
+        if experiment_name and experiment_name in self.experiments_registry:
+            # Experiment already set, but the envoy hasn't received experiment
+            # name (e.g. was disconnected)
+            experiment = self.experiments_registry[experiment_name]
+            if experiment.aggregator.round_number == 0:
+                return experiment_name
+
         self.col_exp[envoy_name] = None
         queue = self.col_exp_queues[envoy_name]
         experiment_name = await queue.get()

--- a/openfl/protocols/director.proto
+++ b/openfl/protocols/director.proto
@@ -13,7 +13,7 @@ service Director {
   // 1. Envoy RPCs
   rpc UpdateShardInfo(UpdateShardInfoRequest) returns (UpdateShardInfoResponse) {}
   // Shard owner could also provide some public data for tests
-  rpc WaitExperiment(stream WaitExperimentRequest) returns (stream WaitExperimentResponse) {}
+  rpc WaitExperiment(WaitExperimentRequest) returns (WaitExperimentResponse) {}
   rpc GetExperimentData(GetExperimentDataRequest) returns (stream ExperimentData) {}
   rpc UpdateEnvoyStatus(UpdateEnvoyStatusRequest) returns (UpdateEnvoyStatusResponse) {}
   rpc SetExperimentFailed (SetExperimentFailedRequest) returns (SetExperimentFailedResponse) {}

--- a/openfl/transport/grpc/director_client.py
+++ b/openfl/transport/grpc/director_client.py
@@ -32,6 +32,7 @@ class ShardDirectorClient:
         """Initialize a shard director client object."""
         self.shard_name = shard_name
         director_addr = f'{director_host}:{director_port}'
+        logger.info(f'Director address: {director_addr}')
         if not tls:
             channel = grpc.insecure_channel(director_addr, options=channel_options)
         else:
@@ -79,9 +80,8 @@ class ShardDirectorClient:
     def wait_experiment(self):
         """Wait an experiment data from the director."""
         logger.info('Send WaitExperiment request')
-        response_iter = self.stub.WaitExperiment(self._get_experiment_data())
-        logger.info('WaitExperiment response has received')
-        response = next(response_iter)
+        response = self.stub.WaitExperiment(self._get_experiment_data())
+        logger.info(f'WaitExperiment response has received: {response}')
         experiment_name = response.experiment_name
         if not experiment_name:
             raise Exception('No experiment')
@@ -116,7 +116,7 @@ class ShardDirectorClient:
 
     def _get_experiment_data(self):
         """Generate the experiment data request."""
-        yield director_pb2.WaitExperimentRequest(collaborator_name=self.shard_name)
+        return director_pb2.WaitExperimentRequest(collaborator_name=self.shard_name)
 
     def send_health_check(
             self, *,

--- a/openfl/transport/grpc/director_server.py
+++ b/openfl/transport/grpc/director_server.py
@@ -197,15 +197,13 @@ class DirectorGRPCServer(director_pb2_grpc.DirectorServicer):
                     break
                 yield director_pb2.ExperimentData(size=len(data), npbytes=data)
 
-    async def WaitExperiment(self, request_iterator, context):  # NOQA:N802
+    async def WaitExperiment(self, request, context):  # NOQA:N802
         """Request for wait an experiment."""
-        logger.info('Request WaitExperiment has got!')
-        async for msg in request_iterator:
-            logger.info(msg)
-            experiment_name = await self.director.wait_experiment(msg.collaborator_name)
-            logger.info(f'Experiment {experiment_name} was prepared')
+        logger.info(f'Request WaitExperiment has got from envoy {request.collaborator_name}!')
+        experiment_name = await self.director.wait_experiment(request.collaborator_name)
+        logger.info(f'Experiment {experiment_name} is ready for {request.collaborator_name}')
 
-            yield director_pb2.WaitExperimentResponse(experiment_name=experiment_name)
+        return director_pb2.WaitExperimentResponse(experiment_name=experiment_name)
 
     async def GetDatasetInfo(self, request, context):  # NOQA:N802
         """Request the info about target and sample shapes in the dataset."""


### PR DESCRIPTION
If disconnection between a director and an envoy happens after an experiment is set but not yet started, the experiment will stuck waiting for the lost envoy to return. But the envoy will never return. 
This PR fix that problem and in addition handle an envoy restart before 0 round is completed. 
RPC method WaitExperiment doesn't use stream options, but it requires additional client logic in disconnection cases. Removing it makes code simpler and more fault-tolerant. 