### PR TITLE
Remove copyright mandate for flake8

### DIFF
--- a/openfl-tutorials/experimental/CrowdGuard/cifar10_crowdguard.py
+++ b/openfl-tutorials/experimental/CrowdGuard/cifar10_crowdguard.py
@@ -517,7 +517,7 @@ if __name__ == '__main__':
     )
 
     args = argparser.parse_args()
-    
+
     download_pretrained_model()
 
     # Setup participants

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,4 +15,3 @@ import-order-style = smarkets
 application-import-names = openfl
 ignore-names=X_*,X,X1,X2
 copyright-check = True
-copyright-regexp = Copyright\s+(\(C\)\s+)?\d{4}([-,]\d{4})*\s+Intel\sCorporation(\s)*\n\s*#*\sSPDX-License-Identifier:\sApache-2.0


### PR DESCRIPTION
This PR:
- Removes an expected Intel copyright from files as part of the Flake8 configuration
- Fixes remaining lint issues