### PR TITLE
Fix incorrectly formatted link in documentation

### DIFF
--- a/docs/running_the_federation.rst
+++ b/docs/running_the_federation.rst
@@ -14,7 +14,9 @@ OpenFL currently offers two ways to set up and run experiments with a federation
 
 
 `Aggregator-Based Workflow`_
-    Define an experiment and distribute it manually. All participants can verify model code and [FL plan](https://openfl.readthedocs.io/en/latest/running_the_federation.html#federated-learning-plan-fl-plan-settings) prior to execution. The federation is terminated when the experiment is finished
+    Define an experiment and distribute it manually. All participants can verify model code and :ref:`FL plan <plan_settings>` prior to execution. The federation is terminated when the experiment is finished
+
+    
 
 
 .. _director_workflow:

--- a/docs/running_the_federation.rst
+++ b/docs/running_the_federation.rst
@@ -16,8 +16,6 @@ OpenFL currently offers two ways to set up and run experiments with a federation
 `Aggregator-Based Workflow`_
     Define an experiment and distribute it manually. All participants can verify model code and :ref:`FL plan <plan_settings>` prior to execution. The federation is terminated when the experiment is finished
 
-    
-
 
 .. _director_workflow:
 


### PR DESCRIPTION
There's an incorrectly formatted markdown link in the documentation. This PR fixes the link so it now works.