### PR TITLE
Print CSR hash in generate-cert-request (#692)

### DIFF
--- a/openfl/cryptography/io.py
+++ b/openfl/cryptography/io.py
@@ -111,3 +111,25 @@ def read_csr(path: Path) -> Tuple[CertificateSigningRequest, str]:
     # TODO: replace assert with exception / sys.exit
     assert (isinstance(csr, x509.CertificateSigningRequest))
     return csr, hasher.hexdigest()
+
+
+def write_csr(certificate: Certificate, path: Path) -> str:
+    """
+    Write certificate signing request.
+
+    Args:
+        certificate: Certificate
+        path : Path (pathlib)
+
+    Returns:
+        SHA-384 hash of the CSR file in hex format
+    """
+    hasher = sha384()
+    pem_data = certificate.public_bytes(
+        encoding=serialization.Encoding.PEM,
+    )
+    hasher.update(pem_data)
+    with open(path, 'wb') as f:
+        f.write(pem_data)
+
+    return hasher.hexdigest()

--- a/openfl/interface/aggregator.py
+++ b/openfl/interface/aggregator.py
@@ -168,7 +168,7 @@ def certify(fqdn, silent):
 
     signing_crt = read_crt(signing_crt_absolute_path)
 
-    echo(f'Certificate request attributes:')
+    echo('Certificate request attributes:')
     for a in csr.subject:
         echo(f'  {style(a.rfc4514_attribute_name, fg="green")} = {style(a.value, fg="red")}')
     echo('The CSR Hash for file '

--- a/openfl/interface/aggregator.py
+++ b/openfl/interface/aggregator.py
@@ -69,7 +69,7 @@ def _generate_cert_request(fqdn):
 def generate_cert_request(fqdn):
     """Create aggregator certificate key pair."""
     from openfl.cryptography.participant import generate_csr
-    from openfl.cryptography.io import write_crt
+    from openfl.cryptography.io import write_csr
     from openfl.cryptography.io import write_key
     from openfl.interface.cli_helper import CERT_DIR
 
@@ -92,8 +92,10 @@ def generate_cert_request(fqdn):
         f'{CERT_DIR}/server', fg='green'))
 
     # Write aggregator csr and key to disk
-    write_crt(server_csr, CERT_DIR / 'server' / f'{file_name}.csr')
+    csr_hash = write_csr(server_csr, CERT_DIR / 'server' / f'{file_name}.csr')
     write_key(server_private_key, CERT_DIR / 'server' / f'{file_name}.key')
+
+    echo(f'  CSR hash = {style(csr_hash, fg="red")}')
 
 
 # TODO: function not used

--- a/openfl/interface/aggregator.py
+++ b/openfl/interface/aggregator.py
@@ -168,6 +168,9 @@ def certify(fqdn, silent):
 
     signing_crt = read_crt(signing_crt_absolute_path)
 
+    echo(f'Certificate request attributes:')
+    for a in csr.subject:
+        echo(f'  {style(a.rfc4514_attribute_name, fg="green")} = {style(a.value, fg="red")}')
     echo('The CSR Hash for file '
          + style(f'{cert_name}.csr', fg='green')
          + ' = '

--- a/openfl/interface/collaborator.py
+++ b/openfl/interface/collaborator.py
@@ -335,6 +335,9 @@ def certify(collaborator_name, silent, request_pkg=None, import_=False):
 
         signing_crt = read_crt(CERT_DIR / signing_crt_path)
 
+        echo(f'Certificate request attributes:')
+        for a in csr.subject:
+            echo(f'  {style(a.rfc4514_attribute_name, fg="green")} = {style(a.value, fg="red")}')
         echo('The CSR Hash for file '
              + style(f'{file_name}.csr', fg='green')
              + ' = '

--- a/openfl/interface/collaborator.py
+++ b/openfl/interface/collaborator.py
@@ -133,7 +133,7 @@ def generate_cert_request(collaborator_name, data_path, silent, skip_package):
     Then create a package with the CSR to send for signing.
     """
     from openfl.cryptography.participant import generate_csr
-    from openfl.cryptography.io import write_crt
+    from openfl.cryptography.io import write_csr
     from openfl.cryptography.io import write_key
     from openfl.interface.cli_helper import CERT_DIR
 
@@ -153,8 +153,10 @@ def generate_cert_request(collaborator_name, data_path, silent, skip_package):
         f'{CERT_DIR}/{file_name}', fg='green'))
 
     # Write collaborator csr and key to disk
-    write_crt(client_csr, CERT_DIR / 'client' / f'{file_name}.csr')
+    csr_hash = write_csr(client_csr, CERT_DIR / 'client' / f'{file_name}.csr')
     write_key(client_private_key, CERT_DIR / 'client' / f'{file_name}.key')
+
+    print(f'  CSR hash = {style(csr_hash, fg="red")}')
 
     if not skip_package:
         from shutil import copytree

--- a/openfl/interface/collaborator.py
+++ b/openfl/interface/collaborator.py
@@ -335,7 +335,7 @@ def certify(collaborator_name, silent, request_pkg=None, import_=False):
 
         signing_crt = read_crt(CERT_DIR / signing_crt_path)
 
-        echo(f'Certificate request attributes:')
+        echo('Certificate request attributes:')
         for a in csr.subject:
             echo(f'  {style(a.rfc4514_attribute_name, fg="green")} = {style(a.value, fg="red")}')
         echo('The CSR Hash for file '


### PR DESCRIPTION
Currently, there is no real way to verify CSR properly when using fx command line: since generate-cert-request does not print the CSR hash, it is not really possible to know in certify that the CSR being signed is the correct one. To mitigate this, add a print with the CSR hash in generate-cert-request. User is then expected to compare the hashes and approve the CSR only if they match

Signed-off-by: Lavi, Nir <nir.lavi@intel.com>