### PR TITLE
Install Python 3.10 from deadsnakes PPA

### DIFF
--- a/openfl-docker/Dockerfile.base
+++ b/openfl-docker/Dockerfile.base
@@ -20,47 +20,40 @@ FROM base as python-dev
 
 ARG PYTHON=python3.10
 ARG PIP=pip3.10
-ARG PYTHON_VER=3.10.13
 
 RUN apt-get update && \
     apt-get install --no-install-recommends --fix-missing -y \
-      build-essential \
-      ca-certificates \
       curl \
-      libbz2-dev \
-      libffi-dev \
-      libgdbm-dev \
-      liblzma-dev \
-      libncurses5-dev \
-      libnss3-dev \
-      libreadline-dev \
-      libsqlite3-dev \
-      libssl-dev \
-      make \
-      pkg-config \
-      zlib1g-dev
+      gpg-agent \
+      software-properties-common && \
+    add-apt-repository -y ppa:deadsnakes/ppa && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get install --no-install-recommends --fix-missing -y \
+      ${PYTHON} \
+      ${PYTHON}-distutils && \
+    curl -s https://bootstrap.pypa.io/get-pip.py | ${PYTHON} && \
+    apt-get purge -y \
+      curl \
+      gpg-agent \
+      software-properties-common && \
+    apt-get autoclean && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN curl https://www.python.org/ftp/python/${PYTHON_VER}/Python-${PYTHON_VER}.tar.xz -o /tmp/Python-${PYTHON_VER}.tar.xz && \
-     cd /tmp/ && \
-     tar -xf Python-${PYTHON_VER}.tar.xz && \
-     rm -rf Python-${PYTHON_VER}.tar.xz
-
-RUN cd /tmp/Python-${PYTHON_VER} && \
-    ./configure --enable-optimizations && \
-    make -s -j${nproc} && \
-    make altinstall && \
-    ldconfig /opt/Python${PYTHON_VER}
-
-RUN ln -sf /usr/local/bin/${PIP} /usr/local/bin/pip && \
-    ln -sf /usr/local/bin/${PIP} /usr/local/bin/pip3 && \
-    ln -sf /usr/local/bin/${PYTHON} /usr/local/bin/python && \
-    ln -sf /usr/local/bin/${PYTHON} /usr/local/bin/python3
+RUN ln -sf /usr/bin/${PYTHON} /usr/bin/python && \
+    ln -sf /usr/bin/${PYTHON} /usr/bin/python3 && \
+    ln -sf /usr/local/bin/${PIP} /usr/local/bin/pip && \
+    ln -sf /usr/local/bin/${PIP} /usr/local/bin/pip3
 
 FROM base as python-base
 
 ARG PYTHON=python3.10
 
+COPY --from=python-dev /usr/lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu
+COPY --from=python-dev /usr/lib/${PYTHON} /usr/lib/${PYTHON}
 COPY --from=python-dev /usr/local/lib/${PYTHON} /usr/local/lib/${PYTHON}
+COPY --from=python-dev /usr/bin /usr/bin
 COPY --from=python-dev /usr/local/bin /usr/local/bin
 
 FROM python-base as openfl
@@ -77,8 +70,6 @@ RUN rm -rf zlib-1.2.13 && rm -rf v1.2.13.tar.gz
 RUN apt-get remove --purge -y wget build-essential && \
     apt-get autoclean -y && \
     apt-get auto-remove -y
-
-WORKDIR /thirdparty
 
 RUN dpkg --get-selections | grep -v deinstall | awk '{print $1}' > base_packages.txt  && \
     rm -rf /var/lib/apt/lists/*

--- a/openfl-docker/Dockerfile.base
+++ b/openfl-docker/Dockerfile.base
@@ -19,6 +19,7 @@ RUN apt-get clean && \
 FROM base as python-dev
 
 ARG PYTHON=python3.10
+ARG PIP=pip3.10
 ARG PYTHON_VER=3.10.13
 
 RUN apt-get update && \
@@ -50,7 +51,9 @@ RUN cd /tmp/Python-${PYTHON_VER} && \
     make altinstall && \
     ldconfig /opt/Python${PYTHON_VER}
 
-RUN ln -sf /usr/local/bin/${PYTHON} /usr/local/bin/python && \
+RUN ln -sf /usr/local/bin/${PIP} /usr/local/bin/pip && \
+    ln -sf /usr/local/bin/${PIP} /usr/local/bin/pip3 && \
+    ln -sf /usr/local/bin/${PYTHON} /usr/local/bin/python && \
     ln -sf /usr/local/bin/${PYTHON} /usr/local/bin/python3
 
 FROM base as python-base
@@ -58,9 +61,7 @@ FROM base as python-base
 ARG PYTHON=python3.10
 
 COPY --from=python-dev /usr/local/lib/${PYTHON} /usr/local/lib/${PYTHON}
-COPY --from=python-dev /usr/local/bin/${PYTHON} /usr/local/bin/${PYTHON}
-COPY --from=python-dev /usr/local/bin/python3 /usr/local/bin/python3
-COPY --from=python-dev /usr/local/bin/python /usr/local/bin/python
+COPY --from=python-dev /usr/local/bin /usr/local/bin
 
 FROM python-base as openfl
 
@@ -110,10 +111,10 @@ RUN apt-get update && \
 WORKDIR /openfl
 COPY . .
 
-# Install pip
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python get-pip.py && rm -rf get-pip.py
-RUN pip install --no-cache-dir . && \
-    pip uninstall -y setuptools
+# Install OpenFL
+RUN pip install --no-cache-dir install --upgrade pip setuptools
+RUN pip install --no-cache-dir .
+
 WORKDIR /thirdparty
 RUN if [ "$INSTALL_SOURCES" = "yes" ]; then \
     pip install --no-cache-dir pip-licenses; \

--- a/openfl-docker/Dockerfile.base
+++ b/openfl-docker/Dockerfile.base
@@ -3,14 +3,74 @@
 
 # If your machine is behind a proxy, make sure you set it up in ~/.docker/config.json
 
-FROM ubuntu:22.04
+ARG IMAGE_NAME=ubuntu
+ARG IMAGE_TAG=22.04
+
+# Base image to be used everywhere
+FROM ${IMAGE_NAME}:${IMAGE_TAG} as base
+RUN apt-get clean && \
+    apt-get update && \
+    apt-get upgrade -y && \
+    apt-get clean autoclean && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
+
+# Python image
+FROM base as python-dev
+
+ARG PYTHON=python3.10
+ARG PYTHON_VER=3.10.13
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends --fix-missing -y \
+      build-essential \
+      ca-certificates \
+      curl \
+      libbz2-dev \
+      libffi-dev \
+      libgdbm-dev \
+      liblzma-dev \
+      libncurses5-dev \
+      libnss3-dev \
+      libreadline-dev \
+      libsqlite3-dev \
+      libssl-dev \
+      make \
+      pkg-config \
+      zlib1g-dev
+
+RUN curl https://www.python.org/ftp/python/${PYTHON_VER}/Python-${PYTHON_VER}.tar.xz -o /tmp/Python-${PYTHON_VER}.tar.xz && \
+     cd /tmp/ && \
+     tar -xf Python-${PYTHON_VER}.tar.xz && \
+     rm -rf Python-${PYTHON_VER}.tar.xz
+
+RUN cd /tmp/Python-${PYTHON_VER} && \
+    ./configure --enable-optimizations && \
+    make -s -j${nproc} && \
+    make altinstall && \
+    ldconfig /opt/Python${PYTHON_VER}
+
+RUN ln -sf /usr/local/bin/${PYTHON} /usr/local/bin/python && \
+    ln -sf /usr/local/bin/${PYTHON} /usr/local/bin/python3
+
+FROM base as python-base
+
+ARG PYTHON=python3.10
+
+COPY --from=python-dev /usr/local/lib/${PYTHON} /usr/local/lib/${PYTHON}
+COPY --from=python-dev /usr/local/bin/${PYTHON} /usr/local/bin/${PYTHON}
+COPY --from=python-dev /usr/local/bin/python3 /usr/local/bin/python3
+COPY --from=python-dev /usr/local/bin/python /usr/local/bin/python
+
+FROM python-base as openfl
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG INSTALL_SOURCES="yes"
 
 WORKDIR /zlib
 #zlib install to 1.2.13
-RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing wget build-essential
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends --fix-missing wget build-essential
 RUN wget --no-check-certificate https://github.com/madler/zlib/archive/refs/tags/v1.2.13.tar.gz && tar -xvf ./v1.2.13.tar.gz && cd zlib-1.2.13 && ./configure --prefix=/usr && make && make install
 RUN rm -rf zlib-1.2.13 && rm -rf v1.2.13.tar.gz
 RUN apt-get remove --purge -y wget build-essential && \
@@ -25,8 +85,6 @@ RUN dpkg --get-selections | grep -v deinstall | awk '{print $1}' > base_packages
 RUN apt-get update && \
     apt-get install -y --no-install-recommends --fix-missing \
         openssh-server=\* \
-        python3.10=\* \
-        python3-distutils=\* \
         curl=\* \
         ca-certificates=\* && \
     if [ "$INSTALL_SOURCES" = "yes" ]; then \
@@ -53,9 +111,9 @@ WORKDIR /openfl
 COPY . .
 
 # Install pip
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.10 1
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python get-pip.py && rm -rf get-pip.py
-RUN pip install --no-cache-dir . 
+RUN pip install --no-cache-dir . && \
+    pip uninstall -y setuptools
 WORKDIR /thirdparty
 RUN if [ "$INSTALL_SOURCES" = "yes" ]; then \
     pip install --no-cache-dir pip-licenses; \


### PR DESCRIPTION
This PR attempts to reduce number of `Trivy` scan issues by building and installing latest `Python 10` version from source.