### PR TITLE
Fix assert subkey step

### DIFF
--- a/openfl/plugins/frameworks_adapters/pytorch_adapter.py
+++ b/openfl/plugins/frameworks_adapters/pytorch_adapter.py
@@ -102,6 +102,25 @@ def _get_optimizer_state(optimizer):
     return derived_opt_state_dict
 
 
+def state_dict_is_empty(state_dict):
+    """Determine if the state is needed for the optimizer by recursively checking
+    if all the values inside the 'state' dictionary are empty or not.
+    
+    Args:
+        state_dict: The optimizer state dictionary
+        
+    Returns:
+        True or False
+    """
+    if isinstance(state_dict, dict):
+        return all(state_dict_is_empty(subvalue) for subvalue in state_dict.values())
+    else:
+        if isinstance(state_dict, pt.Tensor):
+            return False
+        else:
+            return not state_dict
+        
+
 def _derive_opt_state_dict(opt_state_dict):
     """Separate optimizer tensors from the tensor dictionary.
 
@@ -117,7 +136,7 @@ def _derive_opt_state_dict(opt_state_dict):
     derived_opt_state_dict = {}
 
     # Determine if state is needed for this optimizer.
-    if len(opt_state_dict['state']) == 0:
+    if state_dict_is_empty(opt_state_dict['state']) == True:
         derived_opt_state_dict['__opt_state_needed'] = 'false'
         return derived_opt_state_dict
 

--- a/openfl/plugins/frameworks_adapters/pytorch_adapter.py
+++ b/openfl/plugins/frameworks_adapters/pytorch_adapter.py
@@ -105,10 +105,10 @@ def _get_optimizer_state(optimizer):
 def state_dict_is_empty(state_dict):
     """Determine if the state is needed for the optimizer by recursively checking
     if all the values inside the 'state' dictionary are empty or not.
-    
+
     Args:
         state_dict: The optimizer state dictionary
-        
+
     Returns:
         True or False
     """
@@ -119,7 +119,7 @@ def state_dict_is_empty(state_dict):
             return False
         else:
             return not state_dict
-        
+
 
 def _derive_opt_state_dict(opt_state_dict):
     """Separate optimizer tensors from the tensor dictionary.
@@ -136,7 +136,7 @@ def _derive_opt_state_dict(opt_state_dict):
     derived_opt_state_dict = {}
 
     # Determine if state is needed for this optimizer.
-    if state_dict_is_empty(opt_state_dict['state']) == True:
+    if state_dict_is_empty(opt_state_dict['state']):
         derived_opt_state_dict['__opt_state_needed'] = 'false'
         return derived_opt_state_dict
 


### PR DESCRIPTION
**ISSUE**
Assert subkey == 'step' #490 

**STEPS TO REPRODUCE**
Described in Issue #490 

**FIX**
- plugins/frameworks_adapters/pytorch_adapter.py _derive_opt_state_dict(opt_state_dict): Enhance the check to determine 
if the state is needed for the optimizer by recursively checking if all the subvalues inside the 'state' dictionary are empty or not.

**VERIFICATION SUMMARY**
Verified if the fix is working with the following Optimizers and torch 1.13.1

- SGD optimizer without momentum (issue observed with this configuration)
opt_state_dict {'state': {0: {'momentum_buffer': None}, 1: {'momentum_buffer': None}}, 'param_groups': 
	[{'lr':0.0001, 'momentum': 0, 'dampening': 0, 'weight_decay': 0, 'nesterov': False, 'maximize': False, 'foreach': None,
                    'differentiable': False, 'params': [0, 1]}]}
					
- SGD optimizer with momentum=0.9
opt_state_dict {'state': {0: {'momentum_buffer': tensor([[ 0.0150, -0.0175, -0.0272,  ..., -0.0192,  0.0078, 0.0065],
                            [ 0.0041,  0.0050, -0.0166,  ..., -0.0087, -0.0439,  0.0077],
...
                            [ 0.0059,  0.0121, -0.0023,  ...,  0.0045,  0.0092, -0.0030],
                            [-0.0029, -0.0862, -0.0195,  ..., -0.0185,  0.0076, -0.0322]])}, 1: {'momentum_buffer': tensor([ 2.0872e-03,
                    -1.5912e-02,  6.4681e-05, -2.5837e-03, -2.7872e-02,
...
                             3.6283e-02, -6.8240e-03,  1.1136e-02,  2.3619e-02,  2.9504e-02,
...
                             7.6201e-03,  3.7372e-02,  2.2380e-02, -7.8152e-04, -1.6733e-02,
...
                             3.4353e-02,  5.6722e-03, -2.5022e-02, -3.6064e-02, -1.1359e-02])}}, 'param_groups': [{'lr': 0.0001,
                    'momentum': 0.9, 'dampening': 0, 'weight_decay': 0, 'nesterov': False, 'maximize': False, 'foreach': None,
                    'differentiable': False, 'params': [0, 1]}]}

- Adam optimizer
opt_state_dict {'state': {0: {'step': tensor(1563.), 'exp_avg': tensor([[ 1.5027e-03, -8.8387e-04, -2.0845e-04,
...
                              6.6015e-04, -1.5714e-03]]), 'exp_avg_sq': tensor([[6.0632e-05, 1.4667e-04, 8.2511e-05,  ..., 4.3663e-05,
...
                             1.8517e-04]])}, 1: {'step': tensor(1563.), 'exp_avg': tensor([ 7.6849e-04, -8.6977e-04,  1.7936e-04,
                    -3.8109e-04, -1.6975e-03,
...
                             3.5622e-03,  1.0194e-03, -1.9412e-03, -3.5019e-03, -4.4043e-04]), 'exp_avg_sq': tensor([5.2056e-05,
                    5.9920e-05, 5.8261e-05, 6.1558e-05, 6.1341e-05, 6.6114e-05,
...
                            6.0351e-05, 5.0350e-05, 5.7932e-05, 5.8420e-05, 5.7361e-05, 6.4261e-05,
                            6.2983e-05, 6.6013e-05])}}, 'param_groups': [{'lr': 0.0001, 'betas': (0.9, 0.999), 'eps': 1e-08,
                    'weight_decay': 0, 'amsgrad': False, 'maximize': False, 'foreach': None, 'capturable': False, 'differentiable':
                    False, 'fused': False, 'params': [0, 1]}]}

Closes #490 

Signed-off-by: Ishant Thakare <ishantrog752@gmail.com>