### PR TITLE
Suppress pandas FutureWarning

### DIFF
--- a/openfl/databases/tensor_db.py
+++ b/openfl/databases/tensor_db.py
@@ -38,7 +38,9 @@ class TensorDB:
             'tags': 'object',
             'nparray': 'object'
         }
-        self.tensor_db = pd.DataFrame({col: pd.Series(dtype=dtype) for col, dtype in types_dict.items()})
+        self.tensor_db = pd.DataFrame(
+            {col: pd.Series(dtype=dtype) for col, dtype in types_dict.items()}
+        )
         self._bind_convenience_methods()
 
         self.mutex = Lock()

--- a/openfl/databases/tensor_db.py
+++ b/openfl/databases/tensor_db.py
@@ -30,9 +30,15 @@ class TensorDB:
 
     def __init__(self) -> None:
         """Initialize."""
-        self.tensor_db = pd.DataFrame([], columns=[
-            'tensor_name', 'origin', 'round', 'report', 'tags', 'nparray'
-        ])
+        types_dict = {
+            'tensor_name': 'string',
+            'origin': 'string',
+            'round': 'int32',
+            'report': 'bool',
+            'tags': 'object',
+            'nparray': 'object'
+        }
+        self.tensor_db = pd.DataFrame({col: pd.Series(dtype=dtype) for col, dtype in types_dict.items()})
         self._bind_convenience_methods()
 
         self.mutex = Lock()
@@ -87,13 +93,7 @@ class TensorDB:
                     pd.DataFrame([
                         [tensor_name, origin, fl_round, report, tags, nparray]
                     ],
-                        columns=[
-                            'tensor_name',
-                            'origin',
-                            'round',
-                            'report',
-                            'tags',
-                            'nparray']
+                        columns=list(self.tensor_db.columns)
                     )
                 )
 

--- a/openfl/interface/cli.py
+++ b/openfl/interface/cli.py
@@ -130,9 +130,9 @@ class CLI(Group):
 
 @group(cls=CLI)
 @option('-l', '--log-level', default='info', help='Logging verbosity level.')
-@option('--enable-warnings', is_flag=True, help='Enable third-party warnings.')
+@option('--no-warnings', is_flag=True, help='Disable third-party warnings.')
 @pass_context
-def cli(context, log_level, enable_warnings):
+def cli(context, log_level, no_warnings):
     """Command-line Interface."""
     import os
     from sys import argv
@@ -143,7 +143,7 @@ def cli(context, log_level, enable_warnings):
     context.obj['script'] = argv[0]
     context.obj['arguments'] = argv[1:]
 
-    if not enable_warnings:
+    if no_warnings:
         # Setup logging immediately to suppress unnecessary warnings on import
         # This will be overridden later with user selected debugging level
         disable_warnings()


### PR DESCRIPTION
## Issue
Training output mostly consists (depending on the number of neural network parameters) of the following warnings:

```
FutureWarning: In a future version, object-dtype columns with all-bool values will not be included in reductions with bool_only=True. Explicitly cast to bool dtype instead.
```
## Solution
Declare all column types on TensorDB initialization.