### PR TITLE
Fix python path in workspace context manager

### DIFF
--- a/openfl/utilities/workspace.py
+++ b/openfl/utilities/workspace.py
@@ -72,14 +72,14 @@ class ExperimentWorkspace:
         os.chdir(self.experiment_work_dir)
 
         # This is needed for python module finder
-        sys.path.append(self.experiment_work_dir)
+        sys.path.append(str(self.experiment_work_dir))
 
     def __exit__(self, exc_type, exc_value, traceback):
         """Remove the workspace."""
         os.chdir(self.cwd)
         shutil.rmtree(self.experiment_work_dir, ignore_errors=True)
         if self.experiment_work_dir in sys.path:
-            sys.path.remove(self.experiment_work_dir)
+            sys.path.remove(str(self.experiment_work_dir))
 
         if self.remove_archive:
             logger.debug(

--- a/openfl/utilities/workspace.py
+++ b/openfl/utilities/workspace.py
@@ -78,7 +78,7 @@ class ExperimentWorkspace:
         """Remove the workspace."""
         os.chdir(self.cwd)
         shutil.rmtree(self.experiment_work_dir, ignore_errors=True)
-        if self.experiment_work_dir in sys.path:
+        if str(self.experiment_work_dir) in sys.path:
             sys.path.remove(str(self.experiment_work_dir))
 
         if self.remove_archive:


### PR DESCRIPTION
This PR fixes extending the Python paths list in the `workspace` context manager

Signed-off-by: igor-davidyuk <igor.davidyuk@intel.com>