### PR TITLE
revert experimental Adam optimizer call to legacy [dependabot PR #771]

### DIFF
--- a/openfl-workspace/keras_cnn_mnist/src/keras_cnn.py
+++ b/openfl-workspace/keras_cnn_mnist/src/keras_cnn.py
@@ -74,7 +74,7 @@ class KerasCNN(KerasTaskRunner):
         model.add(Dense(num_classes, activation='softmax'))
 
         model.compile(loss=ke.losses.categorical_crossentropy,
-                      optimizer=ke.optimizers.Adam(),
+                      optimizer=ke.optimizers.legacy.Adam(),
                       metrics=['accuracy'])
 
         # initialize the optimizer variables


### PR DESCRIPTION
When upgrading to TF 2.11.1, `ke.optimizers.Adam()` refers to `keras.optimizers.optimizers_experimental`, which breaks the task runner because the weights are being stored differently. `ke.optimizers.legacy.Adam()` behaves consistently with the TF 2.8.4

Resolution for: #771