### PR TITLE
Fix sphinx build warnings

### DIFF
--- a/docs/about/features.rst
+++ b/docs/about/features.rst
@@ -16,7 +16,7 @@ Running a Federation
 Task Runner
     Define an experiment and distribute it manually. All participants can verify model code and FL plan prior to execution. 
     The federation is terminated when the experiment is finished. Formerly known as the aggregator-based workflow.
-    `For more info <features_index/taskrunner.html>`_
+    For more info see :doc:`features_index/taskrunner`
 
     .. toctree::
         :hidden:
@@ -26,7 +26,7 @@ Task Runner
 Interactive
     Setup long-lived components to run many experiments in series. Recommended for FL research when many changes to model, dataloader, or hyperparameters are expected.
     Formerly known as the director-based workflow.
-    `For more info <features_index/interactive.html>`_
+    For more info see :doc:`features_index/interactive`
 
     .. toctree::
         :hidden:
@@ -36,7 +36,7 @@ Interactive
 Workflow Interface (Experimental)
     Formulate the experiment as a series of tasks, or a flow. Every flow begins with the start task and concludes with end.
     Heavily influenced by the interface and design of Netflix's Metaflow, the popular framework for data scientists. 
-    `For more info <features_index/workflowinterface.html>`_
+    For more info see :doc:`features_index/workflowinterface`
 
     .. toctree::
         :hidden:
@@ -91,7 +91,7 @@ FedCurv
 Federated Evaluation
 ---------------------
 
-Evaluate the accuracy and performance of your model on data distributed across decentralized nodes without comprimising data privacy and security. `For more info <features_index/fed_eval.html>`_
+Evaluate the accuracy and performance of your model on data distributed across decentralized nodes without comprimising data privacy and security. For more info see :doc:`features_index/fed_eval`
 
 .. toctree::
     :hidden:
@@ -104,7 +104,7 @@ Evaluate the accuracy and performance of your model on data distributed across d
 Privacy Meter
 ---------------------
 
-Quantitatively audit data privacy in statistical and machine learning algorithms. `For more info <features_index/privacy_meter.html>`_
+Quantitatively audit data privacy in statistical and machine learning algorithms. For more info see :doc:`features_index/privacy_meter`
     
 .. toctree::
     :hidden:

--- a/docs/about/features_index/pynative.rst
+++ b/docs/about/features_index/pynative.rst
@@ -1,6 +1,11 @@
 .. # Copyright (C) 2020-2023 Intel Corporation
 .. # SPDX-License-Identifier: Apache-2.0
 
+.. this page is not be included yet, so it's marked as an orphan.
+.. Remove the below line when you're ready to publish this page.
+
+:orphan:
+
 =================
 Python Native API
 =================

--- a/docs/about/overview.how_can_intel_protect_federated_learning.rst
+++ b/docs/about/overview.how_can_intel_protect_federated_learning.rst
@@ -1,6 +1,11 @@
 .. # Copyright (C) 2020-2023 Intel Corporation
 .. # SPDX-License-Identifier: Apache-2.0
 
+.. this page is not be included yet, so it's marked as an orphan.
+.. Remove the below line when you're ready to publish this page.
+
+:orphan:
+
 *****************************************
 How Can Intel Protect Federated Learning?
 *****************************************

--- a/docs/about/overview.what_is_intel_federated_learning.rst
+++ b/docs/about/overview.what_is_intel_federated_learning.rst
@@ -1,6 +1,11 @@
 .. # Copyright (C) 2020-2023 Intel Corporation
 .. # SPDX-License-Identifier: Apache-2.0
 
+.. this page is not be included yet, so it's marked as an orphan.
+.. Remove the below line when you're ready to publish this page.
+
+:orphan:
+
 *********************************************
 What is Intel\ :sup:`®` \ Federated Learning?
 *********************************************

--- a/docs/about/releases.md
+++ b/docs/about/releases.md
@@ -1,12 +1,11 @@
-Releases
-==========
+# Releases
 
 ## 1.5.1
 [Full Release Notes](https://github.com/securefederatedai/openfl/releases/tag/v1.5.1)
 
 We are excited to announce the release of OpenFL 1.5.1 - our first since moving to LF AI & Data! This release brings the following changes.
 
-### Highlights
+### 1.5.1 Highlights
 - **Documentation accessibility improvements**: As part of our [Global Accessibility Awareness Day](https://www.intel.com/content/www/us/en/developer/articles/community/open-fl-project-improve-accessibility-for-devs.html) (GAAD) Pledge, the OpenFL project is making strides towards more accessible documentation. This release includes the integration of [Intel® One Mono](https://www.intel.com/content/www/us/en/company-overview/one-monospace-font.html) font, contrast color improvements, formatting improvements, and [new accessibility focused issues](https://github.com/securefederatedai/openfl/issues?q=is%3Aissue+is%3Aopen+accessibility) to take up in the future. 
 - **[Documentation to federate a Generally Nuanced Deep Learning Framework (GaNDLF) model with OpenFL](https://openfl.readthedocs.io/en/latest/running_the_federation_with_gandlf.html)**
 - **New OpenFL Interactive API Tutorials**:
@@ -21,7 +20,7 @@ We are excited to announce the release of OpenFL 1.5.1 - our first since moving 
 ## 1.5
 [Full Release Notes](https://github.com/securefederatedai/openfl/releases/tag/v1.5)
 
-### Highlights
+### 1.5 Highlights
 * **New Workflows Interface (Experimental)** - a new way of composing federated learning experiments inspired by [Metaflow](https://github.com/Netflix/metaflow). Enables the creation of custom aggregator and collaborators tasks. This initial release is intended for simulation on a single node (using the LocalRuntime); distributed execution (FederatedRuntime) to be enabled in a future release. 
 * **New use cases enabled by the workflow interface**:
     * **[End-of-round validation with aggregator dataset](https://github.com/intel/openfl/blob/develop/openfl-tutorials/experimental/Workflow_Interface_102_Aggregator_Validation.ipynb)** 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,7 +73,7 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db',
+exclude_patterns = ['_build', 'Thumbs.db', 'README.md', 'structurizer_dsl/README.md',
                     '.DS_Store', 'tutorials/*', 'graveyard/*']
 # add temporary unused files
 exclude_patterns.extend(['modules.rst',

--- a/docs/developer_guide/experimental_features.rst
+++ b/docs/developer_guide/experimental_features.rst
@@ -26,4 +26,4 @@ Experimental features are *not* ready for production. These features are under a
    :maxdepth: 4
    :hidden:
 
-   workflow_interface 
+   ../about/features_index/workflowinterface

--- a/docs/developer_guide/running_the_federation.singularity.rst
+++ b/docs/developer_guide/running_the_federation.singularity.rst
@@ -1,6 +1,11 @@
 .. # Copyright (C) 2020-2023 Intel Corporation
 .. # SPDX-License-Identifier: Apache-2.0
 
+.. this page is not be included yet, so it's marked as an orphan.
+.. Remove the below line when you're ready to publish this page.
+
+:orphan:
+
 .. _running_the_federation_singularity:
 
 Running on Singularity

--- a/docs/get_started/examples.rst
+++ b/docs/get_started/examples.rst
@@ -39,9 +39,9 @@ See :ref:`interactive_tensorflow_mnist`
 
     examples/interactive_tensorflow_mnist
 
--------------------------
+---------------------------------
 Workflow Interface (Experimental)
--------------------------
+---------------------------------
 Formulate the experiment as a series of tasks, or a flow. 
 
 See :ref:`workflowinterface_pytorch_mnist`

--- a/docs/get_started/install.singularity.rst
+++ b/docs/get_started/install.singularity.rst
@@ -1,6 +1,11 @@
 .. # Copyright (C) 2020-2023 Intel Corporation
 .. # SPDX-License-Identifier: Apache-2.0
 
+.. this page is not be included yet, so it's marked as an orphan.
+.. Remove the below line when you're ready to publish this page.
+
+:orphan:
+
 .. _install_singularity:
 
 Singularity Installation


### PR DESCRIPTION
This PR resolves all the below warnings experienced during `make html`:

```
/Users/pboushy/excl/git-repos/openfl/docs/about/features.rst:6: WARNING: Duplicate explicit target name: "for more info".
/Users/pboushy/excl/git-repos/openfl/docs/about/features.rst:6: WARNING: Duplicate explicit target name: "for more info".
/Users/pboushy/excl/git-repos/openfl/docs/about/features.rst:6: WARNING: Duplicate explicit target name: "for more info".
/Users/pboushy/excl/git-repos/openfl/docs/about/features.rst:6: WARNING: Duplicate explicit target name: "for more info".
/Users/pboushy/excl/git-repos/openfl/docs/about/releases.md:24: WARNING: duplicate label about/releases:highlights, other instance in /Users/pboushy/excl/git-repos/openfl/docs/about/releases.md
/Users/pboushy/excl/git-repos/openfl/docs/developer_guide/experimental_features.rst:25: WARNING: toctree contains reference to nonexisting document 'developer_guide/workflow_interface'
/Users/pboushy/excl/git-repos/openfl/docs/get_started/examples.rst:42: WARNING: Title overline too short.

-------------------------
Workflow Interface (Experimental)
-------------------------
/Users/pboushy/excl/git-repos/openfl/docs/get_started/examples.rst:42: WARNING: Title overline too short.

-------------------------
Workflow Interface (Experimental)
-------------------------
looking for now-outdated files... none found
pickling environment... done
checking consistency... /Users/pboushy/excl/git-repos/openfl/docs/README.md: WARNING: document isn't included in any toctree
/Users/pboushy/excl/git-repos/openfl/docs/about/features_index/pynative.rst: WARNING: document isn't included in any toctree
/Users/pboushy/excl/git-repos/openfl/docs/about/overview.how_can_intel_protect_federated_learning.rst: WARNING: document isn't included in any toctree
/Users/pboushy/excl/git-repos/openfl/docs/about/overview.what_is_intel_federated_learning.rst: WARNING: document isn't included in any toctree
/Users/pboushy/excl/git-repos/openfl/docs/developer_guide/running_the_federation.singularity.rst: WARNING: document isn't included in any toctree
/Users/pboushy/excl/git-repos/openfl/docs/get_started/install.singularity.rst: WARNING: document isn't included in any toctree
/Users/pboushy/excl/git-repos/openfl/docs/structurizer_dsl/README.md: WARNING: document isn't included in any toctree
```

NOTE - please double check the exclusion of README.md files from conf.py - they do not appear to be necessary for the website, but I was not certain.