### PR TITLE
Fix Flake8 C419 for Ubuntu CI

### DIFF
--- a/openfl/component/aggregator/aggregator.py
+++ b/openfl/component/aggregator/aggregator.py
@@ -933,9 +933,9 @@ class Aggregator:
         """Check that round is done."""
         tasks_for_round = self.assigner.get_all_tasks_for_round(self.round_number)
 
-        return all([
+        return all(
             self._is_task_done(
-                task_name) for task_name in tasks_for_round])
+                task_name) for task_name in tasks_for_round)
 
     def _log_big_warning(self):
         """Warn user about single collaborator cert mode."""

--- a/openfl/pipelines/pipeline.py
+++ b/openfl/pipelines/pipeline.py
@@ -154,4 +154,4 @@ class TransformationPipeline:
 
     def is_lossy(self):
         """If any of the transformers are lossy, then the pipeline is lossy."""
-        return any([transformer.lossy for transformer in self.transformers])
+        return any(transformer.lossy for transformer in self.transformers)

--- a/openfl/utilities/data_splitters/numpy.py
+++ b/openfl/utilities/data_splitters/numpy.py
@@ -143,7 +143,7 @@ class LogNormalNumPyDataSplitter(NumPyDataSplitter):
                 slice_end = slice_start + self.min_samples_per_class
                 print(f'Assigning {slice_start}:{slice_end} of class {label} to {col} col...')
                 idx[col] += list(label_idx[slice_start:slice_end])
-        if any([len(i) != samples_per_col for i in idx]):
+        if any(len(i) != samples_per_col for i in idx):
             raise SystemError(f'''All collaborators should have {samples_per_col} elements
 but distribution is {[len(i) for i in idx]}''')
 

--- a/openfl/utilities/utils.py
+++ b/openfl/utilities/utils.py
@@ -132,7 +132,7 @@ def split_tensor_dict_by_types(tensor_dict, keep_types):
     keep_dict = {}
     holdout_dict = {}
     for k, v in tensor_dict.items():
-        if any([np.issubdtype(v.dtype, type_) for type_ in keep_types]):
+        if any(np.issubdtype(v.dtype, type_) for type_ in keep_types):
             keep_dict[k] = v
         else:
             holdout_dict[k] = v


### PR DESCRIPTION
C419 Unnecessary list comprehension passed to any()/all() prevents short-circuiting - rewrite as a generator