### PR TITLE
Updated Gaudi2 HPU interactive instruction to using gaudi-docker 1.12.0 

### DIFF
--- a/openfl-tutorials/interactive_api/HPU/PyTorch_Kvasir_UNet/README.md
+++ b/openfl-tutorials/interactive_api/HPU/PyTorch_Kvasir_UNet/README.md
@@ -23,7 +23,7 @@ Let's create a Dockerfile with the following content and name it Dockerfile_Haba
 
 ```
 
-FROM vault.habana.ai/gaudi-docker/1.10.0/ubuntu20.04/habanalabs/pytorch-installer-2.0.1/latest
+FROM vault.habana.ai/gaudi-docker/1.12.0/ubuntu20.04/habanalabs/pytorch-installer-2.0.1:latest
 
 ENV HABANA_VISIBLE_DEVICES=all
 ENV OMPI_MCA_btl_vader_single_copy_mechanism=none
@@ -215,7 +215,7 @@ Refer [getting started with PyTorch](https://www.intel.com/content/www/us/en/dev
    - Navigate to the tutorial:
     
    ```sh
-   cd openfl/openfl-tutorials/interactive_api/PyTorch_Kvasir_UNet
+   cd openfl/openfl-tutorials/interactive_api/HPU/PyTorch_Kvasir_UNet
    ```
 
 <br/>
@@ -255,9 +255,15 @@ Optional: Run a second envoy in an additional terminal:
 
 ```sh
 cd workspace
-jupyter lab PyTorch_Kvasir_UNet.ipynb
+jupyter lab --allow-root PyTorch_Kvasir_UNet.ipynb
 ```
-- A Jupyter Server URL will appear in your terminal. In your browser, proceed to that link. Once the webpage loads, click on the PyTorch_Kvasir_UNet.ipynb file. 
+
+When running on remote host inside a docker container as the case of Gaudi2, one need to port forward jupyter lab to your local host. On your local terminal port formal 
+
+```sh
+ssh -NL 8888:127.0.0.1:8888 gaudi2_host
+```
+- A Jupyter Server URL will appear in your terminal. In your local browser, proceed to that link. Once the webpage loads, click on the PyTorch_Kvasir_UNet.ipynb file. 
 - To run the experiment, select the icon that looks like two triangles to "Restart Kernel and Run All Cells". 
 - You will notice activity in your terminals as the experiment runs, and when the experiment is finished the director terminal will display a message that the experiment has finished successfully.  
  

--- a/openfl-tutorials/interactive_api/HPU/PyTorch_MedMNIST_2D/README.md
+++ b/openfl-tutorials/interactive_api/HPU/PyTorch_MedMNIST_2D/README.md
@@ -36,7 +36,7 @@ Let's create a Dockerfile with the following content and name it Dockerfile_Haba
 
 ```
 
-FROM vault.habana.ai/gaudi-docker/1.10.0/ubuntu20.04/habanalabs/pytorch-installer-2.0.1/latest
+FROM vault.habana.ai/gaudi-docker/1.12.0/ubuntu20.04/habanalabs/pytorch-installer-2.0.1:latest
 
 ENV HABANA_VISIBLE_DEVICES=all
 ENV OMPI_MCA_btl_vader_single_copy_mechanism=none
@@ -223,7 +223,7 @@ Refer [getting started with PyTorch](https://www.intel.com/content/www/us/en/dev
    - Navigate to the tutorial:
     
    ```sh
-   cd openfl/openfl-tutorials/interactive_api/PyTorch_MedMNIST_2D
+   cd openfl/openfl-tutorials/interactive_api/HPU/PyTorch_MedMNIST_2D
    ```
 <br/>
 
@@ -256,9 +256,16 @@ cd envoy
 
 ```sh
 cd workspace
-jupyter lab Pytorch_MedMNIST_2D.ipynb
+jupyter lab --allow-root  HPU_Pytorch_MedMNIST_2D.ipynb
 ```
-- A Jupyter Server URL will appear in your terminal. In your browser, proceed to that link. Once the webpage loads, click on the Pytorch_MedMNIST_2D.ipynb file. 
+
+When running on remote host inside a docker container as the case of Gaudi2, one need to port forward jupyter lab to your local host. On your local terminal port formal 
+
+```sh
+ssh -NL 8888:127.0.0.1:8888 gaudi2_host
+```
+
+- A Jupyter Server URL will appear in your terminal. In your local browser, proceed to that link. Once the webpage loads, click on the HPU_Pytorch_MedMNIST_2D.ipynb file. 
 - To run the experiment, select the icon that looks like two triangles to "Restart Kernel and Run All Cells". 
 - You will notice activity in your terminals as the experiments runs, and when the experiment is finished the director terminal will display a message that the experiment was finished successfully.  
  

--- a/openfl-tutorials/interactive_api/HPU/PyTorch_TinyImageNet/README.md
+++ b/openfl-tutorials/interactive_api/HPU/PyTorch_TinyImageNet/README.md
@@ -249,9 +249,15 @@ cd envoy
 
 ```sh
 cd workspace
-jupyter lab pytorch_tinyimagenet.ipynb
+jupyter lab --allow-root  hpu_pytorch_tinyimagenet.ipynb
 ```
-- A Jupyter Server URL will appear in your terminal. In your browser, proceed to that link. Once the webpage loads, click on the pytorch_tinyimagenet.ipynb file. 
+When running on remote host inside a docker container as the case of Gaudi2, one need to port forward jupyter lab to your local host. On your local terminal port formal 
+
+```sh
+ssh -NL 8888:127.0.0.1:8888 gaudi2_host
+```
+
+- A Jupyter Server URL will appear in your terminal. In your local browser, proceed to that link. Once the webpage loads, click on the pytorch_tinyimagenet.ipynb file. 
 - To run the experiment, select the icon that looks like two triangles to "Restart Kernel and Run All Cells". 
 - You will notice activity in your terminals as the experiment runs, and when the experiment is finished the director terminal will display a message that the experiment has finished successfully.  
 


### PR DESCRIPTION
1) The gaudi-docker/1.10.0/ Docker container is no longer available.   Updated docker file to use gaudi-docker/1.12.0/
2) added jupyter lab port forwarding instructions to local host so notebook can be viewed in local browser. 