### PR TITLE
Remove recursion from LocalRuntime during execution of FLFlow steps

### DIFF
--- a/openfl/experimental/interface/fl_spec.py
+++ b/openfl/experimental/interface/fl_spec.py
@@ -65,7 +65,8 @@ class FLSpec:
             try:
                 self.start()
 
-                # execute_task_args will be updated in self.start() after the next function is executed
+                # execute_task_args will be updated in self.start()
+                # after the next function is executed
                 self.runtime.execute_task(
                     self,
                     self.execute_task_args[0],

--- a/openfl/experimental/interface/fl_spec.py
+++ b/openfl/experimental/interface/fl_spec.py
@@ -160,7 +160,7 @@ class FLSpec:
         Next task in the flow to execute
 
         Args:
-            next_func: The next task that will be executed in the flow
+            f: The next task that will be executed in the flow
         """
 
         # Get the name and reference to the calling function
@@ -179,9 +179,6 @@ class FLSpec:
         filter_attributes(self, f, **kwargs)
 
         self._display_transition_logs(f, parent_func)
-
-        # get the function to be executed
-        self.to_exec = getattr(self, f.__name__)
 
         # update parameters for execute_task function
         self.execute_task_args = [f, parent_func, agg_to_collab_ss, kwargs]

--- a/openfl/experimental/placement/placement.py
+++ b/openfl/experimental/placement/placement.py
@@ -27,15 +27,10 @@ class RayExecutor:
 
     def get_remote_clones(self):
         clones = deepcopy(ray.get(self.remote_functions))
-        cln = clones[0]
-        if cln._is_at_transition_point(cln.execute_task_args[0], cln.execute_task_args[1]):
-            del self.remote_functions
-        else:
-            self.remote_functions= []
+        self.remote_functions =[]
         # Remove clones from ray object store
         for ctx in self.remote_contexts:
             ray.cancel(ctx)
-       
         return clones
 
 

--- a/openfl/experimental/placement/placement.py
+++ b/openfl/experimental/placement/placement.py
@@ -27,10 +27,15 @@ class RayExecutor:
 
     def get_remote_clones(self):
         clones = deepcopy(ray.get(self.remote_functions))
-        del self.remote_functions
+        cln = clones[0]
+        if cln._is_at_transition_point(cln.execute_task_args[0], cln.execute_task_args[1]):
+            del self.remote_functions
+        else:
+            self.remote_functions= []
         # Remove clones from ray object store
         for ctx in self.remote_contexts:
             ray.cancel(ctx)
+       
         return clones
 
 

--- a/openfl/experimental/placement/placement.py
+++ b/openfl/experimental/placement/placement.py
@@ -27,7 +27,7 @@ class RayExecutor:
 
     def get_remote_clones(self):
         clones = deepcopy(ray.get(self.remote_functions))
-        self.remote_functions =[]
+        self.remote_functions = []
         # Remove clones from ray object store
         for ctx in self.remote_contexts:
             ray.cancel(ctx)

--- a/openfl/experimental/placement/placement.py
+++ b/openfl/experimental/placement/placement.py
@@ -27,6 +27,8 @@ class RayExecutor:
 
     def get_remote_clones(self):
         clones = deepcopy(ray.get(self.remote_functions))
+        # delete remote_functions to free ray memory and reinitialize
+        del self.remote_functions
         self.remote_functions = []
         # Remove clones from ray object store
         for ctx in self.remote_contexts:

--- a/openfl/experimental/runtime/local_runtime.py
+++ b/openfl/experimental/runtime/local_runtime.py
@@ -9,6 +9,7 @@ import ray
 import gc
 from openfl.experimental.runtime import Runtime
 from typing import TYPE_CHECKING
+
 if TYPE_CHECKING:
     from openfl.experimental.interface import Aggregator, Collaborator, FLSpec
 from openfl.experimental.placement import RayExecutor
@@ -101,9 +102,7 @@ class LocalRuntime(Runtime):
         }
 
     def restore_instance_snapshot(
-            self,
-            ctx: Type[FLSpec],
-            instance_snapshot: List[Type[FLSpec]]
+        self, ctx: Type[FLSpec], instance_snapshot: List[Type[FLSpec]]
     ):
         """Restores attributes from backup (in instance snapshot) to ctx"""
         for backup in instance_snapshot:
@@ -118,40 +117,43 @@ class LocalRuntime(Runtime):
         f: Callable,
         parent_func: Callable,
         instance_snapshot: List[Type[FLSpec]] = [],
-        **kwargs
+        **kwargs,
     ):
         """
-        Performs the execution of a task as defined by the
-        implementation and underlying backend (single_process, ray, etc)
-        on a single node
+        Defines which function to be executed based on name and kwargs
+        Updates the arguments and executes until end is not reached
+
         Args:
             flspec_obj:        Reference to the FLSpec (flow) object. Contains information
-                               about task sequence, flow attributes, that are needed to
-                               execute a future task
+                               about task sequence, flow attributes.
             f:                 The next task to be executed within the flow
             parent_func:       The prior task executed in the flow
             instance_snapshot: A prior FLSpec state that needs to be restored from
                                (i.e. restoring aggregator state after collaborator
                                execution)
         """
+
         while f.__name__ != "end":
             if "foreach" in kwargs:
-                # save collab first info
-                self._collab_start_func,self._collab_start_parent_func,self._collab_start_kwargs,= f, parent_func, kwargs
                 f, parent_func, instance_snapshot, kwargs = self.execute_foreach_task(
-                    flspec_obj, f, parent_func, instance_snapshot, **kwargs )
+                    flspec_obj, f, parent_func, instance_snapshot, **kwargs
+                )
             else:
-                f,parent_func,instance_snapshot,kwargs,= self.execute_no_transition_task(flspec_obj)
+                f, parent_func, instance_snapshot, kwargs = self.execute_agg_task(
+                    flspec_obj
+                )
         else:
             self.execute_end_task(flspec_obj, f)
 
-    def execute_no_transition_task(self, flspec_obj):
+    def execute_agg_task(self, flspec_obj):
+        """Performs execution of aggregator task"""
         flspec_obj.to_exec()
-        # update the params
         return flspec_obj.execute_task_args
 
     def execute_end_task(self, flspec_obj, f):
-        from openfl.experimental.interface import (final_attributes)
+        """Performs execution of end task"""
+        from openfl.experimental.interface import final_attributes
+
         global final_attributes
         flspec_obj.to_exec()
         checkpoint(flspec_obj, f)
@@ -162,25 +164,42 @@ class LocalRuntime(Runtime):
     def execute_foreach_task(
         self, flspec_obj, f, parent_func, instance_snapshot, **kwargs
     ):
-        from openfl.experimental.interface import (
-            FLSpec,
-        )
+        """
+        Performs
+            1. Filter include/exclude
+            2. Remove aggregator private attributes
+            3. Set runtime, collab private attributes , metaflow_interface
+            4. Execution of all collaborator for each task
+            5. Remove collaborator private attributes
+            6. Execute the next function after transition
+        """
+        from openfl.experimental.interface import FLSpec
 
-        agg_func = None
         flspec_obj._foreach_methods.append(f.__name__)
-        selected_collaborators = flspec_obj.__getattribute__(kwargs["foreach"])
+        selected_collaborators = getattr(flspec_obj, kwargs["foreach"])
 
-        self.filter_exclude_include_private_attr(
-            flspec_obj, f, parent_func, selected_collaborators, **kwargs
-        )
-        
+        # filter exclude/include attributes for clone
+        self.filter_exclude_include(flspec_obj, f, selected_collaborators, **kwargs)
+
+        # Remove aggregator private attributes
+        for col in selected_collaborators:
+            clone = FLSpec._clones[col]
+            if aggregator_to_collaborator(f, parent_func):
+                for attr in self._aggregator.private_attributes:
+                    self._aggregator.private_attributes[attr] = getattr(
+                        flspec_obj, attr
+                    )
+                    if hasattr(clone, attr):
+                        delattr(clone, attr)
+
         if self.backend == "ray":
             ray_executor = RayExecutor()
 
+        # set runtime,collab private attributes and metaflowinterface
         for col in selected_collaborators:
             clone = FLSpec._clones[col]
             # Set new LocalRuntime for clone as it is required
-            # and also new runtime object will not contain private attributes of
+            # new runtime object will not contain private attributes of
             # aggregator or other collaborators
             clone.runtime = LocalRuntime(backend="single_process")
 
@@ -194,60 +213,41 @@ class LocalRuntime(Runtime):
             # ensure clone is getting latest _metaflow_interface
             clone._metaflow_interface = flspec_obj._metaflow_interface
 
-            # execute all collab steps for each collab
-            for each_step in flspec_obj._foreach_methods:
+        # For initial step assume there is no trasition from collab_to_agg
+        not_at_transition_point = True
+
+        # loop until there is no transition
+        while not_at_transition_point:
+            # execute to_exec for for each collab
+            for collab in selected_collaborators:
+                clone = FLSpec._clones[collab]
+                # get the function to be executed
                 to_exec = getattr(clone, f.__name__)
+
                 if self.backend == "ray":
                     ray_executor.ray_call_put(clone, to_exec)
                 else:
                     to_exec()
-                    f, parent_func, _, kwargs = clone.execute_task_args
-                    if clone._is_at_transition_point(f, parent_func):
-                        # get collab starting point for next collab to execute
-                        f, parent_func, kwargs = self._collab_start_func,self._collab_start_parent_func,self._collab_start_kwargs
-                        break
 
-        if self.backend == "ray":
-            # get the initial collab put methods
-            clones = ray_executor.get_remote_clones()
-
-            # iterate until all collab steps re finished and get the next set of collab steps
-            while not hasattr( clones[0], 'execute_next'):
-                for clone_obj in clones:
-                    func_name = clone_obj.execute_task_args[0].name
-                    to_exec = getattr(clone_obj,func_name)
-                    ray_executor.ray_call_put(clone_obj, to_exec)
-                
-                # update clone
+            if self.backend == "ray":
+                # Execute the collab steps
                 clones = ray_executor.get_remote_clones()
-            
-            clone = clones[0]
-            FLSpec._clones.update(zip(selected_collaborators, clones))
+                FLSpec._clones.update(zip(selected_collaborators, clones))
+
+            # update the next arguments
+            f, parent_func, _, kwargs = FLSpec._clones[collab].execute_task_args
+
+            # check for transition
+            if FLSpec._clones[collab]._is_at_transition_point(f, parent_func):
+                not_at_transition_point = False
+
+        # remove clones after transition
+        if self.backend == "ray":
             del ray_executor
             del clones
             gc.collect()
-            
-        self.remove_collab_private_attr(selected_collaborators)
 
-        # Restore the flspec_obj state if back-up is taken
-        self.restore_instance_snapshot(flspec_obj, instance_snapshot)
-        del instance_snapshot
-
-        # get next aggregator function to be executed 
-        agg_func = clone.execute_next
-        
-        g = getattr(flspec_obj, agg_func)
-        # remove private collaborator state
-        gc.collect()
-        g([FLSpec._clones[col] for col in selected_collaborators])
-        return flspec_obj.execute_task_args
-
-    def remove_collab_private_attr(self, selected_collaborators):
-        # Removes private attributes of collaborator after transition 
-        from openfl.experimental.interface import (
-            FLSpec,
-        )
-
+        # Removes collaborator private attributes after transition
         for col in selected_collaborators:
             clone = FLSpec._clones[col]
             for attr in self.__collaborators[clone.input].private_attributes:
@@ -257,14 +257,18 @@ class LocalRuntime(Runtime):
                     ] = getattr(clone, attr)
                     delattr(clone, attr)
 
-    def filter_exclude_include_private_attr(
-        self, flspec_obj, f, parent_func, selected_collaborators, **kwargs
-    ):
-        # This function filters exclude/include attributes
-        # Removes private attributes of aggregator
-        from openfl.experimental.interface import (
-            FLSpec,
-        )
+        # Restore the flspec_obj state if back-up is taken
+        self.restore_instance_snapshot(flspec_obj, instance_snapshot)
+        del instance_snapshot
+
+        g = getattr(flspec_obj, f.__name__)
+        gc.collect()
+        g([FLSpec._clones[col] for col in selected_collaborators])
+        return flspec_obj.execute_task_args
+
+    def filter_exclude_include(self, flspec_obj, f, selected_collaborators, **kwargs):
+        """This function filters exclude/include attributes"""
+        from openfl.experimental.interface import FLSpec
 
         for col in selected_collaborators:
             clone = FLSpec._clones[col]
@@ -277,15 +281,6 @@ class LocalRuntime(Runtime):
             for name, attr in artifacts_iter():
                 setattr(clone, name, deepcopy(attr))
             clone._foreach_methods = flspec_obj._foreach_methods
-
-            # remove private aggregator state
-            if aggregator_to_collaborator(f, parent_func):
-                for attr in self._aggregator.private_attributes:
-                    self._aggregator.private_attributes[attr] = getattr(
-                        flspec_obj, attr
-                    )
-                    if hasattr(clone, attr):
-                        delattr(clone, attr)
 
     def __repr__(self):
         return "LocalRuntime"

--- a/openfl/experimental/runtime/local_runtime.py
+++ b/openfl/experimental/runtime/local_runtime.py
@@ -124,7 +124,6 @@ class LocalRuntime(Runtime):
         Performs the execution of a task as defined by the
         implementation and underlying backend (single_process, ray, etc)
         on a single node
-
         Args:
             flspec_obj:        Reference to the FLSpec (flow) object. Contains information
                                about task sequence, flow attributes, that are needed to
@@ -135,98 +134,158 @@ class LocalRuntime(Runtime):
                                (i.e. restoring aggregator state after collaborator
                                execution)
         """
+        while f.__name__ != "end":
+            if "foreach" in kwargs:
+                # save collab first info
+                self._collab_start_func,self._collab_start_parent_func,self._collab_start_kwargs,= f, parent_func, kwargs
+                f, parent_func, instance_snapshot, kwargs = self.execute_foreach_task(
+                    flspec_obj, f, parent_func, instance_snapshot, **kwargs )
+            else:
+                f,parent_func,instance_snapshot,kwargs,= self.execute_no_transition_task(flspec_obj)
+        else:
+            self.execute_end_task(flspec_obj, f)
+
+    def execute_no_transition_task(self, flspec_obj):
+        flspec_obj.to_exec()
+        # update the params
+        return flspec_obj.execute_task_args
+
+    def execute_end_task(self, flspec_obj, f):
+        from openfl.experimental.interface import (final_attributes)
+        global final_attributes
+        flspec_obj.to_exec()
+        checkpoint(flspec_obj, f)
+        artifacts_iter, _ = generate_artifacts(ctx=flspec_obj)
+        final_attributes = artifacts_iter()
+        return
+
+    def execute_foreach_task(
+        self, flspec_obj, f, parent_func, instance_snapshot, **kwargs
+    ):
         from openfl.experimental.interface import (
             FLSpec,
-            final_attributes,
         )
 
-        global final_attributes
+        agg_func = None
+        flspec_obj._foreach_methods.append(f.__name__)
+        selected_collaborators = flspec_obj.__getattribute__(kwargs["foreach"])
 
-        if "foreach" in kwargs:
-            flspec_obj._foreach_methods.append(f.__name__)
-            selected_collaborators = flspec_obj.__getattribute__(
-                kwargs["foreach"]
-            )
+        self.filter_exclude_include_private_attr(
+            flspec_obj, f, parent_func, selected_collaborators, **kwargs
+        )
+        
+        if self.backend == "ray":
+            ray_executor = RayExecutor()
 
-            for col in selected_collaborators:
-                clone = FLSpec._clones[col]
-                if (
-                    "exclude" in kwargs and hasattr(clone, kwargs["exclude"][0])
-                ) or (
-                    "include" in kwargs and hasattr(clone, kwargs["include"][0])
-                ):
-                    filter_attributes(clone, f, **kwargs)
-                artifacts_iter, _ = generate_artifacts(ctx=flspec_obj)
-                for name, attr in artifacts_iter():
-                    setattr(clone, name, deepcopy(attr))
-                clone._foreach_methods = flspec_obj._foreach_methods
+        for col in selected_collaborators:
+            clone = FLSpec._clones[col]
+            # Set new LocalRuntime for clone as it is required
+            # and also new runtime object will not contain private attributes of
+            # aggregator or other collaborators
+            clone.runtime = LocalRuntime(backend="single_process")
 
-            for col in selected_collaborators:
-                clone = FLSpec._clones[col]
-                clone.input = col
-                if aggregator_to_collaborator(f, parent_func):
-                    # remove private aggregator state
-                    for attr in self._aggregator.private_attributes:
-                        self._aggregator.private_attributes[attr] = getattr(
-                            flspec_obj, attr
-                        )
-                        if hasattr(clone, attr):
-                            delattr(clone, attr)
+            # set collab private attributes
+            for name, attr in self.__collaborators[
+                clone.input
+            ].private_attributes.items():
+                setattr(clone, name, attr)
 
-            func = None
-            if self.backend == "ray":
-                ray_executor = RayExecutor()
-            for col in selected_collaborators:
-                clone = FLSpec._clones[col]
-                # Set new LocalRuntime for clone as it is required
-                # for calling execute_task and also new runtime
-                # object will not contain private attributes of
-                # aggregator or other collaborators
-                clone.runtime = LocalRuntime(backend="single_process")
-                for name, attr in self.__collaborators[
-                    clone.input
-                ].private_attributes.items():
-                    setattr(clone, name, attr)
+            # write the clone to the object store
+            # ensure clone is getting latest _metaflow_interface
+            clone._metaflow_interface = flspec_obj._metaflow_interface
+
+            # execute all collab steps for each collab
+            for each_step in flspec_obj._foreach_methods:
                 to_exec = getattr(clone, f.__name__)
-                # write the clone to the object store
-                # ensure clone is getting latest _metaflow_interface
-                clone._metaflow_interface = flspec_obj._metaflow_interface
                 if self.backend == "ray":
                     ray_executor.ray_call_put(clone, to_exec)
                 else:
                     to_exec()
-            if self.backend == "ray":
-                clones = ray_executor.get_remote_clones()
-                FLSpec._clones.update(zip(selected_collaborators, clones))
-                del ray_executor
-                del clones
-                gc.collect()
-            for col in selected_collaborators:
-                clone = FLSpec._clones[col]
-                func = clone.execute_next
-                for attr in self.__collaborators[
-                    clone.input
-                ].private_attributes:
-                    if hasattr(clone, attr):
-                        self.__collaborators[clone.input].private_attributes[
-                            attr
-                        ] = getattr(clone, attr)
-                        delattr(clone, attr)
-            # Restore the flspec_obj state if back-up is taken
-            self.restore_instance_snapshot(flspec_obj, instance_snapshot)
-            del instance_snapshot
+                    f, parent_func, _, kwargs = clone.execute_task_args
+                    if clone._is_at_transition_point(f, parent_func):
+                        # get collab starting point for next collab to execute
+                        f, parent_func, kwargs = self._collab_start_func,self._collab_start_parent_func,self._collab_start_kwargs
+                        break
 
-            g = getattr(flspec_obj, func)
-            # remove private collaborator state
+        if self.backend == "ray":
+            # get the initial collab put methods
+            clones = ray_executor.get_remote_clones()
+
+            # iterate until all collab steps re finished and get the next set of collab steps
+            while not hasattr( clones[0], 'execute_next'):
+                for clone_obj in clones:
+                    func_name = clone_obj.execute_task_args[0].name
+                    to_exec = getattr(clone_obj,func_name)
+                    ray_executor.ray_call_put(clone_obj, to_exec)
+                
+                # update clone
+                clones = ray_executor.get_remote_clones()
+            
+            clone = clones[0]
+            FLSpec._clones.update(zip(selected_collaborators, clones))
+            del ray_executor
+            del clones
             gc.collect()
-            g([FLSpec._clones[col] for col in selected_collaborators])
-        else:
-            to_exec = getattr(flspec_obj, f.__name__)
-            to_exec()
-            if f.__name__ == "end":
-                checkpoint(flspec_obj, f)
-                artifacts_iter, _ = generate_artifacts(ctx=flspec_obj)
-                final_attributes = artifacts_iter()
+            
+        self.remove_collab_private_attr(selected_collaborators)
+
+        # Restore the flspec_obj state if back-up is taken
+        self.restore_instance_snapshot(flspec_obj, instance_snapshot)
+        del instance_snapshot
+
+        # get next aggregator function to be executed 
+        agg_func = clone.execute_next
+        
+        g = getattr(flspec_obj, agg_func)
+        # remove private collaborator state
+        gc.collect()
+        g([FLSpec._clones[col] for col in selected_collaborators])
+        return flspec_obj.execute_task_args
+
+    def remove_collab_private_attr(self, selected_collaborators):
+        # Removes private attributes of collaborator after transition 
+        from openfl.experimental.interface import (
+            FLSpec,
+        )
+
+        for col in selected_collaborators:
+            clone = FLSpec._clones[col]
+            for attr in self.__collaborators[clone.input].private_attributes:
+                if hasattr(clone, attr):
+                    self.__collaborators[clone.input].private_attributes[
+                        attr
+                    ] = getattr(clone, attr)
+                    delattr(clone, attr)
+
+    def filter_exclude_include_private_attr(
+        self, flspec_obj, f, parent_func, selected_collaborators, **kwargs
+    ):
+        # This function filters exclude/include attributes
+        # Removes private attributes of aggregator
+        from openfl.experimental.interface import (
+            FLSpec,
+        )
+
+        for col in selected_collaborators:
+            clone = FLSpec._clones[col]
+            clone.input = col
+            if ("exclude" in kwargs and hasattr(clone, kwargs["exclude"][0])) or (
+                "include" in kwargs and hasattr(clone, kwargs["include"][0])
+            ):
+                filter_attributes(clone, f, **kwargs)
+            artifacts_iter, _ = generate_artifacts(ctx=flspec_obj)
+            for name, attr in artifacts_iter():
+                setattr(clone, name, deepcopy(attr))
+            clone._foreach_methods = flspec_obj._foreach_methods
+
+            # remove private aggregator state
+            if aggregator_to_collaborator(f, parent_func):
+                for attr in self._aggregator.private_attributes:
+                    self._aggregator.private_attributes[attr] = getattr(
+                        flspec_obj, attr
+                    )
+                    if hasattr(clone, attr):
+                        delattr(clone, attr)
 
     def __repr__(self):
         return "LocalRuntime"


### PR DESCRIPTION
**TITLE**: Remove recursion from LocalRuntime during execution of FLFlow steps

**SUMMARY OF CHANGES**:
   Currently FLFlow steps are executed in a nested manner. This PR attemppts to remove recursion from LocalRuntime, 
   following approach is followed: 
   1. call start()
   2. call execute_task
          -  Function is executed till flow ends and arguments to execute the next step are updated by the FLSpec.next() method
          -  This method is now split into 3 parts based on type of steps being executed: 
        -  execute_foreach_task: For executing collaborator steps
        -  execute_agg_task: For executing aggregator steps
        -  execute_end_task: For executing the last step in the flow

**VERIFICATION SUMMARY**:
- Changes verified in Jupyter notebook and python file, with ray and single process backend  

**NEXT STEPS**:
- Further optimization to avoid serialization of clones in every collaborator step