### PR TITLE
Write keys with restricted permissions (#637)

### DIFF
--- a/openfl/cryptography/io.py
+++ b/openfl/cryptography/io.py
@@ -3,6 +3,7 @@
 
 """Cryptography IO utilities."""
 
+import os
 from hashlib import sha384
 from pathlib import Path
 from typing import Tuple
@@ -44,7 +45,10 @@ def write_key(key: RSAPrivateKey, path: Path) -> None:
         path : Path (pathlib)
 
     """
-    with open(path, 'wb') as f:
+    def key_opener(path, flags):
+        return os.open(path, flags, mode=0o600)
+
+    with open(path, 'wb', opener=key_opener) as f:
         f.write(key.private_bytes(
             encoding=serialization.Encoding.PEM,
             format=serialization.PrivateFormat.TraditionalOpenSSL,


### PR DESCRIPTION
Prior to this fix, keys generated by "fx" command line were saved with default permissions. Depending on the current OS configuration, this may include read permissions to other users.
To fix this, write_key() function was modified such that it will write the key with no permissions to other users.

Fixes #637 