### PR TITLE
Update kc_pipeline.py

### DIFF
--- a/openfl/pipelines/kc_pipeline.py
+++ b/openfl/pipelines/kc_pipeline.py
@@ -88,7 +88,7 @@ class KmeansTransformer(Transformer):
         """
         flatten_array = np_array.reshape(-1)
         unique_value_array = np.unique(flatten_array)
-        int_array = np.zeros(flatten_array.shape, dtype=np.int)
+        int_array = np.zeros(flatten_array.shape, dtype=np.int32)
         int_to_float_map = {}
         float_to_int_map = {}
         # create table

--- a/openfl/pipelines/kc_pipeline.py
+++ b/openfl/pipelines/kc_pipeline.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 """KCPipeline module."""


### PR DESCRIPTION
**ISSUE**:

Interactive API tutorial [Tensorflow_MNIST.ipynb](https://github.com/intel/openfl/blob/develop/openfl-tutorials/interactive_api/Tensorflow_MNIST/workspace/Tensorflow_MNIST.ipynb) fails with error

**ERROR**:

File "/home/ithakarx/newEnv/lib/python3.8/site-packages/openfl/pipelines/kc_pipeline.py", line 52, in forward
int_array, int2float_map = self._float_to_int(quant_array)
File "/home/ithakarx/newEnv/lib/python3.8/site-packages/openfl/pipelines/kc_pipeline.py", line 91, in _float_to_int
int_array = np.zeros(flatten_array.shape, dtype=np.int)
File "/home/ithakarx/newEnv/lib/python3.8/site-packages/numpy/init.py", line 284, in getattr
raise AttributeError("module {!r} has no attribute "
AttributeError: module 'numpy' has no attribute 'int'

**STEPS TO REPRODUCE:**

Described in Issue #686 

**FIX**:

Replace np.int with np.int32 in openfl/pipelines/kc_pipeline.py

**ADDITIONAL INFORMATION:** 

Tensorflownp.int is deprecated since NumPy releases 1.20.0. As NumPy version is not pinnded in openfl therefore by default latest numpy version is installed and the tutorial gives an error when executed

This is a fix for Issue #686 (Error in Tensorflow_MNIST Tutorial numpy version 1.24.1)

**IMPORTANT**: Same fix has been done for other such instances in PR #683 
