### PR TITLE
Stop suppressing gandlf config errors

### DIFF
--- a/openfl/federated/task/runner_gandlf.py
+++ b/openfl/federated/task/runner_gandlf.py
@@ -48,10 +48,7 @@ class GaNDLFTaskRunner(TaskRunner):
         if isinstance(gandlf_config, str) and os.path.exists(gandlf_config):
             gandlf_config = yaml.safe_load(open(gandlf_config, "r"))
 
-        try:
-            gandlf_config = ConfigManager(gandlf_config)
-        except Exception:
-            self.logger.info("WARNING: GANDLF.config_manager.ConfigManager did not work.")
+        gandlf_config = ConfigManager(gandlf_config)
 
         (
             model,


### PR DESCRIPTION
If gandlf config cannot be parsed properly (typos, wrong values, etc), now the error is just suppressed without any meaningful error and `gandlf_config` variable is just broken.

Fix ensures
1. runner fails if gandlf config cannot be parsed,
2. if any errors, they are printed to logs with their stack trace