### PR TITLE
Migrate to Ubuntu 22.04 LTS release (supported through 2027)

### DIFF
--- a/openfl-docker/Dockerfile.base
+++ b/openfl-docker/Dockerfile.base
@@ -3,7 +3,7 @@
 
 # If your machine is behind a proxy, make sure you set it up in ~/.docker/config.json
 
-FROM ubuntu:22.10
+FROM ubuntu:22.04
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG INSTALL_SOURCES="yes"


### PR DESCRIPTION
This PR:
- Fixes OpenFL docker base image that is breaking CI (based on Ubuntu 22.10). Migrates to latest LTS release (22.04) supported through 2027