### PR TITLE
Enable PEP8 naming extension for flake8

### DIFF
--- a/openfl-tutorials/interactive_api/PyTorch_MedMNIST_2D/envoy/medmnist_shard_descriptor.py
+++ b/openfl-tutorials/interactive_api/PyTorch_MedMNIST_2D/envoy/medmnist_shard_descriptor.py
@@ -90,6 +90,7 @@ class MedMNISTShardDescriptor(ShardDescriptor):
         return (f'MedMNIST dataset, shard number {self.rank}'
                 f' out of {self.worldsize}')
 
+    @staticmethod
     def download_data(datapath: str = 'data/',
                       dataname: str = 'bloodmnist',
                       info: dict = {}) -> None:

--- a/openfl-tutorials/interactive_api/PyTorch_MedMNIST_3D/envoy/medmnist_shard_descriptor.py
+++ b/openfl-tutorials/interactive_api/PyTorch_MedMNIST_3D/envoy/medmnist_shard_descriptor.py
@@ -90,6 +90,7 @@ class MedMNISTShardDescriptor(ShardDescriptor):
         return (f'MedMNIST dataset, shard number {self.rank}'
                 f' out of {self.worldsize}')
 
+    @staticmethod
     def download_data(datapath: str = 'data/',
                       dataname: str = 'bloodmnist',
                       info: dict = {}) -> None:

--- a/openfl-tutorials/interactive_api/PyTorch_MedMNIST_3D/workspace/wspace_utils/batchnorm.py
+++ b/openfl-tutorials/interactive_api/PyTorch_MedMNIST_3D/workspace/wspace_utils/batchnorm.py
@@ -97,8 +97,9 @@ class _SynchronizedBatchNorm(_BatchNorm):
         # Compute the output.
         if self.affine:
             # MJY:: Fuse the multiplication for speed.
-            output = (input - _unsqueeze_ft(mean)) * _unsqueeze_ft(inv_std * self.weight)\
-                + _unsqueeze_ft(self.bias)
+            output = (input - _unsqueeze_ft(mean)) * _unsqueeze_ft(
+                inv_std * self.weight
+            ) + _unsqueeze_ft(self.bias)
         else:
             output = (input - _unsqueeze_ft(mean)) * _unsqueeze_ft(inv_std)
 

--- a/openfl-tutorials/interactive_api/PyTorch_MedMNIST_3D/workspace/wspace_utils/utils.py
+++ b/openfl-tutorials/interactive_api/PyTorch_MedMNIST_3D/workspace/wspace_utils/utils.py
@@ -33,7 +33,7 @@ def _convert_module_from_bn_to_syncbn(module):
             hasattr(nn, child.__class__.__name__)
             and 'batchnorm' in child.__class__.__name__.lower()
         ):
-            TargetClass = globals()['Synchronized' + child.__class__.__name__]
+            TargetClass = globals()['Synchronized' + child.__class__.__name__]  # noqa: N806
             arguments = TargetClass.__init__.__code__.co_varnames[1:]
             kwargs = {k: getattr(child, k) for k in arguments}
             setattr(module, child_name, TargetClass(**kwargs))

--- a/openfl/component/aggregator/aggregator.py
+++ b/openfl/component/aggregator/aggregator.py
@@ -65,8 +65,9 @@ class Aggregator:
             # Cleaner solution?
             self.single_col_cert_common_name = ''
 
-        self.straggler_handling_policy = straggler_handling_policy \
-            or CutoffTimeBasedStragglerHandling()
+        self.straggler_handling_policy = (
+            straggler_handling_policy or CutoffTimeBasedStragglerHandling()
+        )
         self._end_of_round_check_done = [False] * rounds_to_train
         self.stragglers_for_task = {}
 

--- a/openfl/databases/utilities/dataframe.py
+++ b/openfl/databases/utilities/dataframe.py
@@ -95,8 +95,7 @@ def _store(self, tensor_name: str = '_', origin: str = '_',
         idx = idx[0]
     else:
         idx = self.shape[0]
-    self.loc[idx] = \
-            [tensor_name, origin, str(fl_round), metric, tags, nparray]
+    self.loc[idx] = [tensor_name, origin, str(fl_round), metric, tags, nparray]
 
 
 def _retrieve(self, tensor_name: str = '_', origin: str = '_',

--- a/openfl/federated/task/runner_fets_challenge.py
+++ b/openfl/federated/task/runner_fets_challenge.py
@@ -36,11 +36,16 @@ class FeTSChallengeTaskRunner(TaskRunner):
         """
         super().__init__(**kwargs)
 
-        model, optimizer, train_loader, val_loader, scheduler, params = \
-            create_pytorch_objects(fets_config_dict,
-                                   train_csv=train_csv,
-                                   val_csv=val_csv,
-                                   device=device)
+        (
+            model,
+            optimizer,
+            train_loader,
+            val_loader,
+            scheduler,
+            params,
+        ) = create_pytorch_objects(
+            fets_config_dict, train_csv=train_csv, val_csv=val_csv, device=device
+        )
         self.model = model
         self.optimizer = optimizer
         self.scheduler = scheduler
@@ -171,13 +176,14 @@ class FeTSChallengeTaskRunner(TaskRunner):
 
         # Return global_tensor_dict, local_tensor_dict
         # is this even pt-specific really?
-        global_tensor_dict, local_tensor_dict = \
-            create_tensorkey_dicts(tensor_dict,
-                                   metric_dict,
-                                   col_name,
-                                   round_num,
-                                   self.logger,
-                                   self.tensor_dict_split_fn_kwargs)
+        global_tensor_dict, local_tensor_dict = create_tensorkey_dicts(
+            tensor_dict,
+            metric_dict,
+            col_name,
+            round_num,
+            self.logger,
+            self.tensor_dict_split_fn_kwargs,
+        )
 
         # Update the required tensors if they need to be pulled from the
         # aggregator

--- a/openfl/pipelines/eden_pipeline.py
+++ b/openfl/pipelines/eden_pipeline.py
@@ -135,8 +135,9 @@ class Eden:
 
             # normal centroids
             for i in centroids:
-                centroids[i] = torch.Tensor([-j for j in centroids[i][::-1]] + centroids[i])\
-                    .to(device)
+                centroids[i] = torch.Tensor(
+                    [-j for j in centroids[i][::-1]] + centroids[i]
+                ).to(device)
 
             # centroids to bin boundaries
             def gen_boundaries(centroids):
@@ -259,9 +260,9 @@ class Eden:
         return (scale * vec)[:int(dim)].cpu().numpy()
 
     # packing the quantization values to bytes
-    def toBits(self, intBoolVec):
+    def to_bits(self, int_bool_vec):
 
-        def toBits_h(ibv):
+        def to_bits_h(ibv):
 
             n = ibv.numel()
             ibv = ibv.view(n // 8, 8).int()
@@ -272,19 +273,19 @@ class Eden:
 
             return bv
 
-        Lunit = intBoolVec.numel() // 8
-        bitVec = torch.zeros(Lunit * self.nbits, dtype=torch.uint8)
+        l_unit = int_bool_vec.numel() // 8
+        bit_vec = torch.zeros(l_unit * self.nbits, dtype=torch.uint8)
 
         for i in range(self.nbits):
-            bitVec[Lunit * i:Lunit * (i + 1)] = toBits_h((intBoolVec % 2 != 0).int())
-            intBoolVec = torch.div(intBoolVec, 2, rounding_mode='floor')
+            bit_vec[l_unit * i:l_unit * (i + 1)] = to_bits_h((int_bool_vec % 2 != 0).int())
+            int_bool_vec = torch.div(int_bool_vec, 2, rounding_mode='floor')
 
-        return bitVec
+        return bit_vec
 
     # unpacking bytes to quantization values
-    def fromBits(self, bitVec):
+    def from_bits(self, bit_vec):
 
-        def fromBits_h(bv, device):
+        def from_bits_h(bv, device):
 
             n = bv.numel()
 
@@ -295,13 +296,13 @@ class Eden:
 
             return iv.T.reshape(-1)
 
-        bitVec = bitVec.view(self.nbits, bitVec.numel() // self.nbits).to(self.device)
-        intVecs = torch.zeros(bitVec.numel() // self.nbits * 8).to(self.device)
+        bit_vec = bit_vec.view(self.nbits, bit_vec.numel() // self.nbits).to(self.device)
+        int_vecs = torch.zeros(bit_vec.numel() // self.nbits * 8).to(self.device)
 
         for i in range(self.nbits):
-            intVecs += 2**i * fromBits_h(bitVec[i], self.device)
+            int_vecs += 2**i * from_bits_h(bit_vec[i], self.device)
 
-        return intVecs.reshape(1, -1)
+        return int_vecs.reshape(1, -1)
 
 
 class EdenTransformer(Transformer):

--- a/openfl/transport/grpc/director_server.py
+++ b/openfl/transport/grpc/director_server.py
@@ -163,7 +163,7 @@ class DirectorGRPCServer(director_pb2_grpc.DirectorServicer):
         logger.info('Send response')
         return director_pb2.SetNewExperimentResponse(accepted=is_accepted)
 
-    async def GetExperimentStatus(self, request, context):
+    async def GetExperimentStatus(self, request, context):  # NOQA: N802
         """Get experiment status and update if experiment was approved."""
         logger.info('GetExperimentStatus request received')
         caller = self.get_caller(context)

--- a/openfl/utilities/fed_timer.py
+++ b/openfl/utilities/fed_timer.py
@@ -161,7 +161,7 @@ class SyncAsyncTaskDecoFactory:
         return sync_wrapper
 
 
-class fedtiming(SyncAsyncTaskDecoFactory):
+class fedtiming(SyncAsyncTaskDecoFactory):  # noqa: N801
     def __init__(self, timeout):
         self.timeout = timeout
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,11 +4,11 @@
 # break occurred after a binary operator
 # N812: lowercase imported as non lowercase. Allow "import torch.nn.functional as F"
 ignore = W503, N812
-select = E,F,W,C4,C90,C801
+select = E,F,W,N,C4,C90,C801
 inline-quotes = '
 multiline-quotes = '
 docstring-quotes = """
-exclude = *_pb2*,tests/github/interactive_api,tests/github/interactive_api_director,.eggs
+exclude = *_pb2*,tests/github/interactive_api,tests/github/interactive_api_director,.eggs, build
 max-line-length = 99
 avoid-escape = False
 import-order-style = smarkets

--- a/tests/openfl/component/director/test_experiment_representation.py
+++ b/tests/openfl/component/director/test_experiment_representation.py
@@ -30,7 +30,7 @@ def experiment_rep(_):
                          [(True, 0, 'pending'), (False, 1, 'rejected')]
                          )
 async def test_review_experiment(
-    ExperimentWorkspace, experiment_rep, review_result,
+    ExperimentWorkspace, experiment_rep, review_result,  # noqa: N803
     archive_unlink_call_count, experiment_status
 ):
     """Review experiment method test."""

--- a/tests/openfl/interface/test_model_api.py
+++ b/tests/openfl/interface/test_model_api.py
@@ -10,7 +10,7 @@ from openfl.federated.task import TaskRunner
 
 @mock.patch('openfl.interface.model.utils')
 @mock.patch('openfl.interface.model.Plan')
-def test_get_model(Plan, utils):
+def test_get_model(Plan, utils):  # noqa: N803
     "Test get_module returns TaskRunner."
     plan_instance = mock.Mock()
     plan_instance.cols_data_paths = ['mock_col_name']


### PR DESCRIPTION
## Issue
`pep8-naming` extension is included in `requirements-linters.txt` that is being installed for flake8 but is not activated in `setup.cfg`.

## Solution
Enable all `N`-type (naming convention) flake8 errors.