### PR TITLE
Fix missing NumPy int attribute

### DIFF
--- a/openfl/federated/task/runner_fets_challenge.py
+++ b/openfl/federated/task/runner_fets_challenge.py
@@ -567,7 +567,7 @@ def expand_derived_opt_state_dict(derived_opt_state_dict, device):
 
     opt_state_dict = {'param_groups': [], 'state': {}}
     nb_params_per_group = list(
-        derived_opt_state_dict.pop('__opt_group_lengths').astype(np.int)
+        derived_opt_state_dict.pop('__opt_group_lengths').astype(np.int32)
     )
 
     # Construct the expanded dict.

--- a/openfl/federated/task/runner_pt.py
+++ b/openfl/federated/task/runner_pt.py
@@ -580,7 +580,7 @@ def expand_derived_opt_state_dict(derived_opt_state_dict, device):
 
     opt_state_dict = {'param_groups': [], 'state': {}}
     nb_params_per_group = list(
-        derived_opt_state_dict.pop('__opt_group_lengths').astype(np.int)
+        derived_opt_state_dict.pop('__opt_group_lengths').astype(np.int32)
     )
 
     # Construct the expanded dict.

--- a/openfl/pipelines/skc_pipeline.py
+++ b/openfl/pipelines/skc_pipeline.py
@@ -154,7 +154,7 @@ class KmeansTransformer(Transformer):
         """
         flatten_array = np_array.reshape(-1)
         unique_value_array = np.unique(flatten_array)
-        int_array = np.zeros(flatten_array.shape, dtype=np.int)
+        int_array = np.zeros(flatten_array.shape, dtype=np.int32)
         int_to_float_map = {}
         float_to_int_map = {}
         # create table

--- a/openfl/pipelines/stc_pipeline.py
+++ b/openfl/pipelines/stc_pipeline.py
@@ -144,7 +144,7 @@ class TernaryTransformer(Transformer):
         """
         flatten_array = np_array.reshape(-1)
         unique_value_array = np.unique(flatten_array)
-        int_array = np.zeros(flatten_array.shape, dtype=np.int)
+        int_array = np.zeros(flatten_array.shape, dtype=np.int32)
         int_to_float_map = {}
         float_to_int_map = {}
         # create table

--- a/openfl/plugins/frameworks_adapters/pytorch_adapter.py
+++ b/openfl/plugins/frameworks_adapters/pytorch_adapter.py
@@ -215,7 +215,7 @@ def expand_derived_opt_state_dict(derived_opt_state_dict, device):
 
     opt_state_dict = {'param_groups': [], 'state': {}}
     nb_params_per_group = list(
-        derived_opt_state_dict.pop('__opt_group_lengths').astype(np.int)
+        derived_opt_state_dict.pop('__opt_group_lengths').astype(np.int32)
     )
 
     # Construct the expanded dict.


### PR DESCRIPTION
## Issue
NumPy library has `int` attribute [deprecated](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations) since release 1.20.0 and no longer exists in the latest version.

## Steps to reproduce
Follow steps in `openfl-tutorials/interactive_api/PyTorch_TinyImageNet/README.md`.

## Error
```
ERROR    Collaborator env_one was failed with error code: 1, error_description: Traceback (most recent call last):             director_server.py:268
                      File "/home/itrushkin/repos/openfl/openfl/component/envoy/envoy.py", line 112, in run                                                     
                        self._run_collaborator()                                                                                                                
                      File "/home/itrushkin/repos/openfl/openfl/component/envoy/envoy.py", line 193, in _run_collaborator                                       
                        col.run()                                                                                                                               
                      File "/home/itrushkin/repos/openfl/openfl/component/collaborator/collaborator.py", line 145, in run                                       
                        self.do_task(task, round_number)                                                                                                        
                      File "/home/itrushkin/repos/openfl/openfl/component/collaborator/collaborator.py", line 255, in do_task                                   
                        global_output_tensor_dict, local_output_tensor_dict = func(                                                                             
                      File "/home/itrushkin/repos/openfl/openfl/federated/task/task_runner.py", line 109, in collaborator_adapted_task                          
                        self.rebuild_model(input_tensor_dict, validation=validation_flag, device=device)                                                        
                      File "/home/itrushkin/repos/openfl/openfl/federated/task/task_runner.py", line 230, in rebuild_model                                      
                        self.set_tensor_dict(input_tensor_dict, with_opt_vars=True, device=device)                                                              
                      File "/home/itrushkin/repos/openfl/openfl/federated/task/task_runner.py", line 382, in set_tensor_dict                                    
                        return self.framework_adapter.set_tensor_dict(*args, **kwargs)                                                                          
                      File "/home/itrushkin/repos/openfl/openfl/plugins/frameworks_adapters/pytorch_adapter.py", line 55, in                                    
                    set_tensor_dict                                                                                                                             
                        _set_optimizer_state(optimizer, device, tensor_dict)                                                                                    
                      File "/home/itrushkin/repos/openfl/openfl/plugins/frameworks_adapters/pytorch_adapter.py", line 70, in                                    
                    _set_optimizer_state                                                                                                                        
                        temp_state_dict = expand_derived_opt_state_dict(                                                                                        
                      File "/home/itrushkin/repos/openfl/openfl/plugins/frameworks_adapters/pytorch_adapter.py", line 218, in                                   
                    expand_derived_opt_state_dict                                                                                                               
                        derived_opt_state_dict.pop('__opt_group_lengths').astype(np.int)                                                                        
                      File "/home/itrushkin/.virtualenvs/openfl3.8/lib/python3.8/site-packages/numpy/__init__.py", line 284, in                                 
                    __getattr__                                                                                                                                 
                        raise AttributeError("module {!r} has no attribute "                                                                                    
                    AttributeError: module 'numpy' has no attribute 'int'
```

## Fix
Replace all `np.int` casts with `np.int32`.