### PR TITLE
Update gRPC. Removes Python 3.6 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ setup(
         'jupyterlab',
         'numpy',
         'pandas',
-        'protobuf==3.19.5',
+        'protobuf==4.21.9',
         'requests',
         'rich',
         'scikit-learn',
@@ -151,8 +151,8 @@ setup(
         'tensorboardX',
         'tqdm',
     ],
-    setup_requires=['grpcio-tools~=1.48.2'],
-    python_requires='>=3.6, <3.11',
+    setup_requires=['grpcio-tools~=1.51.1'],
+    python_requires='>=3.7, <3.11',
     project_urls={
         'Bug Tracker': 'https://github.com/intel/openfl/issues',
         'Documentation': 'https://openfl.readthedocs.io/en/stable/',
@@ -173,7 +173,6 @@ setup(
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,7 @@ setup(
         'docker',
         'dynaconf==3.1.7',
         'flatten_json',
-        'grpcio~=1.48.2',
+        'grpcio~=1.51.1',
         'ipykernel',
         'jupyterlab',
         'numpy',

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ setup(
         'jupyterlab',
         'numpy',
         'pandas',
-        'protobuf==4.21.9',
+        'protobuf==3.19.6',
         'requests',
         'rich',
         'scikit-learn',


### PR DESCRIPTION
This PR:
- Updates gRPC to address [CVE-2022-37434](https://github.com/advisories/GHSA-cfmr-vrgj-vqwv)
- Removes Python 3.6 support (no longer supported by latest gRPC version)