### PR TITLE
Cleanup temporary files (SDLE task)

### DIFF
--- a/openfl/interface/collaborator.py
+++ b/openfl/interface/collaborator.py
@@ -160,6 +160,7 @@ def generate_cert_request(collaborator_name, data_path, silent, skip_package):
         from shutil import copytree
         from shutil import ignore_patterns
         from shutil import make_archive
+        from shutil import rmtree
         from tempfile import mkdtemp
         from os.path import basename
         from os.path import join
@@ -183,6 +184,7 @@ def generate_cert_request(collaborator_name, data_path, silent, skip_package):
 
         # Create Zip archive of directory
         make_archive(archive_name, archive_type, tmp_dir)
+        rmtree(tmp_dir)
 
         echo(f'Archive {archive_file_name} with certificate signing'
              f' request created')
@@ -269,6 +271,7 @@ def certify(collaborator_name, silent, request_pkg=None, import_=False):
     from pathlib import Path
     from shutil import copy
     from shutil import make_archive
+    from shutil import rmtree
     from shutil import unpack_archive
     from glob import glob
     from os.path import basename
@@ -378,6 +381,7 @@ def certify(collaborator_name, silent, request_pkg=None, import_=False):
 
         # Create Zip archive of directory
         make_archive(archive_name, archive_type, tmp_dir)
+        rmtree(tmp_dir)
 
     else:
         # Copy the signed certificate and cert chain into PKI_DIR

--- a/openfl/interface/collaborator.py
+++ b/openfl/interface/collaborator.py
@@ -160,12 +160,13 @@ def generate_cert_request(collaborator_name, data_path, silent, skip_package):
         from shutil import copytree
         from shutil import ignore_patterns
         from shutil import make_archive
-        from shutil import rmtree
         from tempfile import mkdtemp
         from os.path import basename
         from os.path import join
         from os import remove
         from glob import glob
+
+        from openfl.utilities.utils import rmtree
 
         archive_type = 'zip'
         archive_name = f'col_{common_name}_to_agg_cert_request'
@@ -271,7 +272,6 @@ def certify(collaborator_name, silent, request_pkg=None, import_=False):
     from pathlib import Path
     from shutil import copy
     from shutil import make_archive
-    from shutil import rmtree
     from shutil import unpack_archive
     from glob import glob
     from os.path import basename
@@ -285,6 +285,7 @@ def certify(collaborator_name, silent, request_pkg=None, import_=False):
     from openfl.cryptography.io import read_key
     from openfl.cryptography.io import write_crt
     from openfl.interface.cli_helper import CERT_DIR
+    from openfl.utilities.utils import rmtree
 
     common_name = f'{collaborator_name}'.lower()
 

--- a/openfl/interface/workspace.py
+++ b/openfl/interface/workspace.py
@@ -127,11 +127,11 @@ def export_(pip_install_options: Tuple[str]):
     from shutil import copytree
     from shutil import ignore_patterns
     from shutil import make_archive
-    from shutil import rmtree
     from tempfile import mkdtemp
 
     from plan import freeze_plan
     from openfl.interface.cli_helper import WORKSPACE
+    from openfl.utilities.utils import rmtree
 
     plan_file = Path('plan/plan.yaml').absolute()
     try:

--- a/openfl/interface/workspace.py
+++ b/openfl/interface/workspace.py
@@ -127,6 +127,7 @@ def export_(pip_install_options: Tuple[str]):
     from shutil import copytree
     from shutil import ignore_patterns
     from shutil import make_archive
+    from shutil import rmtree
     from tempfile import mkdtemp
 
     from plan import freeze_plan
@@ -173,7 +174,7 @@ def export_(pip_install_options: Tuple[str]):
     # Create Zip archive of directory
     echo('\n 🗜️ Preparing workspace distribution zip file')
     make_archive(archive_name, archive_type, tmp_dir)
-
+    rmtree(tmp_dir)
     echo(f'\n ✔️ Workspace exported to archive: {archive_file_name}')
 
 


### PR DESCRIPTION
Temporary files need to be cleaned to free up the resources.