### PR TITLE
Allow grpcio <=1.48.2 for Raspberry Pi installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ setup(
         'docker',
         'dynaconf==3.1.7',
         'flatten_json',
-        'grpcio~=1.48.2',
+        'grpcio<=1.48.2',
         'ipykernel',
         'jupyterlab',
         'numpy',
@@ -156,7 +156,7 @@ setup(
         'tensorboardX',
         'tqdm',
     ],
-    setup_requires=['grpcio-tools~=1.48.2'],
+    setup_requires=['grpcio-tools<=1.48.2'],
     python_requires='>=3.7, <3.11',
     project_urls={
         'Bug Tracker': 'https://github.com/intel/openfl/issues',


### PR DESCRIPTION
grpcio 1.48.2 throw a glibc error on Raspberry Pi installation. This change will still install 1.48.2 by default, but allow for user downgrades afterwards

Closes https://github.com/intel/openfl/issues/727