### PR TITLE
Fix straggler handling to identify stragglers for a round

### DIFF
--- a/docs/straggler_handling_algorithms.rst
+++ b/docs/straggler_handling_algorithms.rst
@@ -15,12 +15,16 @@ The following are the straggler handling algorithms supported in |productName|:
     Identifies stragglers based on the cutoff time specified in the settings. Arguments to the function are:
         - *Cutoff Time* (straggler_cutoff_time), specifies the cutoff time by which the aggregator should end the round early.
         - *Minimum Reporting* (minimum_reporting), specifies the minimum number of collaborators needed to aggregate the model.
-    
+
+    For example, in a federation of 5 collaborators, if :code:`straggler_cutoff_time` (in seconds) is set to 20 and :code:`minimum_reporting` is set to 2, atleast 2 collaborators (or more) would be included in the round, provided that the time limit of 20 seconds is not exceeded.
+    In an event where :code:`minimum_reporting` collaborators don't make it within the :code:`straggler_cutoff_time`, the straggler handling policy is disregarded. 
+
 ``PercentageBasedStragglerHandling``
     Identifies stragglers based on the percetage specified. Arguments to the function are:
         - *Percentage of collaborators* (percent_collaborators_needed), specifies a percentage of collaborators enough to end the round early.
         - *Minimum Reporting* (minimum_reporting), specifies the minimum number of collaborators needed to aggregate the model.
-    
+
+    For example, in a federation of 5 collaborators, if :code:`percent_collaborators_needed` is set to 0.8 and :code:`minimum_reporting` is set to 1, the first 4 collaborators (80%) to report to aggregator are selected for that round.   
 
 Demonstration of adding the straggler handling interface
 =========================================================

--- a/openfl/component/aggregator/aggregator.py
+++ b/openfl/component/aggregator/aggregator.py
@@ -306,18 +306,16 @@ class Aggregator:
                 t for t in tasks if not self._collaborator_task_completed(
                     collaborator_name, t, self.round_number)
             ]
-            for straggler in self.stragglers:
-                if collaborator_name == straggler:
-                    tasks = []
+            if collaborator_name in self.stragglers:
+                tasks = []
 
         else:
             tasks = [
                 t for t in tasks if not self._collaborator_task_completed(
                     collaborator_name, t.name, self.round_number)
             ]
-            for straggler in self.stragglers:
-                if collaborator_name == straggler:
-                    tasks = []
+            if collaborator_name in self.stragglers:
+                tasks = []
 
         # Do the check again because it's possible that all tasks have
         # been completed

--- a/openfl/component/aggregator/aggregator.py
+++ b/openfl/component/aggregator/aggregator.py
@@ -68,8 +68,7 @@ class Aggregator:
         self.straggler_handling_policy = straggler_handling_policy \
             or CutoffTimeBasedStragglerHandling()
         self._end_of_round_check_done = [False] * rounds_to_train
-        # self.stragglers_for_task = {}
-        self.stragglers_for_task = []
+        self.stragglers = []
 
         self.rounds_to_train = rounds_to_train
 
@@ -307,13 +306,7 @@ class Aggregator:
                 t for t in tasks if not self._collaborator_task_completed(
                     collaborator_name, t, self.round_number)
             ]
-            # init_tasks = deepcopy(tasks)
-            # for t in tasks:
-            #     if t in self.stragglers_for_task:
-            #         for stragglers in self.stragglers_for_task[t]:
-            #             if collaborator_name in stragglers:
-            #                 tasks.remove(t)
-            for straggler in self.stragglers_for_task:
+            for straggler in self.stragglers:
                 if collaborator_name == straggler:
                     tasks = []
 
@@ -322,12 +315,7 @@ class Aggregator:
                 t for t in tasks if not self._collaborator_task_completed(
                     collaborator_name, t.name, self.round_number)
             ]
-            # for t in tasks:
-            #     if t.name in self.stragglers_for_task:
-            #         for stragglers in self.stragglers_for_task[t.name]:
-            #             if collaborator_name in stragglers:
-            #                 tasks.remove(t)
-            for straggler in self.stragglers_for_task:
+            for straggler in self.stragglers:
                 if collaborator_name == straggler:
                     tasks = []
 
@@ -901,8 +889,7 @@ class Aggregator:
         self._end_of_round_check_done[self.round_number] = True
         self.round_number += 1
         # resetting stragglers for task for a new round
-        # self.stragglers_for_task = {}
-        self.stragglers_for_task = []
+        self.stragglers = []
 
         # Save the latest model
         self.logger.info(f'Saving round {self.round_number} model...')
@@ -933,16 +920,12 @@ class Aggregator:
         straggler_check = self.straggler_handling_policy.straggler_cutoff_check(
             len(collaborators_done), all_collaborators)
 
-        # stragglers = []
         if straggler_check:
             for c in all_collaborators:
                 if c not in collaborators_done:
-                    # stragglers.append(c)
-                    self.stragglers_for_task.append(c)
+                    self.stragglers.append(c)
             self.logger.info(f'\tEnding task {task_name} early due to straggler cutoff policy')
-            # self.logger.warning(f'\tIdentified stragglers: {stragglers} for task {task_name}')
-            self.logger.warning(f'\tIdentified stragglers: {self.stragglers_for_task}')
-            # self.stragglers_for_task[task_name] = stragglers
+            self.logger.warning(f'\tIdentified stragglers: {self.stragglers}')
 
         # all are done or straggler policy calls for early round end.
         return straggler_check or len(all_collaborators) == len(collaborators_done)

--- a/openfl/component/aggregator/aggregator.py
+++ b/openfl/component/aggregator/aggregator.py
@@ -68,7 +68,8 @@ class Aggregator:
         self.straggler_handling_policy = straggler_handling_policy \
             or CutoffTimeBasedStragglerHandling()
         self._end_of_round_check_done = [False] * rounds_to_train
-        self.stragglers_for_task = {}
+        # self.stragglers_for_task = {}
+        self.stragglers_for_task = []
 
         self.rounds_to_train = rounds_to_train
 
@@ -306,21 +307,29 @@ class Aggregator:
                 t for t in tasks if not self._collaborator_task_completed(
                     collaborator_name, t, self.round_number)
             ]
-            for t in tasks:
-                if t in self.stragglers_for_task:
-                    for stragglers in self.stragglers_for_task[t]:
-                        if collaborator_name in stragglers:
-                            tasks.remove(t)
+            # init_tasks = deepcopy(tasks)
+            # for t in tasks:
+            #     if t in self.stragglers_for_task:
+            #         for stragglers in self.stragglers_for_task[t]:
+            #             if collaborator_name in stragglers:
+            #                 tasks.remove(t)
+            for straggler in self.stragglers_for_task:
+                if collaborator_name == straggler:
+                    tasks = []
+
         else:
             tasks = [
                 t for t in tasks if not self._collaborator_task_completed(
                     collaborator_name, t.name, self.round_number)
             ]
-            for t in tasks:
-                if t.name in self.stragglers_for_task:
-                    for stragglers in self.stragglers_for_task[t.name]:
-                        if collaborator_name in stragglers:
-                            tasks.remove(t)
+            # for t in tasks:
+            #     if t.name in self.stragglers_for_task:
+            #         for stragglers in self.stragglers_for_task[t.name]:
+            #             if collaborator_name in stragglers:
+            #                 tasks.remove(t)
+            for straggler in self.stragglers_for_task:
+                if collaborator_name == straggler:
+                    tasks = []
 
         # Do the check again because it's possible that all tasks have
         # been completed
@@ -892,7 +901,8 @@ class Aggregator:
         self._end_of_round_check_done[self.round_number] = True
         self.round_number += 1
         # resetting stragglers for task for a new round
-        self.stragglers_for_task = {}
+        # self.stragglers_for_task = {}
+        self.stragglers_for_task = []
 
         # Save the latest model
         self.logger.info(f'Saving round {self.round_number} model...')
@@ -923,14 +933,16 @@ class Aggregator:
         straggler_check = self.straggler_handling_policy.straggler_cutoff_check(
             len(collaborators_done), all_collaborators)
 
-        stragglers = []
+        # stragglers = []
         if straggler_check:
             for c in all_collaborators:
                 if c not in collaborators_done:
-                    stragglers.append(c)
+                    # stragglers.append(c)
+                    self.stragglers_for_task.append(c)
             self.logger.info(f'\tEnding task {task_name} early due to straggler cutoff policy')
-            self.logger.warning(f'\tIdentified stragglers: {stragglers} for task {task_name}')
-            self.stragglers_for_task[task_name] = stragglers
+            # self.logger.warning(f'\tIdentified stragglers: {stragglers} for task {task_name}')
+            self.logger.warning(f'\tIdentified stragglers: {self.stragglers_for_task}')
+            # self.stragglers_for_task[task_name] = stragglers
 
         # all are done or straggler policy calls for early round end.
         return straggler_check or len(all_collaborators) == len(collaborators_done)


### PR DESCRIPTION
Earlier, straggler handling policy used to identify stragglers per task. This led to some failing tests because of existing dependencies between OpenFL tasks (For LMV to happen, the collaborator should perform training too). This PR resolves the issues by identifying the stragglers for a round and preventing them for performing further tasks for the same round.