### PR TITLE
[CI] Fix dockerization test

### DIFF
--- a/tests/github/dockerization_test.py
+++ b/tests/github/dockerization_test.py
@@ -95,14 +95,14 @@ if __name__ == '__main__':
     check_call(['docker', 'load', '--input', image_tar])
     time.sleep(5)
     with ProcessPoolExecutor(max_workers=2) as executor:
-        executor.submit(start_aggregator_container, args=(
+        executor.submit(start_aggregator_container,
             workspace_image_name,
             aggregator_required_files
-        ))
+        )
         time.sleep(5)
-        executor.submit(start_collaborator_container, args=(
+        executor.submit(start_collaborator_container,
             workspace_image_name,
             col
-        ))
+        )
     # If containers are started but collaborator will fail to
     # conect the aggregator, the pipeline will go to the infinite loop

--- a/tests/github/dockerization_test.py
+++ b/tests/github/dockerization_test.py
@@ -95,14 +95,10 @@ if __name__ == '__main__':
     check_call(['docker', 'load', '--input', image_tar])
     time.sleep(5)
     with ProcessPoolExecutor(max_workers=2) as executor:
-        executor.submit(start_aggregator_container,
-            workspace_image_name,
-            aggregator_required_files
+        executor.submit(
+            start_aggregator_container, workspace_image_name, aggregator_required_files
         )
         time.sleep(5)
-        executor.submit(start_collaborator_container,
-            workspace_image_name,
-            col
-        )
+        executor.submit(start_collaborator_container, workspace_image_name, col)
     # If containers are started but collaborator will fail to
     # conect the aggregator, the pipeline will go to the infinite loop


### PR DESCRIPTION
## Issue
The output of CI dockerization jobs stops at the collaborator certification. Aggregator and collaborator containers do not start.

## Fix 
Change `ProcessPoolExecutor.submit` call signature.