### PR TITLE
Align graminize process with setup documentation

### DIFF
--- a/openfl-gramine/Dockerfile.gramine
+++ b/openfl-gramine/Dockerfile.gramine
@@ -4,7 +4,7 @@ FROM ${BASE_IMAGE}
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN --mount=type=cache,target=/root/.cache/ \
-    pip install --upgrade pip && \
+    pip install --upgrade pip setuptools wheel && \
     pip install openfl
 
 # install gramine


### PR DESCRIPTION
Per fix for #672, seup documentation was updated to upgrade pip, setuptools and wheel. Align base Dockerfile used in graminize to reflect this change

Signed-off-by: Lavi, Nir <nir.lavi@intel.com>