### PR TITLE
Envoy can reconnect to current experiment after restarting for the du…

### DIFF
--- a/openfl/component/director/director.py
+++ b/openfl/component/director/director.py
@@ -132,7 +132,7 @@ class Director:
             # Experiment already set, but the envoy hasn't received experiment
             # name (e.g. was disconnected)
             experiment = self.experiments_registry[experiment_name]
-            if experiment.aggregator.round_number == 0:
+            if experiment.aggregator.round_number < experiment.aggregator.rounds_to_train:
                 return experiment_name
 
         self.col_exp[envoy_name] = None


### PR DESCRIPTION
An envoy can reconnect to current experiment after restarting for the duration of the experiment. It will receive the data for experiment like in a beginning, but a collaborator will receive tasks from an aggregator starting with current round.
It will increase fault tolerance of federation, but probably can have any impact on the experiment in any cases. But looks like we haven't these restriction now.