### PR TITLE
Resolve AST parsing error in Jupyter Notebook

### DIFF
--- a/openfl/experimental/utilities/metaflow_utils.py
+++ b/openfl/experimental/utilities/metaflow_utils.py
@@ -201,7 +201,9 @@ class FlowGraph(FlowGraph):
         self._postprocess()
 
     def _create_nodes(self, flow):
-        tree = ast.parse(getsource(flow)).body
+        module = __import__(flow.__module__)
+        tree = ast.parse(getsource(module)).body
+        # tree = ast.parse(getsource(flow)).body
         root = [
             n
             for n in tree

--- a/openfl/experimental/utilities/metaflow_utils.py
+++ b/openfl/experimental/utilities/metaflow_utils.py
@@ -201,8 +201,7 @@ class FlowGraph(FlowGraph):
         self._postprocess()
 
     def _create_nodes(self, flow):
-        module = __import__(flow.__module__)
-        tree = ast.parse(getsource(module)).body
+        tree = ast.parse(getsource(flow)).body
         root = [
             n
             for n in tree
@@ -376,8 +375,6 @@ class MetaflowInterface:
         """
         self.backend = backend
         self.flow_name = flow.__name__
-        self._graph = FlowGraph(flow)
-        self._steps = [getattr(flow, node.name) for node in self._graph]
         if backend == "ray":
             self.counter = Counter.remote()
         else:

--- a/openfl/experimental/utilities/ui.py
+++ b/openfl/experimental/utilities/ui.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2020-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from openfl.experimental.utilities.metaflow_utils import DefaultCard,FlowGraph
+from openfl.experimental.utilities.metaflow_utils import DefaultCard, FlowGraph
 from pathlib import Path
 import os
 import webbrowser
@@ -19,10 +19,8 @@ class InspectFlow:
         self.show_html = show_html
         self.run_id = run_id
         self.flow_name = flow_obj.__class__.__name__
-        
         self._graph = FlowGraph(flow_obj.__class__)
         self._steps = [getattr(flow_obj, node.name) for node in self._graph]
-        
         self.graph_dict, _ = self._graph.output_steps()
         self.show_ui()
 

--- a/openfl/experimental/utilities/ui.py
+++ b/openfl/experimental/utilities/ui.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2020-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from openfl.experimental.utilities.metaflow_utils import DefaultCard
+from openfl.experimental.utilities.metaflow_utils import DefaultCard,FlowGraph
 from pathlib import Path
 import os
 import webbrowser
@@ -19,7 +19,11 @@ class InspectFlow:
         self.show_html = show_html
         self.run_id = run_id
         self.flow_name = flow_obj.__class__.__name__
-        self.graph_dict, _ = flow_obj._metaflow_interface._graph.output_steps()
+        
+        self._graph = FlowGraph(flow_obj.__class__)
+        self._steps = [getattr(flow_obj, node.name) for node in self._graph]
+        
+        self.graph_dict, _ = self._graph.output_steps()
         self.show_ui()
 
     def get_pathspec(self):


### PR DESCRIPTION
**ISSUE** :
- Described in #724 

**STEPS TO REPRODUCE** : 
- Described in #724 
	
**FIX DESCRIPTION / SUMMARY OF CHANGES**: 

1. Refactor Flowgraph related functionality (graph and steps creation) to InspectFlow()
    Rationale: There is no need to create the graph and steps in MetaflowInterface and these steps can be performed only 
    if the user desires to generate FlowGraph

2. Fetch the source code of flow instead of module in FlowGraph()
    Rationale: Only flow source code is required for generation of Graph. 
    Understanding is that this change should also obviate the need to reload the module as it should always fetch the 
    updated source code for the flow
	
**VERIFICATION SUMMARY**:

Verified if the fix is working in Google colab, Jupyter notebook and python file
- Add bug in any of the jupyter notebook cell/google colab/py file and run. 
- Fix the issue and rerun the cell till flflow.run to verify whether its throwing AST error
- For supported flows, verified that graph html is generated properly

Closes #724 
