### PR TITLE
Fixing the problematic version for protobuf

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,7 @@ setup(
         'jupyterlab',
         'numpy',
         'pandas',
-        'protobuf==3.19.6',
+        'protobuf==4.23.4',
         'requests',
         'rich',
         'scikit-learn',


### PR DESCRIPTION
Fixes #831

This version is what gets installed for all [GaNDLF CI runs since yesterday](https://github.com/mlcommons/GaNDLF/actions/workflows/openfl-test.yml).