### PR TITLE
Help redirect users looking for Open Flash Library (OpenFL) Project

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@
 </a>
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/intel/openfl/blob/develop/openfl-tutorials/interactive_api/numpy_linear_regression/workspace/SingleNotebook.ipynb)
 
-OpenFL is a Python 3 framework for Federated Learning. OpenFL is designed to be a _flexible_, _extensible_ and _easily learnable_ tool for data scientists. OpenFL is hosted by The Linux Foundation, aims to be community-driven, and welcomes contributions back to the project. 
+Open Federated Learning (OpenFL) is a Python 3 framework for Federated Learning. OpenFL is designed to be a _flexible_, _extensible_ and _easily learnable_ tool for data scientists. OpenFL is hosted by The Linux Foundation, aims to be community-driven, and welcomes contributions back to the project. 
+
+Looking for the Open Flash Library project also referred to as OpenFL? Find it [here](https://github.com/openfl/openfl)!
 
 ## Installation
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,8 @@ Training of statistical models may be done with any deep learning framework, suc
 
 |productName| is a community supported project, originally developed by Intel Labs and the Intel Internet of Things Group. The team would like to encourage any contributions, notes, or requests to improve the documentation.
 
+Looking for the Open Flash Library project also referred to as OpenFL? Find it [here](https://www.openfl.org/)!
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:


### PR DESCRIPTION
Provides link to Open Flash Library (OpenFL) Github and website to reduce confusion with namespace collision.

Closes https://github.com/securefederatedai/openfl/issues/837