### PR TITLE
Support for federated evaluation

### DIFF
--- a/openfl-tutorials/Federated_Pytorch_MNIST_Tutorial_Evaluation.ipynb
+++ b/openfl-tutorials/Federated_Pytorch_MNIST_Tutorial_Evaluation.ipynb
@@ -1,0 +1,1135 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Federated PyTorch MNIST Tutorial"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: torch in /usr/local/lib/python3.10/dist-packages (1.13.1)\n",
+      "Requirement already satisfied: torchvision in /usr/local/lib/python3.10/dist-packages (0.14.1)\n",
+      "Requirement already satisfied: typing-extensions in /usr/local/lib/python3.10/dist-packages (from torch) (4.5.0)\n",
+      "Requirement already satisfied: nvidia-cuda-runtime-cu11==11.7.99 in /usr/local/lib/python3.10/dist-packages (from torch) (11.7.99)\n",
+      "Requirement already satisfied: nvidia-cudnn-cu11==8.5.0.96 in /usr/local/lib/python3.10/dist-packages (from torch) (8.5.0.96)\n",
+      "Requirement already satisfied: nvidia-cublas-cu11==11.10.3.66 in /usr/local/lib/python3.10/dist-packages (from torch) (11.10.3.66)\n",
+      "Requirement already satisfied: nvidia-cuda-nvrtc-cu11==11.7.99 in /usr/local/lib/python3.10/dist-packages (from torch) (11.7.99)\n",
+      "Requirement already satisfied: setuptools in /usr/local/lib/python3.10/dist-packages (from nvidia-cublas-cu11==11.10.3.66->torch) (67.7.2)\n",
+      "Requirement already satisfied: wheel in /usr/local/lib/python3.10/dist-packages (from nvidia-cublas-cu11==11.10.3.66->torch) (0.40.0)\n",
+      "Requirement already satisfied: numpy in /usr/local/lib/python3.10/dist-packages (from torchvision) (1.24.3)\n",
+      "Requirement already satisfied: requests in /usr/local/lib/python3.10/dist-packages (from torchvision) (2.29.0)\n",
+      "Requirement already satisfied: pillow!=8.3.*,>=5.3.0 in /usr/local/lib/python3.10/dist-packages (from torchvision) (9.5.0)\n",
+      "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.10/dist-packages (from requests->torchvision) (3.1.0)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.10/dist-packages (from requests->torchvision) (3.4)\n",
+      "Requirement already satisfied: urllib3<1.27,>=1.21.1 in /usr/local/lib/python3.10/dist-packages (from requests->torchvision) (1.26.15)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.10/dist-packages (from requests->torchvision) (2022.12.7)\n",
+      "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv\u001b[0m\u001b[33m\n",
+      "\u001b[0m"
+     ]
+    }
+   ],
+   "source": [
+    "#Install dependencies if not already installed\n",
+    "!pip install torch torchvision"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.10/dist-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "import torch.nn.functional as F\n",
+    "import torch.optim as optim\n",
+    "\n",
+    "import torchvision\n",
+    "import torchvision.transforms as transforms\n",
+    "import openfl.native as fx\n",
+    "from openfl.federated import FederatedModel,FederatedDataSet\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "After importing the required packages, the next step is setting up our openfl workspace. To do this, simply run the `fx.init()` command as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating Workspace Directories\n",
+      "Creating Workspace Templates\n",
+      "Requirement already satisfied: torch==1.13.1 in /usr/local/lib/python3.10/dist-packages (from -r /root/.local/workspace/requirements.txt (line 1)) (1.13.1)\n",
+      "Requirement already satisfied: torchvision==0.14.1 in /usr/local/lib/python3.10/dist-packages (from -r /root/.local/workspace/requirements.txt (line 2)) (0.14.1)\n",
+      "Requirement already satisfied: tensorboard in /usr/local/lib/python3.10/dist-packages (from -r /root/.local/workspace/requirements.txt (line 3)) (2.12.2)\n",
+      "Requirement already satisfied: wheel>=0.38.0 in /usr/local/lib/python3.10/dist-packages (from -r /root/.local/workspace/requirements.txt (line 4)) (0.40.0)\n",
+      "Requirement already satisfied: typing-extensions in /usr/local/lib/python3.10/dist-packages (from torch==1.13.1->-r /root/.local/workspace/requirements.txt (line 1)) (4.5.0)\n",
+      "Requirement already satisfied: nvidia-cuda-runtime-cu11==11.7.99 in /usr/local/lib/python3.10/dist-packages (from torch==1.13.1->-r /root/.local/workspace/requirements.txt (line 1)) (11.7.99)\n",
+      "Requirement already satisfied: nvidia-cudnn-cu11==8.5.0.96 in /usr/local/lib/python3.10/dist-packages (from torch==1.13.1->-r /root/.local/workspace/requirements.txt (line 1)) (8.5.0.96)\n",
+      "Requirement already satisfied: nvidia-cublas-cu11==11.10.3.66 in /usr/local/lib/python3.10/dist-packages (from torch==1.13.1->-r /root/.local/workspace/requirements.txt (line 1)) (11.10.3.66)\n",
+      "Requirement already satisfied: nvidia-cuda-nvrtc-cu11==11.7.99 in /usr/local/lib/python3.10/dist-packages (from torch==1.13.1->-r /root/.local/workspace/requirements.txt (line 1)) (11.7.99)\n",
+      "Requirement already satisfied: numpy in /usr/local/lib/python3.10/dist-packages (from torchvision==0.14.1->-r /root/.local/workspace/requirements.txt (line 2)) (1.24.3)\n",
+      "Requirement already satisfied: requests in /usr/local/lib/python3.10/dist-packages (from torchvision==0.14.1->-r /root/.local/workspace/requirements.txt (line 2)) (2.29.0)\n",
+      "Requirement already satisfied: pillow!=8.3.*,>=5.3.0 in /usr/local/lib/python3.10/dist-packages (from torchvision==0.14.1->-r /root/.local/workspace/requirements.txt (line 2)) (9.5.0)\n",
+      "Requirement already satisfied: setuptools in /usr/local/lib/python3.10/dist-packages (from nvidia-cublas-cu11==11.10.3.66->torch==1.13.1->-r /root/.local/workspace/requirements.txt (line 1)) (67.7.2)\n",
+      "Requirement already satisfied: absl-py>=0.4 in /usr/local/lib/python3.10/dist-packages (from tensorboard->-r /root/.local/workspace/requirements.txt (line 3)) (1.4.0)\n",
+      "Requirement already satisfied: grpcio>=1.48.2 in /usr/local/lib/python3.10/dist-packages (from tensorboard->-r /root/.local/workspace/requirements.txt (line 3)) (1.48.2)\n",
+      "Requirement already satisfied: google-auth<3,>=1.6.3 in /usr/local/lib/python3.10/dist-packages (from tensorboard->-r /root/.local/workspace/requirements.txt (line 3)) (2.17.3)\n",
+      "Requirement already satisfied: google-auth-oauthlib<1.1,>=0.5 in /usr/local/lib/python3.10/dist-packages (from tensorboard->-r /root/.local/workspace/requirements.txt (line 3)) (1.0.0)\n",
+      "Requirement already satisfied: markdown>=2.6.8 in /usr/local/lib/python3.10/dist-packages (from tensorboard->-r /root/.local/workspace/requirements.txt (line 3)) (3.4.3)\n",
+      "Requirement already satisfied: protobuf>=3.19.6 in /usr/local/lib/python3.10/dist-packages (from tensorboard->-r /root/.local/workspace/requirements.txt (line 3)) (3.19.6)\n",
+      "Requirement already satisfied: tensorboard-data-server<0.8.0,>=0.7.0 in /usr/local/lib/python3.10/dist-packages (from tensorboard->-r /root/.local/workspace/requirements.txt (line 3)) (0.7.0)\n",
+      "Requirement already satisfied: tensorboard-plugin-wit>=1.6.0 in /usr/local/lib/python3.10/dist-packages (from tensorboard->-r /root/.local/workspace/requirements.txt (line 3)) (1.8.1)\n",
+      "Requirement already satisfied: werkzeug>=1.0.1 in /usr/local/lib/python3.10/dist-packages (from tensorboard->-r /root/.local/workspace/requirements.txt (line 3)) (2.3.1)\n",
+      "Requirement already satisfied: cachetools<6.0,>=2.0.0 in /usr/local/lib/python3.10/dist-packages (from google-auth<3,>=1.6.3->tensorboard->-r /root/.local/workspace/requirements.txt (line 3)) (5.3.0)\n",
+      "Requirement already satisfied: pyasn1-modules>=0.2.1 in /usr/local/lib/python3.10/dist-packages (from google-auth<3,>=1.6.3->tensorboard->-r /root/.local/workspace/requirements.txt (line 3)) (0.3.0)\n",
+      "Requirement already satisfied: six>=1.9.0 in /usr/local/lib/python3.10/dist-packages (from google-auth<3,>=1.6.3->tensorboard->-r /root/.local/workspace/requirements.txt (line 3)) (1.16.0)\n",
+      "Requirement already satisfied: rsa<5,>=3.1.4 in /usr/local/lib/python3.10/dist-packages (from google-auth<3,>=1.6.3->tensorboard->-r /root/.local/workspace/requirements.txt (line 3)) (4.9)\n",
+      "Requirement already satisfied: requests-oauthlib>=0.7.0 in /usr/local/lib/python3.10/dist-packages (from google-auth-oauthlib<1.1,>=0.5->tensorboard->-r /root/.local/workspace/requirements.txt (line 3)) (1.3.1)\n",
+      "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.10/dist-packages (from requests->torchvision==0.14.1->-r /root/.local/workspace/requirements.txt (line 2)) (3.1.0)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.10/dist-packages (from requests->torchvision==0.14.1->-r /root/.local/workspace/requirements.txt (line 2)) (3.4)\n",
+      "Requirement already satisfied: urllib3<1.27,>=1.21.1 in /usr/local/lib/python3.10/dist-packages (from requests->torchvision==0.14.1->-r /root/.local/workspace/requirements.txt (line 2)) (1.26.15)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.10/dist-packages (from requests->torchvision==0.14.1->-r /root/.local/workspace/requirements.txt (line 2)) (2022.12.7)\n",
+      "Requirement already satisfied: MarkupSafe>=2.1.1 in /usr/local/lib/python3.10/dist-packages (from werkzeug>=1.0.1->tensorboard->-r /root/.local/workspace/requirements.txt (line 3)) (2.1.2)\n",
+      "Requirement already satisfied: pyasn1<0.6.0,>=0.4.6 in /usr/local/lib/python3.10/dist-packages (from pyasn1-modules>=0.2.1->google-auth<3,>=1.6.3->tensorboard->-r /root/.local/workspace/requirements.txt (line 3)) (0.5.0)\n",
+      "Requirement already satisfied: oauthlib>=3.0.0 in /usr/local/lib/python3.10/dist-packages (from requests-oauthlib>=0.7.0->google-auth-oauthlib<1.1,>=0.5->tensorboard->-r /root/.local/workspace/requirements.txt (line 3)) (3.2.2)\n",
+      "Successfully installed packages from /root/.local/workspace/requirements.txt.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "New workspace directory structure:\n",
+      "workspace\n",
+      "├── data\n",
+      "│   └── MNIST\n",
+      "│       └── raw\n",
+      "├── src\n",
+      "│   ├── mnist_utils.py\n",
+      "│   ├── __pycache__\n",
+      "│   │   ├── mnist_utils.cpython-310.pyc\n",
+      "│   │   └── __init__.cpython-310.pyc\n",
+      "│   ├── ptmnist_inmemory.py\n",
+      "│   ├── pt_cnn.py\n",
+      "│   └── __init__.py\n",
+      "├── cert\n",
+      "├── save\n",
+      "│   ├── torch_cnn_mnist_last.pbuf\n",
+      "│   ├── torch_cnn_mnist_best.pbuf\n",
+      "│   └── torch_cnn_mnist_init.pbuf\n",
+      "├── final_pytorch_model\n",
+      "├── agg_to_col_two_signed_cert.zip\n",
+      "├── spam_metric.log\n",
+      "├── .workspace\n",
+      "├── plan\n",
+      "│   ├── defaults\n",
+      "│   ├── cols.yaml\n",
+      "│   ├── plan.yaml\n",
+      "│   ├── plan_evaluation.yaml\n",
+      "│   └── data.yaml\n",
+      "├── agg_to_col_one_signed_cert.zip\n",
+      "├── requirements.txt\n",
+      "└── logs\n",
+      "    └── cnn_mnist\n",
+      "        ├── events.out.tfevents.1682679019.241369ca6574.25569.1\n",
+      "        └── events.out.tfevents.1682679019.241369ca6574.25569.0\n",
+      "\n",
+      "10 directories, 22 files\n",
+      "Setting Up Certificate Authority...\n",
+      "\n",
+      "1.  Create Root CA\n",
+      "1.1 Create Directories\n",
+      "1.2 Create Database\n",
+      "1.3 Create CA Request and Certificate\n",
+      "2.  Create Signing Certificate\n",
+      "2.1 Create Directories\n",
+      "2.2 Create Database\n",
+      "2.3 Create Signing Certificate CSR\n",
+      "2.4 Sign Signing Certificate CSR\n",
+      "3   Create Certificate Chain\n",
+      "\n",
+      "Done.\n",
+      "Creating AGGREGATOR certificate key pair with following settings: CN=\u001b[31m241369ca6574\u001b[0m, SAN=\u001b[31mDNS:241369ca6574\u001b[0m\n",
+      "  Writing AGGREGATOR certificate key pair to: \u001b[32m/root/openfl-my/openfl/openfl-tutorials/cert/server\u001b[0m\n",
+      "The CSR Hash for file \u001b[32mserver/agg_241369ca6574.csr\u001b[0m = \u001b[31m9045bdcabec4b28850e109637cb263924ab34d10d6196b0db3f9d8e60aa105cba1e0ee729a6211b0a4d11db803c3b58b\u001b[0m\n",
+      " Signing AGGREGATOR certificate\n",
+      "Creating COLLABORATOR certificate key pair with following settings: CN=\u001b[31mone\u001b[0m, SAN=\u001b[31mDNS:one\u001b[0m\n",
+      "  Moving COLLABORATOR certificate to: \u001b[32m/root/openfl-my/openfl/openfl-tutorials/cert/col_one\u001b[0m\n",
+      "The CSR Hash for file \u001b[32mcol_one.csr\u001b[0m = \u001b[31mbcd0d8312ecac71c879ca9018e3cd3fa57357906be3b1f16885f0e3476ccf1423942695e267632aaee731f573f571988\u001b[0m\n",
+      " Signing COLLABORATOR certificate\n",
+      "\n",
+      "Registering \u001b[32mone\u001b[0m in \u001b[32m/root/.local/workspace/plan/cols.yaml\u001b[0m\n",
+      "Creating COLLABORATOR certificate key pair with following settings: CN=\u001b[31mtwo\u001b[0m, SAN=\u001b[31mDNS:two\u001b[0m\n",
+      "  Moving COLLABORATOR certificate to: \u001b[32m/root/openfl-my/openfl/openfl-tutorials/cert/col_two\u001b[0m\n",
+      "The CSR Hash for file \u001b[32mcol_two.csr\u001b[0m = \u001b[31mcc0f58d169dd8d3487843e555a4d9a6e365d07739b69515932311dde9d023835a4516e663f05e67d3c0ccdfa4ec7a786\u001b[0m\n",
+      " Signing COLLABORATOR certificate\n",
+      "\n",
+      "Registering \u001b[32mtwo\u001b[0m in \u001b[32m/root/.local/workspace/plan/cols.yaml\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Setup default workspace, logging, etc.\n",
+    "fx.init('torch_cnn_mnist', log_level='METRIC', log_file='./spam_metric.log')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we are ready to define our dataset and model to perform federated learning on. The dataset should be composed of a numpy arrayWe start with a simple fully connected model that is trained on the MNIST dataset. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.10/dist-packages/torchvision/datasets/mnist.py:75: UserWarning: train_data has been renamed data\n",
+      "  warnings.warn(\"train_data has been renamed data\")\n",
+      "/usr/local/lib/python3.10/dist-packages/torchvision/datasets/mnist.py:65: UserWarning: train_labels has been renamed targets\n",
+      "  warnings.warn(\"train_labels has been renamed targets\")\n",
+      "/usr/local/lib/python3.10/dist-packages/torchvision/datasets/mnist.py:80: UserWarning: test_data has been renamed data\n",
+      "  warnings.warn(\"test_data has been renamed data\")\n",
+      "/usr/local/lib/python3.10/dist-packages/torchvision/datasets/mnist.py:70: UserWarning: test_labels has been renamed targets\n",
+      "  warnings.warn(\"test_labels has been renamed targets\")\n"
+     ]
+    }
+   ],
+   "source": [
+    "def one_hot(labels, classes):\n",
+    "    return np.eye(classes)[labels]\n",
+    "\n",
+    "transform = transforms.Compose(\n",
+    "    [transforms.ToTensor(),\n",
+    "     transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])\n",
+    "\n",
+    "trainset = torchvision.datasets.MNIST(root='./data', train=True,\n",
+    "                                        download=True, transform=transform)\n",
+    "\n",
+    "train_images,train_labels = trainset.train_data, np.array(trainset.train_labels)\n",
+    "train_images = torch.from_numpy(np.expand_dims(train_images, axis=1)).float()\n",
+    "\n",
+    "validset = torchvision.datasets.MNIST(root='./data', train=False,\n",
+    "                                       download=True, transform=transform)\n",
+    "\n",
+    "valid_images,valid_labels = validset.test_data, np.array(validset.test_labels)\n",
+    "valid_images = torch.from_numpy(np.expand_dims(valid_images, axis=1)).float()\n",
+    "valid_labels = one_hot(valid_labels,10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "feature_shape = train_images.shape[1]\n",
+    "classes       = 10\n",
+    "\n",
+    "fl_data = FederatedDataSet(train_images,train_labels,valid_images,valid_labels,batch_size=32,num_classes=classes)\n",
+    "\n",
+    "class Net(nn.Module):\n",
+    "    def __init__(self):\n",
+    "        super(Net, self).__init__()\n",
+    "        self.conv1 = nn.Conv2d(1, 16, 3)\n",
+    "        self.pool = nn.MaxPool2d(2, 2)\n",
+    "        self.conv2 = nn.Conv2d(16, 32, 3)\n",
+    "        self.fc1 = nn.Linear(32 * 5 * 5, 32)\n",
+    "        self.fc2 = nn.Linear(32, 84)\n",
+    "        self.fc3 = nn.Linear(84, 10)\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        x = self.pool(F.relu(self.conv1(x)))\n",
+    "        x = self.pool(F.relu(self.conv2(x)))\n",
+    "        x = x.view(x.size(0),-1)\n",
+    "        x = F.relu(self.fc1(x))\n",
+    "        x = F.relu(self.fc2(x))\n",
+    "        x = self.fc3(x)\n",
+    "        return F.log_softmax(x, dim=1)\n",
+    "    \n",
+    "optimizer = lambda x: optim.Adam(x, lr=1e-4)\n",
+    "\n",
+    "def cross_entropy(output, target):\n",
+    "    \"\"\"Binary cross-entropy metric\n",
+    "    \"\"\"\n",
+    "    return F.cross_entropy(input=output,target=target)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we can define metric logging function. It should has the following signature described below. You can use it to write metrics to tensorboard or some another specific logging."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from torch.utils.tensorboard import SummaryWriter\n",
+    "\n",
+    "writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)\n",
+    "\n",
+    "\n",
+    "def write_metric(node_name, task_name, metric_name, metric, round_number):\n",
+    "    writer.add_scalar(\"{}/{}/{}\".format(node_name, task_name, metric_name),\n",
+    "                      metric, round_number)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[10:53:41] </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING </span> tried to remove tensor: __opt_state_needed not present in the tensor dict                                                       <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/utilities/utils.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">utils.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/utilities/utils.py#172\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">172</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m[10:53:41]\u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING \u001b[0m tried to remove tensor: __opt_state_needed not present in the tensor dict                                                       \u001b]8;id=665583;file:///usr/local/lib/python3.10/dist-packages/openfl/utilities/utils.py\u001b\\\u001b[2mutils.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=126564;file:///usr/local/lib/python3.10/dist-packages/openfl/utilities/utils.py#172\u001b\\\u001b[2m172\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "\n",
+    "#Create a federated model using the pytorch class, lambda optimizer function, and loss function\n",
+    "fl_model = FederatedModel(build_model=Net,optimizer=optimizer,loss_fn=cross_entropy,data_loader=fl_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `FederatedModel` object is a wrapper around your Keras, Tensorflow or PyTorch model that makes it compatible with openfl. It provides built in federated training and validation functions that we will see used below. Using it's `setup` function, collaborator models and datasets can be automatically defined for the experiment. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING </span> tried to remove tensor: __opt_state_needed not present in the tensor dict                                                       <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/utilities/utils.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">utils.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/utilities/utils.py#172\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">172</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING \u001b[0m tried to remove tensor: __opt_state_needed not present in the tensor dict                                                       \u001b]8;id=130935;file:///usr/local/lib/python3.10/dist-packages/openfl/utilities/utils.py\u001b\\\u001b[2mutils.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=517497;file:///usr/local/lib/python3.10/dist-packages/openfl/utilities/utils.py#172\u001b\\\u001b[2m172\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING </span> tried to remove tensor: __opt_state_needed not present in the tensor dict                                                       <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/utilities/utils.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">utils.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/utilities/utils.py#172\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">172</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING \u001b[0m tried to remove tensor: __opt_state_needed not present in the tensor dict                                                       \u001b]8;id=148058;file:///usr/local/lib/python3.10/dist-packages/openfl/utilities/utils.py\u001b\\\u001b[2mutils.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=787042;file:///usr/local/lib/python3.10/dist-packages/openfl/utilities/utils.py#172\u001b\\\u001b[2m172\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING </span> tried to remove tensor: __opt_state_needed not present in the tensor dict                                                       <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/utilities/utils.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">utils.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/utilities/utils.py#172\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">172</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING \u001b[0m tried to remove tensor: __opt_state_needed not present in the tensor dict                                                       \u001b]8;id=774914;file:///usr/local/lib/python3.10/dist-packages/openfl/utilities/utils.py\u001b\\\u001b[2mutils.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=500717;file:///usr/local/lib/python3.10/dist-packages/openfl/utilities/utils.py#172\u001b\\\u001b[2m172\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "collaborator_models = fl_model.setup(num_collaborators=3)\n",
+    "train_test_collaborators = {'one':collaborator_models[0],'two':collaborator_models[1]}#, 'three':collaborator_models[2]}\n",
+    "validate_collaborators = {'three': collaborator_models[2]}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original training data size: 60000\n",
+      "Original validation data size: 10000\n",
+      "\n",
+      "Collaborator one's training data size: 20000\n",
+      "Collaborator one's validation data size: 3334\n",
+      "\n",
+      "Collaborator two's training data size: 20000\n",
+      "Collaborator two's validation data size: 3333\n",
+      "\n",
+      "Collaborator three's training data size: 20000\n",
+      "Collaborator three's validation data size: 3333\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Original MNIST dataset\n",
+    "print(f'Original training data size: {len(train_images)}')\n",
+    "print(f'Original validation data size: {len(valid_images)}\\n')\n",
+    "\n",
+    "#Collaborator one's data\n",
+    "print(f'Collaborator one\\'s training data size: {len(collaborator_models[0].data_loader.X_train)}')\n",
+    "print(f'Collaborator one\\'s validation data size: {len(collaborator_models[0].data_loader.X_valid)}\\n')\n",
+    "\n",
+    "#Collaborator two's data\n",
+    "print(f'Collaborator two\\'s training data size: {len(collaborator_models[1].data_loader.X_train)}')\n",
+    "print(f'Collaborator two\\'s validation data size: {len(collaborator_models[1].data_loader.X_valid)}\\n')\n",
+    "\n",
+    "# Collaborator three's data\n",
+    "print(f'Collaborator three\\'s training data size: {len(collaborator_models[2].data_loader.X_train)}')\n",
+    "print(f'Collaborator three\\'s validation data size: {len(collaborator_models[2].data_loader.X_valid)}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can see the current plan values by running the `fx.get_plan()` function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "    \"aggregator.settings.best_state_path\": \"save/torch_cnn_mnist_best.pbuf\",\n",
+      "    \"aggregator.settings.db_store_rounds\": 2,\n",
+      "    \"aggregator.settings.init_state_path\": \"save/torch_cnn_mnist_init.pbuf\",\n",
+      "    \"aggregator.settings.last_state_path\": \"save/torch_cnn_mnist_last.pbuf\",\n",
+      "    \"aggregator.settings.log_metric_callback.template\": \"src.mnist_utils.write_metric\",\n",
+      "    \"aggregator.settings.rounds_to_train\": 10,\n",
+      "    \"aggregator.settings.write_logs\": true,\n",
+      "    \"aggregator.template\": \"openfl.component.Aggregator\",\n",
+      "    \"assigner.settings.task_groups.0.name\": \"train_and_validate\",\n",
+      "    \"assigner.settings.task_groups.0.percentage\": 1.0,\n",
+      "    \"assigner.settings.task_groups.0.tasks.0\": \"aggregated_model_validation\",\n",
+      "    \"assigner.settings.task_groups.0.tasks.1\": \"train\",\n",
+      "    \"assigner.settings.task_groups.0.tasks.2\": \"locally_tuned_model_validation\",\n",
+      "    \"assigner.template\": \"openfl.component.RandomGroupedAssigner\",\n",
+      "    \"collaborator.settings.db_store_rounds\": 1,\n",
+      "    \"collaborator.settings.delta_updates\": false,\n",
+      "    \"collaborator.settings.opt_treatment\": \"RESET\",\n",
+      "    \"collaborator.template\": \"openfl.component.Collaborator\",\n",
+      "    \"compression_pipeline.settings\": {},\n",
+      "    \"compression_pipeline.template\": \"openfl.pipelines.NoCompressionPipeline\",\n",
+      "    \"data_loader.settings.batch_size\": 256,\n",
+      "    \"data_loader.settings.collaborator_count\": 2,\n",
+      "    \"data_loader.settings.data_group_name\": \"mnist\",\n",
+      "    \"data_loader.template\": \"src.ptmnist_inmemory.PyTorchMNISTInMemory\",\n",
+      "    \"network.settings.agg_addr\": \"241369ca6574\",\n",
+      "    \"network.settings.agg_port\": 52753,\n",
+      "    \"network.settings.cert_folder\": \"cert\",\n",
+      "    \"network.settings.client_reconnect_interval\": 5,\n",
+      "    \"network.settings.disable_client_auth\": false,\n",
+      "    \"network.settings.hash_salt\": \"auto\",\n",
+      "    \"network.settings.tls\": true,\n",
+      "    \"network.template\": \"openfl.federation.Network\",\n",
+      "    \"task_runner.settings\": {},\n",
+      "    \"task_runner.template\": \"src.pt_cnn.PyTorchCNN\",\n",
+      "    \"tasks.aggregated_model_validation.function\": \"validate\",\n",
+      "    \"tasks.aggregated_model_validation.kwargs.apply\": \"global\",\n",
+      "    \"tasks.aggregated_model_validation.kwargs.metrics.0\": \"acc\",\n",
+      "    \"tasks.locally_tuned_model_validation.function\": \"validate\",\n",
+      "    \"tasks.locally_tuned_model_validation.kwargs.apply\": \"local\",\n",
+      "    \"tasks.locally_tuned_model_validation.kwargs.metrics.0\": \"acc\",\n",
+      "    \"tasks.settings\": {},\n",
+      "    \"tasks.train.function\": \"train_batches\",\n",
+      "    \"tasks.train.kwargs.epochs\": 1,\n",
+      "    \"tasks.train.kwargs.metrics.0\": \"loss\"\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    " #Get the current values of the plan. Each of these can be overridden\n",
+    "print(fx.get_plan())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we are ready to run our experiment. If we want to pass in custom plan settings, we can easily do that with the `override_config` parameter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.10/dist-packages/openfl/federated/task/runner_pt.py:284: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at ../torch/csrc/utils/tensor_numpy.cpp:199.)\n",
+      "  new_state[k] = pt.from_numpy(tensor_dict.pop(k)).to(device)\n",
+      "/usr/local/lib/python3.10/dist-packages/openfl/federated/task/runner_pt.py:107: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).\n",
+      "  data, target = pt.tensor(data).to(self.device), pt.tensor(\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[10:53:42] </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>, collaborator one is sending metric for task aggregated_model_validation: acc   <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.118476</span>                         <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">collaborator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py#415\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">415</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m[10:53:42]\u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m0\u001b[0m, collaborator one is sending metric for task aggregated_model_validation: acc   \u001b[1;36m0.118476\u001b[0m                         \u001b]8;id=689693;file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py\u001b\\\u001b[2mcollaborator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=76793;file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py#415\u001b\\\u001b[2m415\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>, collaborator validate_agg aggregated_model_validation result acc:      <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.118476</span>                                   <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">aggregator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#559\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">559</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m0\u001b[0m, collaborator validate_agg aggregated_model_validation result acc:      \u001b[1;36m0.118476\u001b[0m                                   \u001b]8;id=572022;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\u001b\\\u001b[2maggregator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=54946;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#559\u001b\\\u001b[2m559\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.10/dist-packages/openfl/federated/task/runner_pt.py:458: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).\n",
+      "  data, target = pt.tensor(data).to(self.device), pt.tensor(\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[10:53:43] </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>, collaborator one is sending metric for task train: cross_entropy       <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.634349</span>                                 <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">collaborator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py#415\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">415</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m[10:53:43]\u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m0\u001b[0m, collaborator one is sending metric for task train: cross_entropy       \u001b[1;36m0.634349\u001b[0m                                 \u001b]8;id=851752;file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py\u001b\\\u001b[2mcollaborator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=415463;file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py#415\u001b\\\u001b[2m415\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>, collaborator one train result cross_entropy:   <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.634349</span>                                                           <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">aggregator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#559\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">559</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m0\u001b[0m, collaborator one train result cross_entropy:   \u001b[1;36m0.634349\u001b[0m                                                           \u001b]8;id=591933;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\u001b\\\u001b[2maggregator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=250680;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#559\u001b\\\u001b[2m559\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>, collaborator one is sending metric for task locally_tuned_model_validation: acc        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.943611</span>                 <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">collaborator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py#415\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">415</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m0\u001b[0m, collaborator one is sending metric for task locally_tuned_model_validation: acc        \u001b[1;36m0.943611\u001b[0m                 \u001b]8;id=868164;file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py\u001b\\\u001b[2mcollaborator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=970919;file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py#415\u001b\\\u001b[2m415\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>, collaborator validate_local locally_tuned_model_validation result acc: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.943611</span>                                   <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">aggregator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#559\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">559</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m0\u001b[0m, collaborator validate_local locally_tuned_model_validation result acc: \u001b[1;36m0.943611\u001b[0m                                   \u001b]8;id=273373;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\u001b\\\u001b[2maggregator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=262539;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#559\u001b\\\u001b[2m559\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.10/dist-packages/openfl/federated/task/runner_pt.py:107: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).\n",
+      "  data, target = pt.tensor(data).to(self.device), pt.tensor(\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>, collaborator two is sending metric for task aggregated_model_validation: acc   <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.134113</span>                         <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">collaborator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py#415\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">415</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m0\u001b[0m, collaborator two is sending metric for task aggregated_model_validation: acc   \u001b[1;36m0.134113\u001b[0m                         \u001b]8;id=647635;file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py\u001b\\\u001b[2mcollaborator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=846229;file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py#415\u001b\\\u001b[2m415\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>, collaborator validate_agg aggregated_model_validation result acc:      <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.134113</span>                                   <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">aggregator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#559\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">559</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m0\u001b[0m, collaborator validate_agg aggregated_model_validation result acc:      \u001b[1;36m0.134113\u001b[0m                                   \u001b]8;id=247902;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\u001b\\\u001b[2maggregator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=616853;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#559\u001b\\\u001b[2m559\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.10/dist-packages/openfl/federated/task/runner_pt.py:458: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).\n",
+      "  data, target = pt.tensor(data).to(self.device), pt.tensor(\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[10:53:44] </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>, collaborator two is sending metric for task train: cross_entropy       <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.638118</span>                                 <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">collaborator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py#415\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">415</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m[10:53:44]\u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m0\u001b[0m, collaborator two is sending metric for task train: cross_entropy       \u001b[1;36m0.638118\u001b[0m                                 \u001b]8;id=906134;file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py\u001b\\\u001b[2mcollaborator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=299215;file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py#415\u001b\\\u001b[2m415\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>, collaborator two train result cross_entropy:   <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.638118</span>                                                           <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">aggregator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#559\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">559</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m0\u001b[0m, collaborator two train result cross_entropy:   \u001b[1;36m0.638118\u001b[0m                                                           \u001b]8;id=672490;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\u001b\\\u001b[2maggregator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=532673;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#559\u001b\\\u001b[2m559\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>, collaborator two is sending metric for task locally_tuned_model_validation: acc        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.930993</span>                 <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">collaborator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py#415\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">415</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m0\u001b[0m, collaborator two is sending metric for task locally_tuned_model_validation: acc        \u001b[1;36m0.930993\u001b[0m                 \u001b]8;id=631936;file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py\u001b\\\u001b[2mcollaborator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=549332;file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py#415\u001b\\\u001b[2m415\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>, collaborator validate_local locally_tuned_model_validation result acc: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.930993</span>                                   <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">aggregator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#559\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">559</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m0\u001b[0m, collaborator validate_local locally_tuned_model_validation result acc: \u001b[1;36m0.930993\u001b[0m                                   \u001b]8;id=521804;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\u001b\\\u001b[2maggregator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=114360;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#559\u001b\\\u001b[2m559\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>, aggregator: train <span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">openfl.interface.aggregation_functions.weighted_average.WeightedAverage</span><span style=\"color: #000000; text-decoration-color: #000000\"> object at </span>             <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">aggregator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#842\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">842</span></a>\n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>         <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0x7f3c337ff760</span><span style=\"font-weight: bold\">&gt;</span> cross_entropy:    <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.636233</span>                                                                                 <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                 </span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m0\u001b[0m, aggregator: train \u001b[1m<\u001b[0m\u001b[1;95mopenfl.interface.aggregation_functions.weighted_average.WeightedAverage\u001b[0m\u001b[39m object at \u001b[0m             \u001b]8;id=251518;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\u001b\\\u001b[2maggregator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=424217;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#842\u001b\\\u001b[2m842\u001b[0m\u001b]8;;\u001b\\\n",
+       "\u001b[2;36m           \u001b[0m         \u001b[1;36m0x7f3c337ff760\u001b[0m\u001b[1m>\u001b[0m cross_entropy:    \u001b[1;36m0.636233\u001b[0m                                                                                 \u001b[2m                 \u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>, aggregator: locally_tuned_model_validation                                                                        <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">aggregator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#842\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">842</span></a>\n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>         <span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">openfl.interface.aggregation_functions.weighted_average.WeightedAverage</span><span style=\"color: #000000; text-decoration-color: #000000\"> object at </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0x7f3c337ff760</span><span style=\"font-weight: bold\">&gt;</span> acc:     <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.937303</span>       <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                 </span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m0\u001b[0m, aggregator: locally_tuned_model_validation                                                                        \u001b]8;id=899635;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\u001b\\\u001b[2maggregator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=886594;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#842\u001b\\\u001b[2m842\u001b[0m\u001b]8;;\u001b\\\n",
+       "\u001b[2;36m           \u001b[0m         \u001b[1m<\u001b[0m\u001b[1;95mopenfl.interface.aggregation_functions.weighted_average.WeightedAverage\u001b[0m\u001b[39m object at \u001b[0m\u001b[1;36m0x7f3c337ff760\u001b[0m\u001b[1m>\u001b[0m acc:     \u001b[1;36m0.937303\u001b[0m       \u001b[2m                 \u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>, aggregator: aggregated_model_validation <span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">openfl.interface.aggregation_functions.weighted_average.WeightedAverage</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span> <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">aggregator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#842\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">842</span></a>\n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>         <span style=\"color: #000000; text-decoration-color: #000000\">object at </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0x7f3c337ff760</span><span style=\"font-weight: bold\">&gt;</span> acc:        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.126294</span>                                                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                 </span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m0\u001b[0m, aggregator: aggregated_model_validation \u001b[1m<\u001b[0m\u001b[1;95mopenfl.interface.aggregation_functions.weighted_average.WeightedAverage\u001b[0m\u001b[39m \u001b[0m \u001b]8;id=601662;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\u001b\\\u001b[2maggregator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=35328;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#842\u001b\\\u001b[2m842\u001b[0m\u001b]8;;\u001b\\\n",
+       "\u001b[2;36m           \u001b[0m         \u001b[39mobject at \u001b[0m\u001b[1;36m0x7f3c337ff760\u001b[0m\u001b[1m>\u001b[0m acc:        \u001b[1;36m0.126294\u001b[0m                                                                             \u001b[2m                 \u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>: saved the best model with score <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.126294</span>                                                                          <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">aggregator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#858\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">858</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m0\u001b[0m: saved the best model with score \u001b[1;36m0.126294\u001b[0m                                                                          \u001b]8;id=849588;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\u001b\\\u001b[2maggregator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=181199;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#858\u001b\\\u001b[2m858\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.10/dist-packages/openfl/federated/task/runner_pt.py:107: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).\n",
+      "  data, target = pt.tensor(data).to(self.device), pt.tensor(\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[10:53:45] </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>, collaborator one is sending metric for task aggregated_model_validation: acc   <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.936113</span>                         <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">collaborator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py#415\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">415</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m[10:53:45]\u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m1\u001b[0m, collaborator one is sending metric for task aggregated_model_validation: acc   \u001b[1;36m0.936113\u001b[0m                         \u001b]8;id=797684;file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py\u001b\\\u001b[2mcollaborator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=968970;file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py#415\u001b\\\u001b[2m415\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>, collaborator validate_agg aggregated_model_validation result acc:      <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.936113</span>                                   <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">aggregator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#559\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">559</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m1\u001b[0m, collaborator validate_agg aggregated_model_validation result acc:      \u001b[1;36m0.936113\u001b[0m                                   \u001b]8;id=799479;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\u001b\\\u001b[2maggregator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=173374;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#559\u001b\\\u001b[2m559\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.10/dist-packages/openfl/federated/task/runner_pt.py:458: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).\n",
+      "  data, target = pt.tensor(data).to(self.device), pt.tensor(\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[10:53:46] </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>, collaborator one is sending metric for task train: cross_entropy       <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.178802</span>                                 <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">collaborator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py#415\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">415</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m[10:53:46]\u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m1\u001b[0m, collaborator one is sending metric for task train: cross_entropy       \u001b[1;36m0.178802\u001b[0m                                 \u001b]8;id=199370;file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py\u001b\\\u001b[2mcollaborator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=466690;file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py#415\u001b\\\u001b[2m415\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>, collaborator one train result cross_entropy:   <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.178802</span>                                                           <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">aggregator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#559\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">559</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m1\u001b[0m, collaborator one train result cross_entropy:   \u001b[1;36m0.178802\u001b[0m                                                           \u001b]8;id=657674;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\u001b\\\u001b[2maggregator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=159927;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#559\u001b\\\u001b[2m559\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>, collaborator one is sending metric for task locally_tuned_model_validation: acc        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.968206</span>                 <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">collaborator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py#415\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">415</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m1\u001b[0m, collaborator one is sending metric for task locally_tuned_model_validation: acc        \u001b[1;36m0.968206\u001b[0m                 \u001b]8;id=480712;file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py\u001b\\\u001b[2mcollaborator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=599096;file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py#415\u001b\\\u001b[2m415\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>, collaborator validate_local locally_tuned_model_validation result acc: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.968206</span>                                   <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">aggregator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#559\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">559</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m1\u001b[0m, collaborator validate_local locally_tuned_model_validation result acc: \u001b[1;36m0.968206\u001b[0m                                   \u001b]8;id=845554;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\u001b\\\u001b[2maggregator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=759428;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#559\u001b\\\u001b[2m559\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>, collaborator two is sending metric for task aggregated_model_validation: acc   <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.936094</span>                         <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">collaborator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py#415\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">415</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m1\u001b[0m, collaborator two is sending metric for task aggregated_model_validation: acc   \u001b[1;36m0.936094\u001b[0m                         \u001b]8;id=152133;file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py\u001b\\\u001b[2mcollaborator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=730256;file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py#415\u001b\\\u001b[2m415\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>, collaborator validate_agg aggregated_model_validation result acc:      <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.936094</span>                                   <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">aggregator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#559\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">559</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m1\u001b[0m, collaborator validate_agg aggregated_model_validation result acc:      \u001b[1;36m0.936094\u001b[0m                                   \u001b]8;id=995600;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\u001b\\\u001b[2maggregator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=598841;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#559\u001b\\\u001b[2m559\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[10:53:47] </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>, collaborator two is sending metric for task train: cross_entropy       <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.178073</span>                                 <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">collaborator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py#415\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">415</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m[10:53:47]\u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m1\u001b[0m, collaborator two is sending metric for task train: cross_entropy       \u001b[1;36m0.178073\u001b[0m                                 \u001b]8;id=506291;file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py\u001b\\\u001b[2mcollaborator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=855759;file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py#415\u001b\\\u001b[2m415\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>, collaborator two train result cross_entropy:   <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.178073</span>                                                           <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">aggregator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#559\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">559</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m1\u001b[0m, collaborator two train result cross_entropy:   \u001b[1;36m0.178073\u001b[0m                                                           \u001b]8;id=236332;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\u001b\\\u001b[2maggregator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=704022;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#559\u001b\\\u001b[2m559\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>, collaborator two is sending metric for task locally_tuned_model_validation: acc        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.952895</span>                 <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">collaborator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py#415\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">415</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m1\u001b[0m, collaborator two is sending metric for task locally_tuned_model_validation: acc        \u001b[1;36m0.952895\u001b[0m                 \u001b]8;id=61606;file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py\u001b\\\u001b[2mcollaborator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=931336;file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py#415\u001b\\\u001b[2m415\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>, collaborator validate_local locally_tuned_model_validation result acc: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.952895</span>                                   <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">aggregator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#559\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">559</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m1\u001b[0m, collaborator validate_local locally_tuned_model_validation result acc: \u001b[1;36m0.952895\u001b[0m                                   \u001b]8;id=817447;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\u001b\\\u001b[2maggregator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=913965;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#559\u001b\\\u001b[2m559\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>, aggregator: train <span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">openfl.interface.aggregation_functions.weighted_average.WeightedAverage</span><span style=\"color: #000000; text-decoration-color: #000000\"> object at </span>             <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">aggregator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#842\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">842</span></a>\n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>         <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0x7f3c337ff760</span><span style=\"font-weight: bold\">&gt;</span> cross_entropy:    <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.178438</span>                                                                                 <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                 </span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m1\u001b[0m, aggregator: train \u001b[1m<\u001b[0m\u001b[1;95mopenfl.interface.aggregation_functions.weighted_average.WeightedAverage\u001b[0m\u001b[39m object at \u001b[0m             \u001b]8;id=747054;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\u001b\\\u001b[2maggregator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=45321;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#842\u001b\\\u001b[2m842\u001b[0m\u001b]8;;\u001b\\\n",
+       "\u001b[2;36m           \u001b[0m         \u001b[1;36m0x7f3c337ff760\u001b[0m\u001b[1m>\u001b[0m cross_entropy:    \u001b[1;36m0.178438\u001b[0m                                                                                 \u001b[2m                 \u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>, aggregator: locally_tuned_model_validation                                                                        <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">aggregator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#842\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">842</span></a>\n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>         <span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">openfl.interface.aggregation_functions.weighted_average.WeightedAverage</span><span style=\"color: #000000; text-decoration-color: #000000\"> object at </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0x7f3c337ff760</span><span style=\"font-weight: bold\">&gt;</span> acc:     <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.960552</span>       <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                 </span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m1\u001b[0m, aggregator: locally_tuned_model_validation                                                                        \u001b]8;id=445820;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\u001b\\\u001b[2maggregator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=434712;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#842\u001b\\\u001b[2m842\u001b[0m\u001b]8;;\u001b\\\n",
+       "\u001b[2;36m           \u001b[0m         \u001b[1m<\u001b[0m\u001b[1;95mopenfl.interface.aggregation_functions.weighted_average.WeightedAverage\u001b[0m\u001b[39m object at \u001b[0m\u001b[1;36m0x7f3c337ff760\u001b[0m\u001b[1m>\u001b[0m acc:     \u001b[1;36m0.960552\u001b[0m       \u001b[2m                 \u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>, aggregator: aggregated_model_validation <span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">openfl.interface.aggregation_functions.weighted_average.WeightedAverage</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span> <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">aggregator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#842\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">842</span></a>\n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>         <span style=\"color: #000000; text-decoration-color: #000000\">object at </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0x7f3c337ff760</span><span style=\"font-weight: bold\">&gt;</span> acc:        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.936103</span>                                                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                 </span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m1\u001b[0m, aggregator: aggregated_model_validation \u001b[1m<\u001b[0m\u001b[1;95mopenfl.interface.aggregation_functions.weighted_average.WeightedAverage\u001b[0m\u001b[39m \u001b[0m \u001b]8;id=828316;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\u001b\\\u001b[2maggregator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=175548;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#842\u001b\\\u001b[2m842\u001b[0m\u001b]8;;\u001b\\\n",
+       "\u001b[2;36m           \u001b[0m         \u001b[39mobject at \u001b[0m\u001b[1;36m0x7f3c337ff760\u001b[0m\u001b[1m>\u001b[0m acc:        \u001b[1;36m0.936103\u001b[0m                                                                             \u001b[2m                 \u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[10:53:48] </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>: saved the best model with score <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.936103</span>                                                                          <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">aggregator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#858\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">858</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m[10:53:48]\u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m1\u001b[0m: saved the best model with score \u001b[1;36m0.936103\u001b[0m                                                                          \u001b]8;id=946380;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\u001b\\\u001b[2maggregator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=373163;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#858\u001b\\\u001b[2m858\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Run experiment, return trained FederatedModel\n",
+    "\n",
+    "final_fl_model = fx.run_experiment(train_test_collaborators, override_config={\n",
+    "    'aggregator.settings.rounds_to_train': 2,\n",
+    "    'aggregator.settings.log_metric_callback': write_metric,\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Save final model\n",
+    "final_fl_model.save_native('final_pytorch_model')"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we have finished the training process.\n",
+    "\n",
+    "We can validate the model on `validate_collaborators`. It's worth to noting that we can get the tensor dict with `get_tensor_dict()` from `final_fl_model`. \n",
+    "\n",
+    "First, we setup the new aggregator's tensors with the tensors of the trained model(`final_fl_model`). Then, we set the parameter 'rounds_to_train' to 1 to cancel the training process. Finally, we only let collaborators perform \"aggregated_model_validation\" task to achieve federated evaluation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.10/dist-packages/openfl/federated/task/runner_pt.py:107: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).\n",
+      "  data, target = pt.tensor(data).to(self.device), pt.tensor(\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[10:55:16] </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>, collaborator three is sending metric for task aggregated_model_validation: acc <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.936994</span>                         <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">collaborator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py#415\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">415</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m[10:55:16]\u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m0\u001b[0m, collaborator three is sending metric for task aggregated_model_validation: acc \u001b[1;36m0.936994\u001b[0m                         \u001b]8;id=206687;file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py\u001b\\\u001b[2mcollaborator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=890079;file:///usr/local/lib/python3.10/dist-packages/openfl/component/collaborator/collaborator.py#415\u001b\\\u001b[2m415\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>, collaborator validate_agg aggregated_model_validation result acc:      <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.936994</span>                                   <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">aggregator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#559\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">559</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m0\u001b[0m, collaborator validate_agg aggregated_model_validation result acc:      \u001b[1;36m0.936994\u001b[0m                                   \u001b]8;id=941998;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\u001b\\\u001b[2maggregator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=246216;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#559\u001b\\\u001b[2m559\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>, aggregator: aggregated_model_validation <span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">openfl.interface.aggregation_functions.weighted_average.WeightedAverage</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span> <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">aggregator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#842\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">842</span></a>\n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>         <span style=\"color: #000000; text-decoration-color: #000000\">object at </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0x7f3c337ff760</span><span style=\"font-weight: bold\">&gt;</span> acc:        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.936994</span>                                                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                 </span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m0\u001b[0m, aggregator: aggregated_model_validation \u001b[1m<\u001b[0m\u001b[1;95mopenfl.interface.aggregation_functions.weighted_average.WeightedAverage\u001b[0m\u001b[39m \u001b[0m \u001b]8;id=145571;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\u001b\\\u001b[2maggregator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=938784;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#842\u001b\\\u001b[2m842\u001b[0m\u001b]8;;\u001b\\\n",
+       "\u001b[2;36m           \u001b[0m         \u001b[39mobject at \u001b[0m\u001b[1;36m0x7f3c337ff760\u001b[0m\u001b[1m>\u001b[0m acc:        \u001b[1;36m0.936994\u001b[0m                                                                             \u001b[2m                 \u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>METRIC   Round <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>: saved the best model with score <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.936994</span>                                                                          <a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">aggregator.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#858\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">858</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mMETRIC   Round \u001b[1;36m0\u001b[0m: saved the best model with score \u001b[1;36m0.936994\u001b[0m                                                                          \u001b]8;id=250840;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py\u001b\\\u001b[2maggregator.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=603242;file:///usr/local/lib/python3.10/dist-packages/openfl/component/aggregator/aggregator.py#858\u001b\\\u001b[2m858\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "tensor_dict = final_fl_model.get_tensor_dict()\n",
+    "\n",
+    "fx.run_evaluation(validate_collaborators, update_plan_file='plan/plan_evaluation.yaml', aggregator_tensor_dict=tensor_dict)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/openfl-workspace/torch_cnn_mnist/plan/plan_evaluation.yaml
+++ b/openfl-workspace/torch_cnn_mnist/plan/plan_evaluation.yaml
@@ -1,0 +1,56 @@
+# Copyright (C) 2020-2021 Intel Corporation
+# Licensed subject to the terms of the separately executed evaluation license agreement between Intel Corporation and you.
+
+aggregator :
+  defaults : plan/defaults/aggregator.yaml
+  template : openfl.component.Aggregator
+  settings :
+    init_state_path     : save/torch_cnn_mnist_init.pbuf
+    best_state_path     : save/torch_cnn_mnist_best.pbuf
+    last_state_path     : save/torch_cnn_mnist_last.pbuf
+    rounds_to_train     : 1
+    log_metric_callback :
+      template : src.mnist_utils.write_metric
+
+
+collaborator :
+  defaults : plan/defaults/collaborator.yaml
+  template : openfl.component.Collaborator
+  settings :
+    delta_updates    : false
+    opt_treatment    : RESET
+
+data_loader :
+  defaults : plan/defaults/data_loader.yaml
+  template : src.ptmnist_inmemory.PyTorchMNISTInMemory
+  settings :
+    collaborator_count : 1
+    data_group_name    : mnist
+    batch_size         : 256
+
+task_runner :
+  defaults : plan/defaults/task_runner.yaml
+  template : src.pt_cnn.PyTorchCNN
+
+network :
+  defaults : plan/defaults/network.yaml
+
+assigner :
+  template : openfl.component.RandomGroupedAssigner
+  settings :
+    task_groups  :
+      - name       : validate
+        percentage : 1.0
+        tasks      :
+          - aggregated_model_validation
+  
+tasks :
+  aggregated_model_validation:
+    function : validate
+    kwargs   :
+      apply   : global
+      metrics :
+        - acc
+
+compression_pipeline :
+  defaults : plan/defaults/compression_pipeline.yaml

--- a/openfl/native/native.py
+++ b/openfl/native/native.py
@@ -311,8 +311,8 @@ def get_plan(fl_plan=None, indent=4, sort_keys=True):
     return json.dumps(flat_plan_config, indent=indent, sort_keys=sort_keys)
 
 
-def run_evaluation(collaborator_dict: dict, override_config: dict = None, 
-                   update_plan_file: str = None, aggregator_tensor_dict: dict=None):
+def run_evaluation(collaborator_dict: dict, override_config: dict = None,
+                   update_plan_file: str = None, aggregator_tensor_dict: dict = None):
     """
     Core function that executes the evaluation.
 
@@ -349,7 +349,7 @@ def run_evaluation(collaborator_dict: dict, override_config: dict = None,
     plan = None
     if update_plan_file:
         plan = Plan.parse(plan_config_path=Path(update_plan_file),
-                      resolve=False)
+                          resolve=False)
 
     # Update the plan if necessary
     plan = update_plan(override_config, plan=plan)


### PR DESCRIPTION
This adds a new tutorial example Support for federated evaluation with aggregator based workflow.

The example adds federate evaluation after the model has been trained. In the plan, we set parameter `rounds_to_train` to 1 and make collaborators only do `aggregator_model_validation` task.

Fixes  #788 