### PR TITLE
pinned tensorboardX

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -153,7 +153,7 @@ setup(
         'rich',
         'scikit-learn',
         'tensorboard',
-        'tensorboardX',
+        'tensorboardX<=2.6',
         'tqdm',
     ],
     setup_requires=['grpcio-tools~=1.48.2'],


### PR DESCRIPTION
openfl 1.5 requires protobuf 3.19.6, tensorboardX 2.6 is compatible with that protobuf, after that newer protobuf is needed, 
tensorboardX 2.6.2 did not pin protobuf although it probably needs at least 4.22.3(inferred from 2.6.1 pin). 
we should pin tensorboardX<=2.6 since tensorboardX needs a higher version of protobuf anyway