### PR TITLE
Minor updates to docker Makefile and scan job

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Build an image from Dockerfile
         run: |
-          docker build -t docker.io/securefederatedai/openfl:${{ github.sha }} -f openfl-docker/Dockerfile.base .
+          docker build --pull -t docker.io/securefederatedai/openfl:${{ github.sha }} -f openfl-docker/Dockerfile.base .
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master

--- a/openfl-docker/Dockerfile.base
+++ b/openfl-docker/Dockerfile.base
@@ -79,6 +79,7 @@ RUN apt-get update && \
         openssh-server=\* \
         curl=\* \
         ca-certificates=\* && \
+    rm -rf /etc/ssh/ssh_host_*_key && \
     if [ "$INSTALL_SOURCES" = "yes" ]; then \
         dpkg --get-selections | grep -v deinstall | awk '{print $1}' > all_packages.txt && \
         sed -Ei 's/# deb-src /deb-src /' /etc/apt/sources.list && \

--- a/openfl-docker/Makefile
+++ b/openfl-docker/Makefile
@@ -1,6 +1,6 @@
 build:
-	@docker build -t openfl -f Dockerfile.base ..
+	@docker build --pull -t openfl -f Dockerfile.base ..
 run:
-	@docker run -it --network host openfl
+	@docker run --rm -it --network host openfl
 save:
-	@docker save openfl > openfl.tar
+	@docker save openfl | gzip > openfl.tar.gz


### PR DESCRIPTION
This PR:
- updates `Makefile` and `Trivy` workspace file so that the `docker build` always pulls latest base `ubuntu:22.04` first
-  updates `Makefile` so that the container is saved in `gzip` format rather than `tar` so the saved image has a smaller footprint:
```
$ du -sh openfl.tar*
1.2G 	openfl.tar
463M	openfl.tar.gz
```
- Removes stock ssh keys installed under `/etc/ssh/` by openssh server, since they are not needed and also `Trivy` flags them incorrectly as `secrets` left on the container.