### PR TITLE
CI badges

### DIFF
--- a/.github/workflows/dockerization.yml
+++ b/.github/workflows/dockerization.yml
@@ -4,8 +4,6 @@
 name: Dockerization
 
 on:
-  push:
-    branches: [ develop ]
   pull_request:
     branches: [ develop ]
 

--- a/.github/workflows/double_ws_export.yml
+++ b/.github/workflows/double_ws_export.yml
@@ -4,8 +4,6 @@
 name: Double workspace export
 
 on:
-  push:
-    branches: [ develop ]
   pull_request:
     branches: [ develop ]
 

--- a/.github/workflows/fets-challenge.yml
+++ b/.github/workflows/fets-challenge.yml
@@ -4,8 +4,6 @@
 name: FeTS Challenge TaskRunner
 
 on:
-  push:
-    branches: [ develop ]
   pull_request:
     branches: [ develop ]
 

--- a/.github/workflows/interactive-kvasir.yml
+++ b/.github/workflows/interactive-kvasir.yml
@@ -4,8 +4,6 @@
 name: Interactive API - Pytorch Kvasir UNet
 
 on:
-  push:
-    branches: [ develop ]
   pull_request:
     branches: [ develop ]
 

--- a/.github/workflows/interactive-tensorflow.yml
+++ b/.github/workflows/interactive-tensorflow.yml
@@ -4,8 +4,6 @@
 name: Interactive API - Tensorflow MNIST
 
 on:
-  push:
-    branches: [ develop ]
   pull_request:
     branches: [ develop ]
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,8 +4,6 @@
 name: Lint with Flake8
 
 on:
-  push:
-    branches: [ develop ]
   pull_request:
     branches: [ develop ]
 

--- a/.github/workflows/pki.yml
+++ b/.github/workflows/pki.yml
@@ -4,8 +4,6 @@
 name: Private Key Infrastructure
 
 on:
-  push:
-    branches: [ develop ]
   pull_request:
     branches: [ develop ]
 

--- a/.github/workflows/pytest_coverage.yml
+++ b/.github/workflows/pytest_coverage.yml
@@ -4,8 +4,6 @@
 name: Pytest and code coverage 
 
 on:
-  push:
-    branches: [ develop ]
   pull_request:
     branches: [ develop ]
 

--- a/.github/workflows/straggler-handling.yml
+++ b/.github/workflows/straggler-handling.yml
@@ -4,8 +4,6 @@
 name: Straggler Handling Test
 
 on:
-  push:
-    branches: [ develop ]
   pull_request:
     branches: [ develop ]
 

--- a/.github/workflows/taskrunner.yml
+++ b/.github/workflows/taskrunner.yml
@@ -4,8 +4,6 @@
 name: TaskRunner
 
 on:
-  push:
-    branches: [ develop ]
   pull_request:
     branches: [ develop ]
 

--- a/.github/workflows/taskrunner_python_3.10.yml
+++ b/.github/workflows/taskrunner_python_3.10.yml
@@ -4,8 +4,6 @@
 name: TaskRunner (Python 3.10)
 
 on:
-  push:
-    branches: [ develop ]
   pull_request:
     branches: [ develop ]
 

--- a/.github/workflows/taskrunner_python_3.9.yml
+++ b/.github/workflows/taskrunner_python_3.9.yml
@@ -4,8 +4,6 @@
 name: TaskRunner (Python 3.9)
 
 on:
-  push:
-    branches: [ develop ]
   pull_request:
     branches: [ develop ]
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,8 +1,9 @@
 name: Ubuntu (latest)
 
 on:
-  schedule:
-    - cron: '0 0 * * *'
+  push:
+    branches:
+      - ci_badges
 
 permissions:
   contents: read

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,4 +1,4 @@
-name: ['Ubuntu (latest)']
+name: Ubuntu (latest)
 
 on:
   schedule:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,0 +1,103 @@
+name: ['Ubuntu (latest)']
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  contents: read
+
+env:
+  OS: ubuntu-latest
+
+jobs:
+  lint: # from lint.yml
+    runs-on: $OS
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.8"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements-linters.txt 
+        pip install .
+    - name: Lint with flake8
+      run: |
+        flake8 --show-source
+
+  pytest-coverage: # from pytest_coverage.yml
+    needs: lint
+    runs-on: $OS
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.8"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest coverage
+        pip install -r requirements-test.txt
+        pip install .
+    - name: Test with pytest and report code coverage
+      run: |
+        coverage run -m pytest -rA
+        coverage report
+    
+  dockerization: # from dockerization.yml
+    needs: [lint, pytest-coverage]
+    runs-on: $OS
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.8"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+      - name: Dockerization test
+        run: |
+          python -m tests.github.dockerization_test
+  
+  interactive-kvasir: # from interactive-kvasir.yml
+    needs: [lint, pytest-coverage, dockerization]
+    runs-on: $OS
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.8"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .
+    - name: Interactive API - pytorch_kvasir_unet
+      run: |
+        python setup.py build_grpc
+        pip install torch==1.8.1
+        pip install torchvision==0.9.1
+        python -m tests.github.interactive_api_director.experiments.pytorch_kvasir_unet.run
+  
+  cli:
+    needs: [lint, pytest-coverage, dockerization, interactive-kvasir]
+    runs-on: $OS
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.8"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+      - name: Test TaskRunner API
+        run: |
+          python -m tests.github.test_hello_federation --template keras_cnn_mnist --fed_workspace aggregator --col1 col1 --col2 col2  --rounds-to-train 3 --save-model output_model

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -7,12 +7,9 @@ on:
 permissions:
   contents: read
 
-env:
-  OS: ubuntu-latest
-
 jobs:
   lint: # from lint.yml
-    runs-on: $OS
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.8
@@ -30,7 +27,7 @@ jobs:
 
   pytest-coverage: # from pytest_coverage.yml
     needs: lint
-    runs-on: $OS
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.8
@@ -50,7 +47,7 @@ jobs:
     
   dockerization: # from dockerization.yml
     needs: [lint, pytest-coverage]
-    runs-on: $OS
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.8
@@ -67,7 +64,7 @@ jobs:
   
   interactive-kvasir: # from interactive-kvasir.yml
     needs: [lint, pytest-coverage, dockerization]
-    runs-on: $OS
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.8
@@ -87,7 +84,7 @@ jobs:
   
   cli:
     needs: [lint, pytest-coverage, dockerization, interactive-kvasir]
-    runs-on: $OS
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.8

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,9 +1,8 @@
 name: Ubuntu (latest)
 
 on:
-  push:
-    branches:
-      - ci_badges
+  schedule:
+    - cron: '0 0 * * *'
 
 permissions:
   contents: read

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,4 +1,4 @@
-name: ['Windows (latest)']
+name: Windows (latest)
 
 on:
   schedule:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,12 +7,9 @@ on:
 permissions:
   contents: read
 
-env:
-  OS: windows-latest
-
 jobs:
   lint: # from lint.yml
-    runs-on: $OS
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.8
@@ -30,7 +27,7 @@ jobs:
 
   pytest-coverage: # from pytest_coverage.yml
     needs: lint
-    runs-on: $OS
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.8
@@ -50,7 +47,7 @@ jobs:
     
   dockerization: # from dockerization.yml
     needs: [lint, pytest-coverage]
-    runs-on: $OS
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.8
@@ -67,7 +64,7 @@ jobs:
   
   interactive-kvasir: # from interactive-kvasir.yml
     needs: [lint, pytest-coverage, dockerization]
-    runs-on: $OS
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.8
@@ -87,7 +84,7 @@ jobs:
   
   cli:
     needs: [lint, pytest-coverage, dockerization, interactive-kvasir]
-    runs-on: $OS
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.8

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,23 +9,6 @@ permissions:
   contents: read
 
 jobs:
-  lint: # from lint.yml
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v3
-      with:
-        python-version: "3.8"
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements-linters.txt 
-        pip install .
-    - name: Lint with flake8
-      run: |
-        flake8 --show-source
-
   pytest-coverage: # from pytest_coverage.yml
     needs: lint
     runs-on: windows-latest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,9 +1,8 @@
 name: Windows (latest)
 
 on:
-  push:
-    branches:
-      - ci_badges
+  schedule:
+    - cron: '0 0 * * *'
 
 permissions:
   contents: read

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,26 +27,9 @@ jobs:
       run: |
         coverage run -m pytest -rA
         coverage report
-    
-  dockerization: # from dockerization.yml
-    needs: [pytest-coverage]
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v3
-        with:
-          python-version: "3.8"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install .
-      - name: Dockerization test
-        run: |
-          python -m tests.github.dockerization_test
   
   interactive-kvasir: # from interactive-kvasir.yml
-    needs: [pytest-coverage, dockerization]
+    needs: [pytest-coverage]
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v3
@@ -65,8 +48,8 @@ jobs:
         pip install torchvision==0.9.1
         python -m tests.github.interactive_api_director.experiments.pytorch_kvasir_unet.run
   
-  cli:
-    needs: [pytest-coverage, dockerization, interactive-kvasir]
+  cli: # from taskrunner.yml
+    needs: [pytest-coverage, interactive-kvasir]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,8 +1,9 @@
 name: Windows (latest)
 
 on:
-  schedule:
-    - cron: '0 0 * * *'
+  push:
+    branches:
+      - ci_badges
 
 permissions:
   contents: read

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,7 +10,6 @@ permissions:
 
 jobs:
   pytest-coverage: # from pytest_coverage.yml
-    needs: lint
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v3
@@ -30,7 +29,7 @@ jobs:
         coverage report
     
   dockerization: # from dockerization.yml
-    needs: [lint, pytest-coverage]
+    needs: [pytest-coverage]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
@@ -47,7 +46,7 @@ jobs:
           python -m tests.github.dockerization_test
   
   interactive-kvasir: # from interactive-kvasir.yml
-    needs: [lint, pytest-coverage, dockerization]
+    needs: [pytest-coverage, dockerization]
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v3
@@ -67,7 +66,7 @@ jobs:
         python -m tests.github.interactive_api_director.experiments.pytorch_kvasir_unet.run
   
   cli:
-    needs: [lint, pytest-coverage, dockerization, interactive-kvasir]
+    needs: [pytest-coverage, dockerization, interactive-kvasir]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,103 @@
+name: ['Windows (latest)']
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  contents: read
+
+env:
+  OS: windows-latest
+
+jobs:
+  lint: # from lint.yml
+    runs-on: $OS
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.8"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements-linters.txt 
+        pip install .
+    - name: Lint with flake8
+      run: |
+        flake8 --show-source
+
+  pytest-coverage: # from pytest_coverage.yml
+    needs: lint
+    runs-on: $OS
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.8"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest coverage
+        pip install -r requirements-test.txt
+        pip install .
+    - name: Test with pytest and report code coverage
+      run: |
+        coverage run -m pytest -rA
+        coverage report
+    
+  dockerization: # from dockerization.yml
+    needs: [lint, pytest-coverage]
+    runs-on: $OS
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.8"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+      - name: Dockerization test
+        run: |
+          python -m tests.github.dockerization_test
+  
+  interactive-kvasir: # from interactive-kvasir.yml
+    needs: [lint, pytest-coverage, dockerization]
+    runs-on: $OS
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.8"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .
+    - name: Interactive API - pytorch_kvasir_unet
+      run: |
+        python setup.py build_grpc
+        pip install torch==1.8.1
+        pip install torchvision==0.9.1
+        python -m tests.github.interactive_api_director.experiments.pytorch_kvasir_unet.run
+  
+  cli:
+    needs: [lint, pytest-coverage, dockerization, interactive-kvasir]
+    runs-on: $OS
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.8"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+      - name: Test TaskRunner API
+        run: |
+          python -m tests.github.test_hello_federation --template keras_cnn_mnist --fed_workspace aggregator --col1 col1 --col2 col2  --rounds-to-train 3 --save-model output_model

--- a/README.md
+++ b/README.md
@@ -79,10 +79,6 @@ You can find more details in the following articles:
 | FedOpt | [Reddi et al., 2020](https://arxiv.org/abs/2003.00295) | ✅ | ✅ | ✅ | [docs](http://openfl.readthedocs.io/en/latest/supported_aggregation_algorithms.html#fedopt) |
 | FedCurv | [Shoham et al., 2019](https://arxiv.org/pdf/1910.07796.pdf) | ✅ | ❌ | ❌ | [docs](http://openfl.readthedocs.io/en/latest/supported_aggregation_algorithms.html#fedcurv) |
 
-## Build status
-| Operating system | Status |
-| ---- | ------ | 
-| ubuntu-latest | [![CLI](https://github.com/intel/openfl/actions/workflows/taskrunner.yml/badge.svg)](https://github.com/intel/openfl/actions/workflows/taskrunner.yml)
 ## Support
 Please join us for our bi-monthly community meetings starting December 1 & 2, 2022! <br>
 Meet with some of the Intel team members behind OpenFL. <br>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Open Federated Learning (OpenFL) - An Open-Source Framework For Federated Learning
 
 [![PyPI - Python Version](https://img.shields.io/badge/python-3.6%20%7C%203.7%20%7C%203.8-blue)](https://pypi.org/project/openfl/)
-[![Continuous Integration](https://github.com/intel/openfl/actions/workflows/python-app.yml/badge.svg?branch=develop)](https://github.com/intel/openfl/actions/workflows/python-app.yml)
+[![Ubuntu CI status](https://github.com/intel/openfl/actions/workflows/ubuntu.yml/badge.svg)](https://github.com/intel/openfl/actions/workflows/ubuntu.yml)
+[![Windows CI status](https://github.com/intel/openfl/actions/workflows/windows.yml/badge.svg)](https://github.com/intel/openfl/actions/workflows/windows.yml)
 [![Documentation Status](https://readthedocs.org/projects/openfl/badge/?version=latest)](https://openfl.readthedocs.io/en/latest/?badge=latest)
 [![Downloads](https://pepy.tech/badge/openfl)](https://pepy.tech/project/openfl)
 [![DockerHub](https://img.shields.io/docker/pulls/intel/openfl.svg)](https://hub.docker.com/r/intel/openfl)
@@ -78,6 +79,10 @@ You can find more details in the following articles:
 | FedOpt | [Reddi et al., 2020](https://arxiv.org/abs/2003.00295) | ✅ | ✅ | ✅ | [docs](http://openfl.readthedocs.io/en/latest/supported_aggregation_algorithms.html#fedopt) |
 | FedCurv | [Shoham et al., 2019](https://arxiv.org/pdf/1910.07796.pdf) | ✅ | ❌ | ❌ | [docs](http://openfl.readthedocs.io/en/latest/supported_aggregation_algorithms.html#fedcurv) |
 
+## Build status
+| Operating system | Status |
+| ---- | ------ | 
+| ubuntu-latest | [![CLI](https://github.com/intel/openfl/actions/workflows/taskrunner.yml/badge.svg)](https://github.com/intel/openfl/actions/workflows/taskrunner.yml)
 ## Support
 Please join us for our bi-monthly community meetings starting December 1 & 2, 2022! <br>
 Meet with some of the Intel team members behind OpenFL. <br>


### PR DESCRIPTION
## New
- Ubuntu test sequence
- Windows test sequence
- 2 badges in the README.md

The test sequence for both operating systems is following:
- Linter (removed on Windows because of https://github.com/savoirfairelinux/flake8-copyright/pull/16)
- PyTest
- Dockerization (removed on Windows because of inability to switch to Windows containers inside Github Actions).
- Interactive API (UNet Kvasir example)
- CLI (Keras CNN MNIST template)
