### PR TITLE
Fix TensorFlow version comparison

### DIFF
--- a/openfl/plugins/frameworks_adapters/keras_adapter.py
+++ b/openfl/plugins/frameworks_adapters/keras_adapter.py
@@ -4,6 +4,7 @@
 from logging import getLogger
 
 from .framework_adapter_interface import FrameworkAdapterPluginInterface
+from packaging import version
 
 logger = getLogger(__name__)
 
@@ -51,7 +52,7 @@ class FrameworkAdapterPlugin(FrameworkAdapterPluginInterface):
             cls.__reduce__ = __reduce__
 
         # Run the function
-        if tf.__version__ <= '2.7.1':
+        if version.parse(tf.__version__) <= version.parse('2.7.1'):
             logger.warn('Applying hotfix for model serialization.'
                         'Please consider updating to tensorflow>=2.8 to silence this warning.')
             make_keras_picklable()


### PR DESCRIPTION
## Issue
We have a logic that makes Keras models picklable for TensorFlow versions less than 2.7 where picklability is included. Starting with TensorFlow 2.10, string comparison with `'2.7.1'` does not work because `'2.10.1' < '2.7.1'`.
## Fix
Use `packaging.version` module to compare versions properly.

