### PR TITLE
ci: add branch value for pypiPublish pushOn parameter

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,7 +129,9 @@ pipeline {
                 }
                 stage('Publish Package') {
                     steps {
-                        pypiPublish()
+                        pypiPublish([
+                            pypiPublishPushOn: /^(?:jenkins-v\d+.\d+)$/
+                        ])
                     }
                 }
             }


### PR DESCRIPTION
Add `pypiPublishPushOn` parameter to designate valid branch for pushing to PyPi. This is a parameter that was recently added to the `pypiPublish` function and is needed to designate which branches are allowed to publish to PyPi.

Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>