### PR TITLE
Gaudi2 validation

### DIFF
--- a/openfl-tutorials/interactive_api/HPU/PyTorch_Kvasir_UNet/README.md
+++ b/openfl-tutorials/interactive_api/HPU/PyTorch_Kvasir_UNet/README.md
@@ -17,9 +17,9 @@ For accessing the Gaudi2 instances on the Intel Developer Cloud follow the instr
 
 The Gaudi instance in the Intel Developer Cloud comes SynapseAI SW Stack for Gaudi2 installed. Skip sections (**II. , III.***)
 
-Further more our testing was done using the habana based Docker container built using the fololowing Dockerfile base:
+Further more our testing was done using the habana based Docker container built using the Dockerfile base discussed below:
 
-Let's consider the following Dockerfile name Dockerfile_Habana:
+Let's create a Dockerfile with the following content and name it Dockerfile_Habana:
 
 ```
 
@@ -80,7 +80,7 @@ pip list | grep openfl
 
 ``` 
 
-if not install it using:
+if not, then install it using:
 
 ```
 pip install openfl

--- a/openfl-tutorials/interactive_api/HPU/PyTorch_Kvasir_UNet/README.md
+++ b/openfl-tutorials/interactive_api/HPU/PyTorch_Kvasir_UNet/README.md
@@ -17,7 +17,9 @@ For accessing the Gaudi2 instances on the Intel Developer Cloud follow the instr
 
 The Gaudi instance in the Intel Developer Cloud comes SynapseAI SW Stack for Gaudi2 installed. Skip sections (**II. , III.***)
 
-Further more our testing was done using the habana based Docker container built using the following Dockerfile base:
+Further more our testing was done using the habana based Docker container built using the fololowing Dockerfile base:
+
+Let's consider the following Dockerfile name Dockerfile_Habana:
 
 ```
 
@@ -26,6 +28,23 @@ FROM vault.habana.ai/gaudi-docker/1.10.0/ubuntu20.04/habanalabs/pytorch-installe
 ENV HABANA_VISIBLE_DEVICES=all
 ENV OMPI_MCA_btl_vader_single_copy_mechanism=none
 
+ENV DEBIAN_FRONTEND="noninteractive"  TZ=Etc/UTC
+RUN apt-get update && apt-get install -y tzdata bash-completion \
+        #RUN apt update && apt-get install -y tzdata bash-completion \
+        python3-pip openssh-server vim git iputils-ping net-tools curl bc gawk \
+        && rm -rf /var/lib/apt/lists/*
+
+
+RUN pip install numpy \
+        && pip install jupyterlab \
+        && pip install matplotlib \
+        && pip install openfl
+
+
+RUN git clone https://github.com/securefederatedai/openfl.git /root/openfl
+
+WORKDIR /root
+ 
 ```
 
 This base container comes with HPU Pytorch packages already installed.  Hence you could skip step: **IV.** below. 
@@ -33,7 +52,10 @@ This base container comes with HPU Pytorch packages already installed.  Hence yo
 Build the above container and then launch it using:
 
 ```
-docker run  --net host -id --name openfl_gaudi_run  Container_Image bash
+export Container_Image="myrepo_name:gaudi-docker-ubuntu20.04-openfl"
+
+docker build -t ${container_image}  -f Dockerfile_Habana .
+docker run  --net host -id --name openfl_gaudi_run  ${Container_Image} bash
 ```
 
 Then access the container bash shell using:
@@ -43,13 +65,22 @@ docker exec -it openfl_gaudi_run bash
 
 ```
 
-Once inside the container, clone the openfl repo using:
+Once inside the container, ensure openfl repo is cloned!
+
+otherwise clone the openfl repo using:
 
 ```
-https://github.com/securefederatedai/openfl.git
+git clone https://github.com/securefederatedai/openfl.git
 ```
 
-Then install the openfl package:
+Then check if the openfl package is installed 
+
+```
+pip list | grep openfl 
+
+``` 
+
+if not install it using:
 
 ```
 pip install openfl

--- a/openfl-tutorials/interactive_api/HPU/PyTorch_Kvasir_UNet/README.md
+++ b/openfl-tutorials/interactive_api/HPU/PyTorch_Kvasir_UNet/README.md
@@ -52,10 +52,10 @@ This base container comes with HPU Pytorch packages already installed.  Hence yo
 Build the above container and then launch it using:
 
 ```
-export Container_Image="myrepo_name:gaudi-docker-ubuntu20.04-openfl"
+export GAUDI_DOCKER_IMAGE="gaudi-docker-ubuntu20.04-openfl"
 
-docker build -t ${container_image}  -f Dockerfile_Habana .
-docker run  --net host -id --name openfl_gaudi_run  ${Container_Image} bash
+docker build -t ${GAUDI_DOCKER_IMAGE} -f Dockerfile_Habana .
+docker run  --net host -id --name openfl_gaudi_run  ${GAUDI_DOCKER_IMAGE} bash
 ```
 
 Then access the container bash shell using:

--- a/openfl-tutorials/interactive_api/HPU/PyTorch_Kvasir_UNet/README.md
+++ b/openfl-tutorials/interactive_api/HPU/PyTorch_Kvasir_UNet/README.md
@@ -4,13 +4,63 @@
 #### The name of the file/example that contain HPU adaptations start with "HPU". 
 For example: PyTorch_Kvasir_UNet.ipynb placed under workspace folder contains the required HPU adaptations.
 
- All the execution steps mention in last section (**V. How to run this tutorial**) remain same for HPU examples but as pre-requisite it needs some additional environment setup and Habana supported package installations which is explained below from **section I to IV**.
+ All the execution steps mention in last section (**V. How to run this tutorial**) remain same for HPU examples but as pre-requisite it needs some additional environment setup and Habana supported package installations which is explained below from **section I to V**.
 
  **Note:** By default these experiments utilize 1 HPU device
 
  <br/>
 
- ## **I. AWS DL1 Instance Setup**
+ ## **I. Intel Developer Cloud Setup**
+This example was test on the Intel Developer Cloud utilizing Gaudi2 instance. 
+
+For accessing the Gaudi2 instances on the Intel Developer Cloud follow the instructions [here](https://developer.habana.ai/intel-developer-cloud/)
+
+The Gaudi instance in the Intel Developer Cloud comes SynapseAI SW Stack for Gaudi2 installed. Skip sections (**II. , III.***)
+
+Further more our testing was done using the habana based Docker container built using the following Dockerfile base:
+
+```
+
+FROM vault.habana.ai/gaudi-docker/1.10.0/ubuntu20.04/habanalabs/pytorch-installer-2.0.1/latest
+
+ENV HABANA_VISIBLE_DEVICES=all
+ENV OMPI_MCA_btl_vader_single_copy_mechanism=none
+
+```
+
+This base container comes with HPU Pytorch packages already installed.  Hence you could skip step: **IV.** below. 
+
+Build the above container and then launch it using:
+
+```
+docker run  --net host -id --name openfl_gaudi_run  Container_Image bash
+```
+
+Then access the container bash shell using:
+
+```
+docker exec -it openfl_gaudi_run bash
+
+```
+
+Once inside the container, clone the openfl repo using:
+
+```
+https://github.com/securefederatedai/openfl.git
+```
+
+Then install the openfl package:
+
+```
+pip install openfl
+```
+
+Then follow instruction in section **V. HPU Adaptations For PyTorch Examples** below.
+
+
+<br/>
+
+ ## **II. AWS DL1 Instance Setup**
 
  This example was tested on AWS EC2 instance created by following the instructions mentioned [here](https://docs.habana.ai/en/latest/AWS_EC2_DL1_and_PyTorch_Quick_Start/AWS_EC2_DL1_and_PyTorch_Quick_Start.html) . 
  
@@ -18,7 +68,7 @@ For example: PyTorch_Kvasir_UNet.ipynb placed under workspace folder contains th
 
  <br/>
 
- ## **II. Set Up SynapseAI SW Stack**
+ ## **III. Set Up SynapseAI SW Stack**
 
  - To perform an installation of the full driver and SynapseAI software stack independently on the EC2 instance, run the following command:
  
@@ -33,7 +83,7 @@ You can refer the [Habana docs](https://docs.habana.ai/en/latest/Installation_Gu
 
 <br/>
 
- ## **III. HPU Pytorch Installation**
+ ## **IV. HPU Pytorch Installation**
 
  For this example make sure to install the PyTorch package provided by Habana. These packages are optimized for Habana Gaudi HPU. Installing public PyTorch packages is not supported.
  Habana PyTorch packages consist of:
@@ -69,7 +119,7 @@ The default virtual environment folder is `$HOME/habanalabs-venv`. To override t
 
  </br>
 
- ## **IV. HPU Adaptations For PyTorch Examples**
+ ## **V. HPU Adaptations For PyTorch Examples**
 
 The following set of code additions are required in the workspace notebook to run a model on Habana. The following steps cover Eager and Lazy modes of execution.
 
@@ -112,7 +162,7 @@ Refer [getting started with PyTorch](https://www.intel.com/content/www/us/en/dev
 
 <br/>
 
-## **V. How to run this tutorial (without TLC and locally as a simulation):**
+## **VI. How to run this tutorial (without TLC and locally as a simulation):**
 <br/>
 
 ### 0. If you haven't done so already, create a virtual environment, install OpenFL, and upgrade pip:

--- a/openfl-tutorials/interactive_api/HPU/PyTorch_MedMNIST_2D/README.md
+++ b/openfl-tutorials/interactive_api/HPU/PyTorch_MedMNIST_2D/README.md
@@ -65,10 +65,10 @@ This base container comes with HPU Pytorch packages already installed.  Hence yo
 Build the above container and then launch it using:
 
 ```
-export Container_Image="myrepo_name:gaudi-docker-ubuntu20.04-openfl"
+export GAUDI_DOCKER_IMAGE="gaudi-docker-ubuntu20.04-openfl"
 
-docker build -t ${container_image}  -f Dockerfile_Habana .
-docker run  --net host -id --name openfl_gaudi_run  ${Container_Image} bash
+docker build -t ${GAUDI_DOCKER_IMAGE} -f Dockerfile_Habana .
+docker run  --net host -id --name openfl_gaudi_run  ${GAUDI_DOCKER_IMAGE} bash
 ```
 
 Then access the container bash shell using:

--- a/openfl-tutorials/interactive_api/HPU/PyTorch_MedMNIST_2D/README.md
+++ b/openfl-tutorials/interactive_api/HPU/PyTorch_MedMNIST_2D/README.md
@@ -30,7 +30,9 @@ For accessing the Gaudi2 instances on the Intel Developer Cloud follow the instr
 
 The Gaudi instance in the Intel Developer Cloud comes SynapseAI SW Stack for Gaudi2 installed. Skip sections (**II. , III.***)
 
-Further more our testing was done using the habana based Docker container built using the following Dockerfile base:
+Further more our testing was done using the habana based Docker container built using the Dockerfile base discussed below:
+
+Let's create a Dockerfile with the following content and name it Dockerfile_Habana:
 
 ```
 
@@ -39,14 +41,34 @@ FROM vault.habana.ai/gaudi-docker/1.10.0/ubuntu20.04/habanalabs/pytorch-installe
 ENV HABANA_VISIBLE_DEVICES=all
 ENV OMPI_MCA_btl_vader_single_copy_mechanism=none
 
+ENV DEBIAN_FRONTEND="noninteractive"  TZ=Etc/UTC
+RUN apt-get update && apt-get install -y tzdata bash-completion \
+        #RUN apt update && apt-get install -y tzdata bash-completion \
+        python3-pip openssh-server vim git iputils-ping net-tools curl bc gawk \
+        && rm -rf /var/lib/apt/lists/*
+
+
+RUN pip install numpy \
+        && pip install jupyterlab \
+        && pip install matplotlib \
+        && pip install openfl
+
+
+RUN git clone https://github.com/securefederatedai/openfl.git /root/openfl
+
+WORKDIR /root
+
 ```
 
-This base container comes with HPU Pytorch packages already installed.  Hence you could skip step: **IV.** below. 
+This base container comes with HPU Pytorch packages already installed.  Hence you could skip step: **IV.** below.
 
 Build the above container and then launch it using:
 
 ```
-docker run  --net host -id --name openfl_gaudi_run  Container_Image bash
+export Container_Image="myrepo_name:gaudi-docker-ubuntu20.04-openfl"
+
+docker build -t ${container_image}  -f Dockerfile_Habana .
+docker run  --net host -id --name openfl_gaudi_run  ${Container_Image} bash
 ```
 
 Then access the container bash shell using:
@@ -56,20 +78,28 @@ docker exec -it openfl_gaudi_run bash
 
 ```
 
-Once inside the container, clone the openfl repo using:
+Once inside the container, ensure openfl repo is cloned!
+
+otherwise clone the openfl repo using:
 
 ```
-https://github.com/securefederatedai/openfl.git
+git clone https://github.com/securefederatedai/openfl.git
 ```
 
-Then install the openfl package:
+Then check if the openfl package is installed
+
+```
+pip list | grep openfl
+
+```
+
+if not, then install it using:
 
 ```
 pip install openfl
 ```
 
 Then follow instruction in section **V. HPU Adaptations For PyTorch Examples** below.
-
 
 <br/>
 

--- a/openfl-tutorials/interactive_api/HPU/PyTorch_MedMNIST_2D/README.md
+++ b/openfl-tutorials/interactive_api/HPU/PyTorch_MedMNIST_2D/README.md
@@ -22,7 +22,58 @@ For example: HPU_PyTorch_MedMNIST_2D.ipynb placed under workspace folder contain
 
  <br/>
 
- ## **I. AWS DL1 Instance Setup**
+
+ ## **I. Intel Developer Cloud Setup**
+This example was test on the Intel Developer Cloud utilizing Gaudi2 instance. 
+
+For accessing the Gaudi2 instances on the Intel Developer Cloud follow the instructions [here](https://developer.habana.ai/intel-developer-cloud/)
+
+The Gaudi instance in the Intel Developer Cloud comes SynapseAI SW Stack for Gaudi2 installed. Skip sections (**II. , III.***)
+
+Further more our testing was done using the habana based Docker container built using the following Dockerfile base:
+
+```
+
+FROM vault.habana.ai/gaudi-docker/1.10.0/ubuntu20.04/habanalabs/pytorch-installer-2.0.1/latest
+
+ENV HABANA_VISIBLE_DEVICES=all
+ENV OMPI_MCA_btl_vader_single_copy_mechanism=none
+
+```
+
+This base container comes with HPU Pytorch packages already installed.  Hence you could skip step: **IV.** below. 
+
+Build the above container and then launch it using:
+
+```
+docker run  --net host -id --name openfl_gaudi_run  Container_Image bash
+```
+
+Then access the container bash shell using:
+
+```
+docker exec -it openfl_gaudi_run bash
+
+```
+
+Once inside the container, clone the openfl repo using:
+
+```
+https://github.com/securefederatedai/openfl.git
+```
+
+Then install the openfl package:
+
+```
+pip install openfl
+```
+
+Then follow instruction in section **V. HPU Adaptations For PyTorch Examples** below.
+
+
+<br/>
+
+ ## **II. AWS DL1 Instance Setup**
 
  This example was tested on AWS EC2 instance created by following the instructions mentioned [here](https://docs.habana.ai/en/latest/AWS_EC2_DL1_and_PyTorch_Quick_Start/AWS_EC2_DL1_and_PyTorch_Quick_Start.html) . 
  
@@ -30,7 +81,7 @@ For example: HPU_PyTorch_MedMNIST_2D.ipynb placed under workspace folder contain
 
  <br/>
 
- ## **II. Set Up SynapseAI SW Stack**
+ ## **III. Set Up SynapseAI SW Stack**
 
  - To perform an installation of the full driver and SynapseAI software stack independently on the EC2 instance, run the following command:
  
@@ -45,7 +96,7 @@ You can refer the [Habana docs](https://docs.habana.ai/en/latest/Installation_Gu
 
 <br/>
 
- ## **III. HPU Pytorch Installation**
+ ## **IV. HPU Pytorch Installation**
 
  For this example make sure to install the PyTorch package provided by Habana. These packages are optimized for Habana Gaudi HPU. Installing public PyTorch packages is not supported.
  Habana PyTorch packages consist of:
@@ -81,7 +132,7 @@ The default virtual environment folder is $HOME/habanalabs-venv. To override the
 
  </br>
 
- ## **IV. HPU Adaptations For PyTorch Examples**
+ ## **V. HPU Adaptations For PyTorch Examples**
 
 The following set of code additions are required in the workspace notebook to run a model on Habana. The following steps cover Eager and Lazy modes of execution.
 
@@ -124,7 +175,7 @@ Refer [getting started with PyTorch](https://www.intel.com/content/www/us/en/dev
 
 <br/>
 
-## **V. How to run this tutorial (without TLC and locally as a simulation):**
+## **VI. How to run this tutorial (without TLC and locally as a simulation):**
 ### 0. If you haven't done so already, create a virtual environment, install OpenFL, and upgrade pip:
   - For help with this step, visit the "Install the Package" section of the [OpenFL installation instructions](https://openfl.readthedocs.io/en/latest/install.html#install-the-package).
 <br/>

--- a/openfl-tutorials/interactive_api/HPU/PyTorch_TinyImageNet/README.md
+++ b/openfl-tutorials/interactive_api/HPU/PyTorch_TinyImageNet/README.md
@@ -10,7 +10,58 @@ For example: HPU_pytorch_tinyimagenet.ipynb placed under workspace folder contai
 
  <br/>
 
- ## **I. AWS DL1 Instance Setup**
+
+ ## **I. Intel Developer Cloud Setup**
+This example was test on the Intel Developer Cloud utilizing Gaudi2 instance. 
+
+For accessing the Gaudi2 instances on the Intel Developer Cloud follow the instructions [here](https://developer.habana.ai/intel-developer-cloud/)
+
+The Gaudi instance in the Intel Developer Cloud comes SynapseAI SW Stack for Gaudi2 installed. Skip sections (**II. , III.***)
+
+Further more our testing was done using the habana based Docker container built using the following Dockerfile base:
+
+```
+
+FROM vault.habana.ai/gaudi-docker/1.10.0/ubuntu20.04/habanalabs/pytorch-installer-2.0.1/latest
+
+ENV HABANA_VISIBLE_DEVICES=all
+ENV OMPI_MCA_btl_vader_single_copy_mechanism=none
+
+```
+
+This base container comes with HPU Pytorch packages already installed.  Hence you could skip step: **IV.** below. 
+
+Build the above container and then launch it using:
+
+```
+docker run  --net host -id --name openfl_gaudi_run  Container_Image bash
+```
+
+Then access the container bash shell using:
+
+```
+docker exec -it openfl_gaudi_run bash
+
+```
+
+Once inside the container, clone the openfl repo using:
+
+```
+https://github.com/securefederatedai/openfl.git
+```
+
+Then install the openfl package:
+
+```
+pip install openfl
+```
+
+Then follow instruction in section **V. HPU Adaptations For PyTorch Examples** below.
+
+
+<br/>
+
+ ## **II. AWS DL1 Instance Setup**
 
  This example was tested on AWS EC2 instance created by following the instructions mentioned [here](https://docs.habana.ai/en/latest/AWS_EC2_DL1_and_PyTorch_Quick_Start/AWS_EC2_DL1_and_PyTorch_Quick_Start.html) . 
  
@@ -18,7 +69,7 @@ For example: HPU_pytorch_tinyimagenet.ipynb placed under workspace folder contai
 
  <br/>
 
- ## **II. Set Up SynapseAI SW Stack**
+ ## **III. Set Up SynapseAI SW Stack**
 
  - To perform an installation of the full driver and SynapseAI software stack independently on the EC2 instance, run the following command:
  
@@ -33,7 +84,7 @@ You can refer the [Habana docs](https://docs.habana.ai/en/latest/Installation_Gu
 
 <br/>
 
- ## **III. HPU Pytorch Installation**
+ ## **IV. HPU Pytorch Installation**
 
  For this example make sure to install the PyTorch package provided by Habana. These packages are optimized for Habana Gaudi HPU. Installing public PyTorch packages is not supported.
  Habana PyTorch packages consist of:
@@ -69,7 +120,7 @@ The default virtual environment folder is $HOME/habanalabs-venv. To override the
 
  </br>
 
- ## **IV. HPU Adaptations For PyTorch Examples**
+ ## **V. HPU Adaptations For PyTorch Examples**
 
 The following set of code additions are required in the workspace notebook to run a model on Habana. The following steps cover Eager and Lazy modes of execution.
 
@@ -113,7 +164,7 @@ Refer [getting started with PyTorch](https://www.intel.com/content/www/us/en/dev
 <br/>
 
 
-## **V. How to run this tutorial (without TLS and locally as a simulation):**
+## **VI. How to run this tutorial (without TLS and locally as a simulation):**
 <br/>
 
 ### 0. If you haven't done so already, install OpenFL in the virtual environment created during Habana setup, and upgrade pip:

--- a/openfl-tutorials/interactive_api/HPU/PyTorch_TinyImageNet/README.md
+++ b/openfl-tutorials/interactive_api/HPU/PyTorch_TinyImageNet/README.md
@@ -53,10 +53,10 @@ This base container comes with HPU Pytorch packages already installed.  Hence yo
 Build the above container and then launch it using:
 
 ```
-export Container_Image="myrepo_name:gaudi-docker-ubuntu20.04-openfl"
+export GAUDI_DOCKER_IMAGE="gaudi-docker-ubuntu20.04-openfl"
 
-docker build -t ${container_image}  -f Dockerfile_Habana .
-docker run  --net host -id --name openfl_gaudi_run  ${Container_Image} bash
+docker build -t ${GAUDI_DOCKER_IMAGE} -f Dockerfile_Habana .
+docker run  --net host -id --name openfl_gaudi_run  ${GAUDI_DOCKER_IMAGE} bash
 ```
 
 Then access the container bash shell using:

--- a/openfl-tutorials/interactive_api/HPU/PyTorch_TinyImageNet/README.md
+++ b/openfl-tutorials/interactive_api/HPU/PyTorch_TinyImageNet/README.md
@@ -18,7 +18,9 @@ For accessing the Gaudi2 instances on the Intel Developer Cloud follow the instr
 
 The Gaudi instance in the Intel Developer Cloud comes SynapseAI SW Stack for Gaudi2 installed. Skip sections (**II. , III.***)
 
-Further more our testing was done using the habana based Docker container built using the following Dockerfile base:
+Further more our testing was done using the habana based Docker container built using the Dockerfile base discussed below:
+
+Let's create a Dockerfile with the following content and name it Dockerfile_Habana:
 
 ```
 
@@ -27,14 +29,34 @@ FROM vault.habana.ai/gaudi-docker/1.10.0/ubuntu20.04/habanalabs/pytorch-installe
 ENV HABANA_VISIBLE_DEVICES=all
 ENV OMPI_MCA_btl_vader_single_copy_mechanism=none
 
+ENV DEBIAN_FRONTEND="noninteractive"  TZ=Etc/UTC
+RUN apt-get update && apt-get install -y tzdata bash-completion \
+        #RUN apt update && apt-get install -y tzdata bash-completion \
+        python3-pip openssh-server vim git iputils-ping net-tools curl bc gawk \
+        && rm -rf /var/lib/apt/lists/*
+
+
+RUN pip install numpy \
+        && pip install jupyterlab \
+        && pip install matplotlib \
+        && pip install openfl
+
+
+RUN git clone https://github.com/securefederatedai/openfl.git /root/openfl
+
+WORKDIR /root
+
 ```
 
-This base container comes with HPU Pytorch packages already installed.  Hence you could skip step: **IV.** below. 
+This base container comes with HPU Pytorch packages already installed.  Hence you could skip step: **IV.** below.
 
 Build the above container and then launch it using:
 
 ```
-docker run  --net host -id --name openfl_gaudi_run  Container_Image bash
+export Container_Image="myrepo_name:gaudi-docker-ubuntu20.04-openfl"
+
+docker build -t ${container_image}  -f Dockerfile_Habana .
+docker run  --net host -id --name openfl_gaudi_run  ${Container_Image} bash
 ```
 
 Then access the container bash shell using:
@@ -44,20 +66,28 @@ docker exec -it openfl_gaudi_run bash
 
 ```
 
-Once inside the container, clone the openfl repo using:
+Once inside the container, ensure openfl repo is cloned!
+
+otherwise clone the openfl repo using:
 
 ```
-https://github.com/securefederatedai/openfl.git
+git clone https://github.com/securefederatedai/openfl.git
 ```
 
-Then install the openfl package:
+Then check if the openfl package is installed
+
+```
+pip list | grep openfl
+
+```
+
+if not, then install it using:
 
 ```
 pip install openfl
 ```
 
 Then follow instruction in section **V. HPU Adaptations For PyTorch Examples** below.
-
 
 <br/>
 


### PR DESCRIPTION
Updated README.md instructions file for the HBU examples to describe the steps to run these examples on the Gaudi2 instances of the Intel Developer clouds. 

The instructions were limited to the setting up and running Gaudi based containers on the above gaudi2 instance. 

No code changes were necessary as the examples ran as is.   