### PR TITLE
Hashing function update

### DIFF
--- a/openfl/experimental/utilities/metaflow_utils.py
+++ b/openfl/experimental/utilities/metaflow_utils.py
@@ -62,7 +62,7 @@ class SystemMutex:
         self.name = name
 
     def __enter__(self):
-        lock_id = hashlib.md5(self.name.encode("utf8")).hexdigest()
+        lock_id = hashlib.new('md5', self.name.encode("utf8"), usedforsecurity=False).hexdigest()
         self.fp = open(f"/tmp/.lock-{lock_id}.lck", "wb")
         fcntl.flock(self.fp.fileno(), fcntl.LOCK_EX)
 


### PR DESCRIPTION
Clarifies that MD5 hashing function is not used for security purposes