### PR TITLE
Updating pytorch versions, renaming deprecated on_epoch_end hook

### DIFF
--- a/openfl-tutorials/interactive_api/PyTorch_Lightning_MNIST_GAN/envoy/sd_requirements.txt
+++ b/openfl-tutorials/interactive_api/PyTorch_Lightning_MNIST_GAN/envoy/sd_requirements.txt
@@ -1,5 +1,5 @@
 numpy
 pillow
 pynvml==11.4.1
-torch==1.9.1
-torchvision==0.10.1
+torch==1.13.1
+torchvision==0.14.1

--- a/openfl-tutorials/interactive_api/PyTorch_Lightning_MNIST_GAN/workspace/PyTorch_Lightning_GAN.ipynb
+++ b/openfl-tutorials/interactive_api/PyTorch_Lightning_MNIST_GAN/workspace/PyTorch_Lightning_GAN.ipynb
@@ -15,7 +15,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install \"pytorch-lightning>=1.3\" \"torch==1.9.1\" \"torchvision==0.10.1\" \"torchmetrics>=0.3\" \"scikit-image\" \"matplotlib\""
+    "!pip install \"pytorch-lightning>=1.3\" \"torch==1.13.1\" \"torchvision==0.14.1\" \"torchmetrics>=0.3\" \"scikit-image\" \"matplotlib\""
    ]
   },
   {
@@ -429,7 +429,7 @@
     "        self.log(name=\"Discriminator val loss\", value=val_real_loss, on_epoch=True)\n",
     "        return {\"val_loss\": val_real_loss}\n",
     "\n",
-    "    def on_epoch_end(self):\n",
+    "    def on_val_epoch_end(self):\n",
     "        z = self.validation_z.type_as(self.generator.model[0].weight)\n",
     "\n",
     "        sample_imgs = self(z)\n",
@@ -454,7 +454,7 @@
     "        super().__init__()\n",
     "        self.metrics = []\n",
     "\n",
-    "    def on_epoch_end(self, trainer, pl_module):\n",
+    "    def on_val_epoch_end(self, trainer, pl_module):\n",
     "        met = copy.deepcopy(trainer.callback_metrics)\n",
     "        self.metrics.append(met)\n",
     "\n",


### PR DESCRIPTION
Updating pytorch version for PyTorch_Lightning_MNIST_GAN and renaming deprecated hooks. It's connected to https://github.com/intel/openfl/pull/655