### PR TITLE
Fix CONTINUE_GLOBAL optimizer treatment

### DIFF
--- a/openfl-tutorials/Federated_FedProx_PyTorch_MNIST_Tutorial.ipynb
+++ b/openfl-tutorials/Federated_FedProx_PyTorch_MNIST_Tutorial.ipynb
@@ -242,7 +242,13 @@
    "outputs": [],
    "source": [
     "#Run experiment, return trained FederatedModel\n",
-    "final_fl_model = fx.run_experiment(collaborators,{'aggregator.settings.rounds_to_train':5})"
+    "final_fl_model = fx.run_experiment(\n",
+    "    collaborators,\n",
+    "    {\n",
+    "        'aggregator.settings.rounds_to_train': 5,\n",
+    "        'collaborator.settings.opt_treatment': 'CONTINUE_GLOBAL',\n",
+    "    }\n",
+    ")"
    ]
   },
   {
@@ -473,7 +479,13 @@
    "outputs": [],
    "source": [
     "#Run experiment, return trained FederatedModel\n",
-    "final_fl_model = fx.run_experiment(collaborators,{'aggregator.settings.rounds_to_train':20})"
+    "final_fl_model = fx.run_experiment(\n",
+    "    collaborators,\n",
+    "    {\n",
+    "        'aggregator.settings.rounds_to_train': 20,\n",
+    "        'collaborator.settings.opt_treatment': 'CONTINUE_GLOBAL',\n",
+    "    }\n",
+    ")"
    ]
   },
   {

--- a/openfl/federated/task/runner_fets_challenge.py
+++ b/openfl/federated/task/runner_fets_challenge.py
@@ -200,7 +200,7 @@ class FeTSChallengeTaskRunner(TaskRunner):
 
         # This will signal that the optimizer values are now present,
         # and can be loaded when the model is rebuilt
-        self.train_round_completed = True
+        self.training_round_completed = True
 
         # Return global_tensor_dict, local_tensor_dict
         return global_tensor_dict, local_tensor_dict

--- a/openfl/federated/task/runner_pt.py
+++ b/openfl/federated/task/runner_pt.py
@@ -214,7 +214,7 @@ class PyTorchTaskRunner(nn.Module, TaskRunner):
 
         # This will signal that the optimizer values are now present,
         # and can be loaded when the model is rebuilt
-        self.train_round_completed = True
+        self.training_round_completed = True
 
         # Return global_tensor_dict, local_tensor_dict
         return global_tensor_dict, local_tensor_dict


### PR DESCRIPTION
## Issue
Optimizer treatment `CONTINUE_GLOBAL`  is never handled in PyTorch scenario since `PyTorchTaskRunner.training_round_completed` is never set to `True`. There is a logic that sets `train_round_completed` variable to `True`, but it is not handled.

## Fix
Rename the flag getting set at the end of the training task.

Also, global optimizer treatment is set in PyTorch FedProx examples.

Closes #710.