### PR TITLE
Standardize linting and formatting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,101 +1,78 @@
 # Contributing to OpenFL
 
-We welcome contributions from the community. We believe that anyone can bring something valuable to OpenFL and help us to improve the project. This document explains how to contribute to OpenFL. 
+We welcome contributions from the community. There are several ways to contribute:
+* Improvements in [documentation](https://openfl.readthedocs.io/en/latest/install.html).
+* Contributing to OpenFL's code-base: via bug-fixes or feature additions.
+* Answering questions on our [discussions page](https://github.com/securefederatedai/openfl/discussions).
+* Participating in our [roadmap](https://github.com/securefederatedai/openfl/blob/develop/ROADMAP.md) discussions.
 
-We accept various contributions from documentation improvement and bug fixing to major features proposals and [roadmap](https://github.com/intel/openfl/blob/develop/ROADMAP.md) suggestions.
+We have a slack [channel](https://join.slack.com/t/openfl/shared_invite/zt-ovzbohvn-T5fApk05~YS_iZhjJ5yaTw) and we host regular [community meetings](https://github.com/intel/openfl#support).
 
-Documentation improvement: review our [documentation](https://openfl.readthedocs.io/en/latest/install.html) and let us know if something is not clear or not relevant. 
-Propose your own formulations or even write new section explaining something that you know how works, but do not see in the documentation. 
-Propose it through GitHub [issues](https://github.com/intel/openfl/issues/new/choose) or [Discussions](https://github.com/intel/openfl/discussions).
 
-To propose bugs, new features, or other code improvements:
+## How to contribute code
+### Step 1. Open an issue
 
-1.	Check open and closed [issues](https://github.com/intel/openfl/issues) and make sure there is no similar proposal.
-2.	Open a [new issue](https://github.com/intel/openfl/issues/new/choose), select a relevant category (Bug report / Feature request / Report a security vulnerability) and describe your idea using the template. 
-3.	If you want to fix a bug or create this feature by yourself, prepare a contribution.
-	-	Format your code following the [flake8 style](https://flake8.pycqa.org/en/latest/).
-	-	Make sure that your code is original and corresponds to [OpenFL license](#license).
-	-	Sing your work - [see below](#sign-your-work). 
-	-	Create a [pull request](#formatting-of-pull-requests) and wait for feedback.
-	-	Verify that all tests in our [CI/CD pipeline](#Continuous-Integration-and-Continuous-Development) passed.
-4.	Hurrah! You are a new contributor to OpenFL! You will see your name in released notes of the subsequent releases!😊
+Before you start making any changes, it is always good to open an [issue](https://github.com/securefederatedai/openfl/issues/new/choose) first (assuming one does not already exist), outlining your proposed changes. We can give you feedback, and potentially validate the proposed changes.
 
-Join our [Slack](https://join.slack.com/t/openfl/shared_invite/zt-ovzbohvn-T5fApk05~YS_iZhjJ5yaTw) and [Community meetings](https://github.com/intel/openfl#support) and participate in the discussions. 
+For minor changes (akin to a documentation or bug fix), proceed to opening a Pull Request (PR) directly.
 
-Are you an expert in Federated Learning and want to contribute to our roadmap? You can nominate yourself as a member of our Technical Steering Committee and be part of the OpenFL decision making group. Please reach us through our [Slack](https://join.slack.com/t/openfl/shared_invite/zt-ovzbohvn-T5fApk05~YS_iZhjJ5yaTw).
+### Step 2. Make code changes
 
-### Code format and style
+To modify code, you need to fork the repository. Set up a development environment as covered in the section "Setup environment" below.
 
-We use [flake8](https://flake8.pycqa.org/en/latest/) for PEP8 style guide enforcement. This is run as a part of our CI/CD pipeline and it’s required prior a merge. 
+### Step 3. Create a Pull Request (PR)
 
-### Formatting of Pull Requests
+Once the change is ready, open a PR from your branch in your fork, to the `develop` branch in [securefederatedai/openfl](https://github.com/securefederatedai/openfl). OpenFL follows standard recommendations of PR formatting. Find more details [here](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/).
 
-OpenFL follows standard recommendations of PR formatting. Please find more details [here](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/).
+### Step 4. Sign your work
 
-### Continuous Integration and Continuous Development
-
-OpenFL uses GitHub actions to perform all functional and unit tests. Before your contribution can be merged make sure that all your tests are passing. 
-For more information of what fails you can click on the “details” link near the pipeline that failed.
-
-![CI/CD](docs/images/CI_details.png)
- 
-### Writing the tests
-
-The OpenFL team recommend including tests for all new features contributions. Test can be found in the “Tests” directory. 
-The [Tests/OpenFL folder](https://github.com/intel/openfl/tree/develop/tests/openfl) contains unit tests and the [Tests/GitHub folder](https://github.com/intel/openfl/tree/develop/tests/github) contains end-to-end and functional tests.
-
-### License
-
-OpenFL is licensed under the terms in [Apache 2.0 license](https://github.com/intel/openfl/blob/develop/LICENSE). By contributing to the project, you agree to the license and copyright terms therein and release your contribution under these terms.
-
-### Sign your work
-
-Please use the sign-off line at the end of the patch. Your signature certifies that you wrote the patch or otherwise have the right to pass it on as an open-source patch. The rules are pretty simple: if you can certify
-the below (from [developercertificate.org](http://developercertificate.org/)):
-
-```
-Developer Certificate of Origin
-Version 1.1
-
-Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
-660 York Street, Suite 102,
-San Francisco, CA 94110 USA
-
-Everyone is permitted to copy and distribute verbatim copies of this
-license document, but changing it is not allowed.
-
-Developer's Certificate of Origin 1.1
-
-By making a contribution to this project, I certify that:
-
-(a) The contribution was created in whole or in part by me and I
-    have the right to submit it under the open source license
-    indicated in the file; or
-
-(b) The contribution is based upon previous work that, to the best
-    of my knowledge, is covered under an appropriate open source
-    license and I have the right under that license to submit that
-    work with modifications, whether created in whole or in part
-    by me, under the same open source license (unless I am
-    permitted to submit under a different license), as indicated
-    in the file; or
-
-(c) The contribution was provided directly to me by some other
-    person who certified (a), (b) or (c) and I have not modified
-    it.
-
-(d) I understand and agree that this project and the contribution
-    are public and that a record of the contribution (including all
-    personal information I submit with it, including my sign-off) is
-    maintained indefinitely and may be redistributed consistent with
-    this project or the open source license(s) involved.
-```
-
-Then you just add a line to every git commit message:
+Signoff your patch commits using your real name. We discourage anonymous contributions.
 
     Signed-off-by: Joe Smith <joe.smith@email.com>
 
-Use your real name (sorry, no pseudonyms or anonymous contributions.)
-
 If you set your `user.name` and `user.email` git configs, you can sign your
-commit automatically with `git commit -s`.
+commits using `git commit --signoff`.
+
+Your signature [certifies](http://developercertificate.org/) that you wrote the patch, or, you otherwise have the right to pass it on as an open-source patch.
+
+OpenFL is licensed under the [Apache 2.0 license](https://github.com/intel/openfl/blob/develop/LICENSE). By contributing to the project, you agree to the license and copyright terms therein and release your contribution under these terms.
+
+### Step 5. Code review and merge
+
+Verify that your contribution passes all tests in our CI/CD pipeline. In case of a failure, like shown below, look into the error messages and try to fix them.
+
+![CI/CD](docs/images/CI_details.png)
+
+Meanwhile, a reviewer will review the pull request and provide comments. Post few iterations of
+reviews and changes (depending on the complexity of the changes), PR will be approved for merge.
+
+## Setup environment
+
+We recommend setting up a local dev environment. Clone your forked repo to your local machine and install the dependencies.
+
+```shell
+git clone https://github.com/YOUR_GITHUB_USERNAME/openfl.git
+cd openfl
+pip install -U pip setuptools wheel
+pip install .
+```
+
+## Code style
+
+OpenFL uses [black](https://black.readthedocs.io/en/stable/) and [isort](https://pycqa.github.io/isort/) to format the code.
+
+Run the following command at the **root** directory of the repo to format your code.
+
+```
+sh shell/format.sh
+```
+You may need to resolve errors that could not be resolved by autoformatting. To only show lint errors, run `sh shell/lint.sh` at the **root** directory of the repo.
+
+### Docstrings
+Since docstrings cannot be checked or standardized, if you do write/edit any docstring, make sure to check them manually. OpenFL docstrings should follow the conventions below:
+
+A **class** or a **function** docstring may contain:
+* A one-line description of the class/function.
+* Paragraph(s) of detailed information.
+* Optional `Examples` section.
+* `Args` section for arguments under `__init__()`.

--- a/openfl/experimental/component/__init__.py
+++ b/openfl/experimental/component/__init__.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """openfl.experimental.component package."""
 
-from .aggregator import Aggregator
-from .collaborator import Collaborator
-
-__all__ = ["Aggregator", "Collaborator"]
+# FIXME: Too much recursion
+from openfl.experimental.component.aggregator import Aggregator
+from openfl.experimental.component.collaborator import Collaborator

--- a/openfl/experimental/component/__init__.py
+++ b/openfl/experimental/component/__init__.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2020-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
 """openfl.experimental.component package."""
 
 from .aggregator import Aggregator

--- a/openfl/experimental/component/aggregator/__init__.py
+++ b/openfl/experimental/component/aggregator/__init__.py
@@ -1,8 +1,9 @@
 # Copyright (C) 2020-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
 """openfl.experimental.component.aggregator package."""
 
 from .aggregator import Aggregator
 
-__all__ = ["Aggregator",]
+__all__ = [
+    "Aggregator",
+]

--- a/openfl/experimental/component/aggregator/__init__.py
+++ b/openfl/experimental/component/aggregator/__init__.py
@@ -2,8 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 """openfl.experimental.component.aggregator package."""
 
-from .aggregator import Aggregator
-
-__all__ = [
-    "Aggregator",
-]
+# FIXME: Too much recursion.
+from openfl.experimental.component.aggregator import Aggregator

--- a/openfl/experimental/component/aggregator/aggregator.py
+++ b/openfl/experimental/component/aggregator/aggregator.py
@@ -2,18 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Experimental Aggregator module."""
-import time
-import queue
-import pickle
 import inspect
-from threading import Event
+import pickle
+import queue
+import time
 from logging import getLogger
-from typing import Any, Callable
-from typing import Dict, List, Tuple
+from threading import Event
+from typing import Any, Callable, Dict, List, Tuple
 
-from openfl.experimental.utilities import aggregator_to_collaborator
 from openfl.experimental.runtime import FederatedRuntime
-from openfl.experimental.utilities import checkpoint
+from openfl.experimental.utilities import (aggregator_to_collaborator,
+                                           checkpoint)
 from openfl.experimental.utilities.metaflow_utils import MetaflowInterface
 
 
@@ -222,9 +221,7 @@ class Aggregator:
             None
         """
         if self.checkpoint:
-            from openfl.experimental.interface import (
-                FLSpec,
-            )
+            from openfl.experimental.interface import FLSpec
 
             # Check if arguments are pickled, if yes then unpickle
             if not isinstance(ctx, FLSpec):

--- a/openfl/experimental/component/aggregator/aggregator.py
+++ b/openfl/experimental/component/aggregator/aggregator.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2020-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
 """Experimental Aggregator module."""
 import inspect
 import pickle
@@ -35,22 +34,18 @@ class Aggregator:
         None
     """
 
-    def __init__(
-            self,
-            aggregator_uuid: str,
-            federation_uuid: str,
-            authorized_cols: List,
-
-            flow: Any,
-            rounds_to_train: int = 1,
-            checkpoint: bool = False,
-            private_attributes_callable: Callable = None,
-            private_attributes_kwargs: Dict = {},
-
-            single_col_cert_common_name: str = None,
-
-            log_metric_callback: Callable = None,
-            **kwargs) -> None:
+    def __init__(self,
+                 aggregator_uuid: str,
+                 federation_uuid: str,
+                 authorized_cols: List,
+                 flow: Any,
+                 rounds_to_train: int = 1,
+                 checkpoint: bool = False,
+                 private_attributes_callable: Callable = None,
+                 private_attributes_kwargs: Dict = {},
+                 single_col_cert_common_name: str = None,
+                 log_metric_callback: Callable = None,
+                 **kwargs) -> None:
 
         self.logger = getLogger(__name__)
 
@@ -80,16 +75,16 @@ class Aggregator:
         # Event to inform aggregator that collaborators have sent the results
         self.collaborator_task_results = Event()
         # A queue for each task
-        self.__collaborator_tasks_queue = {collab: queue.Queue() for collab
-                                           in self.authorized_cols}
+        self.__collaborator_tasks_queue = {
+            collab: queue.Queue() for collab in self.authorized_cols
+        }
 
         self.flow = flow
         self.checkpoint = checkpoint
         self.flow._foreach_methods = []
         self.logger.info("MetaflowInterface creation.")
         self.flow._metaflow_interface = MetaflowInterface(
-            self.flow.__class__, "single_process"
-        )
+            self.flow.__class__, "single_process")
         self.flow._run_id = self.flow._metaflow_interface.create_run()
         self.flow.runtime = FederatedRuntime()
         self.flow.runtime.aggregator = "aggregator"
@@ -110,9 +105,7 @@ class Aggregator:
         Call private_attrs_callable function set
             attributes to self.__private_attrs.
         """
-        self.__private_attrs = self.__private_attrs_callable(
-            **kwargs
-        )
+        self.__private_attrs = self.__private_attrs_callable(**kwargs)
 
     def __set_attributes_to_clone(self, clone: Any) -> None:
         """
@@ -122,7 +115,9 @@ class Aggregator:
             for name, attr in self.__private_attrs.items():
                 setattr(clone, name, attr)
 
-    def __delete_agg_attrs_from_clone(self, clone: Any, replace_str: str = None) -> None:
+    def __delete_agg_attrs_from_clone(self,
+                                      clone: Any,
+                                      replace_str: str = None) -> None:
         """
         Remove aggregator private attributes from FLSpec clone before
         transition from Aggregator step to collaborator steps.
@@ -132,7 +127,8 @@ class Aggregator:
         if len(self.__private_attrs) > 0:
             for attr_name in self.__private_attrs:
                 if hasattr(clone, attr_name):
-                    self.__private_attrs.update({attr_name: getattr(clone, attr_name)})
+                    self.__private_attrs.update(
+                        {attr_name: getattr(clone, attr_name)})
                     if replace_str:
                         setattr(clone, attr_name, replace_str)
                     else:
@@ -144,8 +140,7 @@ class Aggregator:
             f"\n{the_dragon}\nYOU ARE RUNNING IN SINGLE COLLABORATOR CERT MODE! THIS IS"
             f" NOT PROPER PKI AND "
             f"SHOULD ONLY BE USED IN DEVELOPMENT SETTINGS!!!! YE HAVE BEEN"
-            f" WARNED!!!"
-        )
+            f" WARNED!!!")
 
     @staticmethod
     def _get_sleep_time() -> int:
@@ -185,27 +180,34 @@ class Aggregator:
                 len_connected_collabs = len(self.connected_collaborators)
                 if len_connected_collabs < len_sel_collabs:
                     # Waiting for collaborators to connect.
-                    self.logger.info("Waiting for "
-                                     + f"{len_connected_collabs}/{len_sel_collabs}"
-                                     + " collaborators to connect...")
+                    self.logger.info(
+                        "Waiting for " +
+                        f"{len_connected_collabs}/{len_sel_collabs}" +
+                        " collaborators to connect...")
                 elif self.tasks_sent_to_collaborators != len_sel_collabs:
-                    self.logger.info("Waiting for "
-                                     + f"{self.tasks_sent_to_collaborators}/{len_sel_collabs}"
-                                     + " to make requests for tasks...")
+                    self.logger.info(
+                        "Waiting for " +
+                        f"{self.tasks_sent_to_collaborators}/{len_sel_collabs}"
+                        + " to make requests for tasks...")
                 else:
                     # Waiting for selected collaborators to send the results.
-                    self.logger.info("Waiting for "
-                                     + f"{self.collaborators_counter}/{len_sel_collabs}"
-                                     + " collaborators to send results...")
+                    self.logger.info(
+                        "Waiting for " +
+                        f"{self.collaborators_counter}/{len_sel_collabs}" +
+                        " collaborators to send results...")
                 time.sleep(Aggregator._get_sleep_time())
 
             self.collaborator_task_results.clear()
             f_name = self.next_step
             if hasattr(self, "instance_snapshot"):
-                self.flow.restore_instance_snapshot(self.flow, list(self.instance_snapshot))
+                self.flow.restore_instance_snapshot(
+                    self.flow, list(self.instance_snapshot))
                 delattr(self, "instance_snapshot")
 
-    def call_checkpoint(self, ctx: Any, f: Callable, stream_buffer: bytes = None) -> None:
+    def call_checkpoint(self,
+                        ctx: Any,
+                        f: Callable,
+                        stream_buffer: bytes = None) -> None:
         """
         Perform checkpoint task.
 
@@ -232,7 +234,8 @@ class Aggregator:
                 f = pickle.loads(f)
             if isinstance(stream_buffer, bytes):
                 # Set stream buffer as function parameter
-                setattr(f.__func__, "_stream_buffer", pickle.loads(stream_buffer))
+                setattr(f.__func__, "_stream_buffer",
+                        pickle.loads(stream_buffer))
 
             checkpoint(ctx, f)
 
@@ -263,10 +266,12 @@ class Aggregator:
             # If it is time to then inform the collaborator
             if self.time_to_quit:
                 self.logger.info(
-                    f"Sending signal to collaborator {collaborator_name} to shutdown...")
+                    f"Sending signal to collaborator {collaborator_name} to shutdown..."
+                )
                 # FIXME: 0, and "" instead of None is just for protobuf compatibility.
                 #  Cleaner solution?
-                return 0, "", None, Aggregator._get_sleep_time(), self.time_to_quit
+                return 0, "", None, Aggregator._get_sleep_time(
+                ), self.time_to_quit
 
             # If not time to quit then sleep for 10 seconds
             time.sleep(Aggregator._get_sleep_time())
@@ -276,9 +281,11 @@ class Aggregator:
             collaborator_name].get()
 
         self.tasks_sent_to_collaborators += 1
-        self.logger.info("Sending tasks to collaborator"
-                         + f" {collaborator_name} for round {self.current_round}...")
-        return self.current_round, next_step, pickle.dumps(clone), 0, self.time_to_quit
+        self.logger.info(
+            "Sending tasks to collaborator" +
+            f" {collaborator_name} for round {self.current_round}...")
+        return self.current_round, next_step, pickle.dumps(
+            clone), 0, self.time_to_quit
 
     def do_task(self, f_name: str) -> Any:
         """
@@ -303,7 +310,8 @@ class Aggregator:
             if f.__name__ == "end":
                 f()
                 # Take the checkpoint of "end" step
-                self.__delete_agg_attrs_from_clone(self.flow, "Private attributes: Not Available.")
+                self.__delete_agg_attrs_from_clone(
+                    self.flow, "Private attributes: Not Available.")
                 self.call_checkpoint(self.flow, f)
                 self.__set_attributes_to_clone(self.flow)
                 # Check if all rounds of external loop is executed
@@ -339,7 +347,8 @@ class Aggregator:
             # clones are arguments
             f(*selected_clones)
 
-            self.__delete_agg_attrs_from_clone(self.flow, "Private attributes: Not Available.")
+            self.__delete_agg_attrs_from_clone(
+                self.flow, "Private attributes: Not Available.")
             # Take the checkpoint of executed step
             self.call_checkpoint(self.flow, f)
             self.__set_attributes_to_clone(self.flow)
@@ -358,7 +367,8 @@ class Aggregator:
                     temp = self.flow.execute_task_args[3:]
                     self.clones_dict, self.instance_snapshot, self.kwargs = temp
 
-                    self.selected_collaborators = getattr(self.flow, self.kwargs["foreach"])
+                    self.selected_collaborators = getattr(
+                        self.flow, self.kwargs["foreach"])
                 else:
                     self.kwargs = self.flow.execute_task_args[3]
 
@@ -370,8 +380,8 @@ class Aggregator:
 
         return f_name if f_name != "end" else None
 
-    def send_task_results(self, collab_name: str, round_number: int, next_step: str,
-                          clone_bytes: bytes) -> None:
+    def send_task_results(self, collab_name: str, round_number: int,
+                          next_step: str, clone_bytes: bytes) -> None:
         """
         After collaborator execution, collaborator will call this function via gRPc
             to send next function.
@@ -389,13 +399,10 @@ class Aggregator:
         if round_number is not self.current_round:
             self.logger.warning(
                 f"Collaborator {collab_name} is reporting results"
-                f" for the wrong round: {round_number}. Ignoring..."
-            )
+                f" for the wrong round: {round_number}. Ignoring...")
         else:
-            self.logger.info(
-                f"Collaborator {collab_name} sent task results"
-                f" for round {round_number}."
-            )
+            self.logger.info(f"Collaborator {collab_name} sent task results"
+                             f" for round {round_number}.")
         # Unpickle the clone (FLSpec object)
         clone = pickle.loads(clone_bytes)
         # Update the clone in clones_dict dictionary
@@ -409,7 +416,8 @@ class Aggregator:
             # Set the event to inform aggregator to resume the flow execution
             self.collaborator_task_results.set()
             # Empty tasks_sent_to_collaborators list for next time.
-            if self.tasks_sent_to_collaborators == len(self.selected_collaborators):
+            if self.tasks_sent_to_collaborators == len(
+                    self.selected_collaborators):
                 self.tasks_sent_to_collaborators = 0
 
     def valid_collaborator_cn_and_id(self, cert_common_name: str,
@@ -430,13 +438,13 @@ class Aggregator:
         # FIXME: "" instead of None is just for protobuf compatibility.
         #  Cleaner solution?
         if self.single_col_cert_common_name == "":
-            return (cert_common_name == collaborator_common_name
-                    and collaborator_common_name in self.authorized_cols)
+            return (cert_common_name == collaborator_common_name and
+                    collaborator_common_name in self.authorized_cols)
         # otherwise, common_name must be in whitelist and
         # collaborator_common_name must be in authorized_cols
         else:
-            return (cert_common_name == self.single_col_cert_common_name
-                    and collaborator_common_name in self.authorized_cols)
+            return (cert_common_name == self.single_col_cert_common_name and
+                    collaborator_common_name in self.authorized_cols)
 
     def all_quit_jobs_sent(self) -> bool:
         """Assert all quit jobs are sent to collaborators."""

--- a/openfl/experimental/component/aggregator/aggregator.py
+++ b/openfl/experimental/component/aggregator/aggregator.py
@@ -10,8 +10,7 @@ from threading import Event
 from typing import Any, Callable, Dict, List, Tuple
 
 from openfl.experimental.runtime import FederatedRuntime
-from openfl.experimental.utilities import (aggregator_to_collaborator,
-                                           checkpoint)
+from openfl.experimental.utilities import aggregator_to_collaborator, checkpoint
 from openfl.experimental.utilities.metaflow_utils import MetaflowInterface
 
 

--- a/openfl/experimental/component/collaborator/__init__.py
+++ b/openfl/experimental/component/collaborator/__init__.py
@@ -1,8 +1,9 @@
 # Copyright (C) 2020-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
 """openfl.experimental.component.collaborator package."""
 
 from .collaborator import Collaborator
 
-__all__ = ["Collaborator",]
+__all__ = [
+    "Collaborator",
+]

--- a/openfl/experimental/component/collaborator/__init__.py
+++ b/openfl/experimental/component/collaborator/__init__.py
@@ -2,8 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 """openfl.experimental.component.collaborator package."""
 
-from .collaborator import Collaborator
-
-__all__ = [
-    "Collaborator",
-]
+# FIXME: Too much recursion.
+from openfl.experimental.component.collaborator.collaborator import Collaborator

--- a/openfl/experimental/component/collaborator/collaborator.py
+++ b/openfl/experimental/component/collaborator/collaborator.py
@@ -26,14 +26,16 @@ class Collaborator:
         \* - Plan setting.
     """
 
-    def __init__(self,
-                 collaborator_name: str,
-                 aggregator_uuid: str,
-                 federation_uuid: str,
-                 client: Any,
-                 private_attributes_callable: Any = None,
-                 private_attributes_kwargs: Dict = {},
-                 **kwargs) -> None:
+    def __init__(
+        self,
+        collaborator_name: str,
+        aggregator_uuid: str,
+        federation_uuid: str,
+        client: Any,
+        private_attributes_callable: Any = None,
+        private_attributes_kwargs: Dict = {},
+        **kwargs,
+    ) -> None:
 
         self.name = collaborator_name
         self.aggregator_uuid = aggregator_uuid
@@ -78,9 +80,9 @@ class Collaborator:
             for name, attr in self.__private_attrs.items():
                 setattr(clone, name, attr)
 
-    def __delete_agg_attrs_from_clone(self,
-                                      clone: Any,
-                                      replace_str: str = None) -> None:
+    def __delete_agg_attrs_from_clone(
+        self, clone: Any, replace_str: str = None
+    ) -> None:
         """
         Remove aggregator private attributes from FLSpec clone before
         transition from Aggregator step to collaborator steps
@@ -98,14 +100,16 @@ class Collaborator:
             for attr_name in self.__private_attrs:
                 if hasattr(clone, attr_name):
                     self.__private_attrs.update(
-                        {attr_name: getattr(clone, attr_name)})
+                        {attr_name: getattr(clone, attr_name)}
+                    )
                     if replace_str:
                         setattr(clone, attr_name, replace_str)
                     else:
                         delattr(clone, attr_name)
 
-    def call_checkpoint(self, ctx: Any, f: Callable,
-                        stream_buffer: Any) -> None:
+    def call_checkpoint(
+        self, ctx: Any, f: Callable, stream_buffer: Any
+    ) -> None:
         """
         Call checkpoint gRPC.
 
@@ -117,9 +121,12 @@ class Collaborator:
         Returns:
             None
         """
-        self.client.call_checkpoint(self.name,
-                                    pickle.dumps(ctx), pickle.dumps(f),
-                                    pickle.dumps(stream_buffer))
+        self.client.call_checkpoint(
+            self.name,
+            pickle.dumps(ctx),
+            pickle.dumps(f),
+            pickle.dumps(stream_buffer),
+        )
 
     def run(self) -> None:
         """
@@ -156,10 +163,13 @@ class Collaborator:
         Returns:
             None
         """
-        self.logger.info(f"Round {self.round_number},"
-                         f" collaborator {self.name} is sending results...")
-        self.client.send_task_results(self.name, self.round_number, next_step,
-                                      pickle.dumps(clone))
+        self.logger.info(
+            f"Round {self.round_number},"
+            f" collaborator {self.name} is sending results..."
+        )
+        self.client.send_task_results(
+            self.name, self.round_number, next_step, pickle.dumps(clone)
+        )
 
     def get_tasks(self) -> Tuple:
         """
@@ -176,7 +186,9 @@ class Collaborator:
         """
         self.logger.info("Waiting for tasks...")
         temp = self.client.get_tasks(self.name)
-        self.round_number, next_step, clone_bytes, sleep_time, time_to_quit = temp
+        self.round_number, next_step, clone_bytes, sleep_time, time_to_quit = (
+            temp
+        )
 
         return next_step, pickle.loads(clone_bytes), sleep_time, time_to_quit
 
@@ -201,7 +213,8 @@ class Collaborator:
             f()
             # Checkpoint the function
             self.__delete_agg_attrs_from_clone(
-                ctx, "Private attributes: Not Available.")
+                ctx, "Private attributes: Not Available."
+            )
             self.call_checkpoint(ctx, f, f._stream_buffer)
             self.__set_attributes_to_clone(ctx)
 

--- a/openfl/experimental/component/collaborator/collaborator.py
+++ b/openfl/experimental/component/collaborator/collaborator.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2020-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
 """Experimental Collaborator module."""
 import pickle
 import time
@@ -26,6 +25,7 @@ class Collaborator:
     Note:
         \* - Plan setting.
     """
+
     def __init__(self,
                  collaborator_name: str,
                  aggregator_uuid: str,
@@ -61,9 +61,7 @@ class Collaborator:
         Returns:
             None
         """
-        self.__private_attrs = self.__private_attrs_callable(
-            **kwrags
-        )
+        self.__private_attrs = self.__private_attrs_callable(**kwrags)
 
     def __set_attributes_to_clone(self, clone: Any) -> None:
         """
@@ -80,7 +78,9 @@ class Collaborator:
             for name, attr in self.__private_attrs.items():
                 setattr(clone, name, attr)
 
-    def __delete_agg_attrs_from_clone(self, clone: Any, replace_str: str = None) -> None:
+    def __delete_agg_attrs_from_clone(self,
+                                      clone: Any,
+                                      replace_str: str = None) -> None:
         """
         Remove aggregator private attributes from FLSpec clone before
         transition from Aggregator step to collaborator steps
@@ -97,13 +97,15 @@ class Collaborator:
         if len(self.__private_attrs) > 0:
             for attr_name in self.__private_attrs:
                 if hasattr(clone, attr_name):
-                    self.__private_attrs.update({attr_name: getattr(clone, attr_name)})
+                    self.__private_attrs.update(
+                        {attr_name: getattr(clone, attr_name)})
                     if replace_str:
                         setattr(clone, attr_name, replace_str)
                     else:
                         delattr(clone, attr_name)
 
-    def call_checkpoint(self, ctx: Any, f: Callable, stream_buffer: Any) -> None:
+    def call_checkpoint(self, ctx: Any, f: Callable,
+                        stream_buffer: Any) -> None:
         """
         Call checkpoint gRPC.
 
@@ -115,10 +117,9 @@ class Collaborator:
         Returns:
             None
         """
-        self.client.call_checkpoint(
-            self.name,
-            pickle.dumps(ctx), pickle.dumps(f), pickle.dumps(stream_buffer)
-        )
+        self.client.call_checkpoint(self.name,
+                                    pickle.dumps(ctx), pickle.dumps(f),
+                                    pickle.dumps(stream_buffer))
 
     def run(self) -> None:
         """
@@ -157,10 +158,8 @@ class Collaborator:
         """
         self.logger.info(f"Round {self.round_number},"
                          f" collaborator {self.name} is sending results...")
-        self.client.send_task_results(
-            self.name, self.round_number,
-            next_step, pickle.dumps(clone)
-        )
+        self.client.send_task_results(self.name, self.round_number, next_step,
+                                      pickle.dumps(clone))
 
     def get_tasks(self) -> Tuple:
         """
@@ -201,7 +200,8 @@ class Collaborator:
             f = getattr(ctx, f_name)
             f()
             # Checkpoint the function
-            self.__delete_agg_attrs_from_clone(ctx, "Private attributes: Not Available.")
+            self.__delete_agg_attrs_from_clone(
+                ctx, "Private attributes: Not Available.")
             self.call_checkpoint(ctx, f, f._stream_buffer)
             self.__set_attributes_to_clone(ctx)
 

--- a/openfl/experimental/component/collaborator/collaborator.py
+++ b/openfl/experimental/component/collaborator/collaborator.py
@@ -2,12 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Experimental Collaborator module."""
-import time
 import pickle
-
-from typing import Any, Callable
-from typing import Dict, Tuple
+import time
 from logging import getLogger
+from typing import Any, Callable, Dict, Tuple
 
 
 class Collaborator:

--- a/openfl/experimental/federated/__init__.py
+++ b/openfl/experimental/federated/__init__.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2020-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
 """openfl.experimental.federated package."""
 
 from .plan import Plan  # NOQA

--- a/openfl/experimental/federated/__init__.py
+++ b/openfl/experimental/federated/__init__.py
@@ -2,6 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 """openfl.experimental.federated package."""
 
-from .plan import Plan  # NOQA
-
-__all__ = ["Plan"]
+# FIXME: Recursion!
+from openfl.experimental.federated.plan import Plan

--- a/openfl/experimental/federated/plan/__init__.py
+++ b/openfl/experimental/federated/plan/__init__.py
@@ -1,8 +1,9 @@
 # Copyright (C) 2020-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
 """Experimental Plan package."""
 
 from .plan import Plan
 
-__all__ = ['Plan',]
+__all__ = [
+    'Plan',
+]

--- a/openfl/experimental/federated/plan/__init__.py
+++ b/openfl/experimental/federated/plan/__init__.py
@@ -2,8 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 """Experimental Plan package."""
 
-from .plan import Plan
-
-__all__ = [
-    "Plan",
-]
+# FIXME: Too much recursion in namespace
+from openfl.experimental.federated.plan.plan import Plan

--- a/openfl/experimental/federated/plan/__init__.py
+++ b/openfl/experimental/federated/plan/__init__.py
@@ -5,5 +5,5 @@
 from .plan import Plan
 
 __all__ = [
-    'Plan',
+    "Plan",
 ]

--- a/openfl/experimental/federated/plan/plan.py
+++ b/openfl/experimental/federated/plan/plan.py
@@ -9,13 +9,11 @@ from logging import getLogger
 from os.path import splitext
 from pathlib import Path
 
-from yaml import dump
-from yaml import safe_load
-from yaml import SafeDumper
+from yaml import SafeDumper, dump, safe_load
 
 from openfl.experimental.interface.cli.cli_helper import WORKSPACE
-from openfl.experimental.transport import AggregatorGRPCClient
-from openfl.experimental.transport import AggregatorGRPCServer
+from openfl.experimental.transport import (AggregatorGRPCClient,
+                                           AggregatorGRPCServer)
 from openfl.utilities.utils import getfqdn_env
 
 SETTINGS = "settings"
@@ -440,8 +438,9 @@ class Plan:
         private_attrs_kwargs = {}
 
         import os
-        from openfl.experimental.federated.plan import Plan
         from pathlib import Path
+
+        from openfl.experimental.federated.plan import Plan
 
         data_yaml = "plan/data.yaml"
 

--- a/openfl/experimental/federated/plan/plan.py
+++ b/openfl/experimental/federated/plan/plan.py
@@ -11,7 +11,10 @@ from pathlib import Path
 from yaml import SafeDumper, dump, safe_load
 
 from openfl.experimental.interface.cli.cli_helper import WORKSPACE
-from openfl.experimental.transport import AggregatorGRPCClient, AggregatorGRPCServer
+from openfl.experimental.transport import (
+    AggregatorGRPCClient,
+    AggregatorGRPCServer,
+)
 from openfl.utilities.utils import getfqdn_env
 
 SETTINGS = "settings"
@@ -47,7 +50,8 @@ class Plan:
             plan = Plan()
             plan.config = config
             frozen_yaml_path = Path(
-                f"{yaml_path.parent}/{yaml_path.stem}_{plan.hash[:8]}.yaml")
+                f"{yaml_path.parent}/{yaml_path.stem}_{plan.hash[:8]}.yaml"
+            )
             if frozen_yaml_path.exists():
                 Plan.logger.info(f"{yaml_path.name} is already frozen")
                 return
@@ -110,7 +114,8 @@ class Plan:
                     if SETTINGS in defaults:
                         # override defaults with section settings
                         defaults[SETTINGS].update(
-                            plan.config[section][SETTINGS])
+                            plan.config[section][SETTINGS]
+                        )
                         plan.config[section][SETTINGS] = defaults[SETTINGS]
 
                     defaults.update(plan.config[section])
@@ -118,7 +123,8 @@ class Plan:
                     plan.config[section] = defaults
 
             plan.authorized_cols = Plan.load(cols_config_path).get(
-                "collaborators", [])
+                "collaborators", []
+            )
 
             if resolve:
                 plan.resolve()
@@ -176,9 +182,11 @@ class Plan:
             extra={"markup": True},
         )
         Plan.logger.debug(
-            f"Settings [red]🡆[/] {settings}", extra={"markup": True})
+            f"Settings [red]🡆[/] {settings}", extra={"markup": True}
+        )
         Plan.logger.debug(
-            f"Override [red]🡆[/] {override}", extra={"markup": True})
+            f"Override [red]🡆[/] {override}", extra={"markup": True}
+        )
 
         settings.update(**override)
         module = import_module(module_path)
@@ -234,7 +242,8 @@ class Plan:
         self.hash_ = sha384(dump(self.config).encode("utf-8"))
         Plan.logger.info(
             f"FL-Plan hash is [blue]{self.hash_.hexdigest()}[/]",
-            extra={"markup": True})
+            extra={"markup": True},
+        )
 
         return self.hash_.hexdigest()
 
@@ -244,30 +253,34 @@ class Plan:
         self.aggregator_uuid = f"aggregator_{self.federation_uuid}"
 
         self.rounds_to_train = self.config["aggregator"][SETTINGS][
-            "rounds_to_train"]
+            "rounds_to_train"
+        ]
 
         if self.config["network"][SETTINGS]["agg_addr"] == AUTO:
             self.config["network"][SETTINGS]["agg_addr"] = getfqdn_env()
 
         if self.config["network"][SETTINGS]["agg_port"] == AUTO:
             self.config["network"][SETTINGS]["agg_port"] = (
-                int(self.hash[:8], 16) % (60999 - 49152) + 49152)
+                int(self.hash[:8], 16) % (60999 - 49152) + 49152
+            )
 
     def get_aggregator(self):
         """Get federation aggregator."""
-        defaults = self.config.get("aggregator", {
-            TEMPLATE: "openfl.experimental.Aggregator",
-            SETTINGS: {}
-        })
+        defaults = self.config.get(
+            "aggregator",
+            {TEMPLATE: "openfl.experimental.Aggregator", SETTINGS: {}},
+        )
 
         defaults[SETTINGS]["aggregator_uuid"] = self.aggregator_uuid
         defaults[SETTINGS]["federation_uuid"] = self.federation_uuid
         defaults[SETTINGS]["authorized_cols"] = self.authorized_cols
 
         private_attrs_callable, private_attrs_kwargs = self.get_private_attr(
-            "aggregator")
+            "aggregator"
+        )
         defaults[SETTINGS][
-            "private_attributes_callable"] = private_attrs_callable
+            "private_attributes_callable"
+        ] = private_attrs_callable
         defaults[SETTINGS]["private_attributes_kwargs"] = private_attrs_kwargs
 
         defaults[SETTINGS]["flow"] = self.get_flow()
@@ -283,7 +296,8 @@ class Plan:
             elif not callable(log_metric_callback):
                 raise TypeError(
                     f"log_metric_callback should be callable object "
-                    f"or be import from code part, get {log_metric_callback}")
+                    f"or be import from code part, get {log_metric_callback}"
+                )
         defaults[SETTINGS]["log_metric_callback"] = log_metric_callback
 
         if self.aggregator_ is None:
@@ -300,20 +314,22 @@ class Plan:
         client=None,
     ):
         """Get collaborator."""
-        defaults = self.config.get("collaborator", {
-            TEMPLATE: "openfl.experimental.Collaborator",
-            SETTINGS: {}
-        })
+        defaults = self.config.get(
+            "collaborator",
+            {TEMPLATE: "openfl.experimental.Collaborator", SETTINGS: {}},
+        )
 
         defaults[SETTINGS]["collaborator_name"] = collaborator_name
         defaults[SETTINGS]["aggregator_uuid"] = self.aggregator_uuid
         defaults[SETTINGS]["federation_uuid"] = self.federation_uuid
 
         private_attrs_callable, private_attrs_kwargs = self.get_private_attr(
-            collaborator_name)
+            collaborator_name
+        )
 
         defaults[SETTINGS][
-            "private_attributes_callable"] = private_attrs_callable
+            "private_attributes_callable"
+        ] = private_attrs_callable
         defaults[SETTINGS]["private_attributes_kwargs"] = private_attrs_kwargs
 
         if client is not None:
@@ -365,11 +381,13 @@ class Plan:
 
         return self.client_
 
-    def get_server(self,
-                   root_certificate=None,
-                   private_key=None,
-                   certificate=None,
-                   **kwargs):
+    def get_server(
+        self,
+        root_certificate=None,
+        private_key=None,
+        certificate=None,
+        **kwargs,
+    ):
         """Get gRPC server of the aggregator instance."""
         common_name = self.config["network"][SETTINGS]["agg_addr"].lower()
 
@@ -398,10 +416,7 @@ class Plan:
         """instantiates federated flow object"""
         defaults = self.config.get(
             "federated_flow",
-            {
-                TEMPLATE: self.config["federated_flow"]["template"],
-                SETTINGS: {}
-            },
+            {TEMPLATE: self.config["federated_flow"]["template"], SETTINGS: {}},
         )
         defaults = self.import_kwargs_modules(defaults)
 
@@ -422,8 +437,8 @@ class Plan:
                             if import_module(module_path):
                                 module = import_module(module_path)
                                 value_defaults_data = {
-                                    'template': value,
-                                    'settings': settings.get('settings', {}),
+                                    "template": value,
+                                    "settings": settings.get("settings", {}),
                                 }
                                 attr = getattr(module, class_name)
 
@@ -454,16 +469,19 @@ class Plan:
 
             if d.get(private_attr_name, None):
                 private_attrs_callable = {
-                    "template":
-                        d.get(private_attr_name)["callable_func"]["template"]
+                    "template": d.get(private_attr_name)["callable_func"][
+                        "template"
+                    ]
                 }
 
                 private_attrs_kwargs = self.import_kwargs_modules(
-                    d.get(private_attr_name)["callable_func"])["settings"]
+                    d.get(private_attr_name)["callable_func"]
+                )["settings"]
 
                 if isinstance(private_attrs_callable, dict):
                     private_attrs_callable = Plan.import_(
-                        **private_attrs_callable)
+                        **private_attrs_callable
+                    )
                 elif not callable(private_attrs_callable):
                     raise TypeError(
                         f"private_attrs_callable should be callable object "

--- a/openfl/experimental/federated/plan/plan.py
+++ b/openfl/experimental/federated/plan/plan.py
@@ -11,8 +11,7 @@ from pathlib import Path
 from yaml import SafeDumper, dump, safe_load
 
 from openfl.experimental.interface.cli.cli_helper import WORKSPACE
-from openfl.experimental.transport import (AggregatorGRPCClient,
-                                           AggregatorGRPCServer)
+from openfl.experimental.transport import AggregatorGRPCClient, AggregatorGRPCServer
 from openfl.utilities.utils import getfqdn_env
 
 SETTINGS = "settings"

--- a/openfl/experimental/interface/__init__.py
+++ b/openfl/experimental/interface/__init__.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2020-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
 """openfl.experimental.interface package."""
 
 from .fl_spec import FLSpec

--- a/openfl/experimental/interface/__init__.py
+++ b/openfl/experimental/interface/__init__.py
@@ -2,7 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 """openfl.experimental.interface package."""
 
-from .fl_spec import FLSpec
-from .participants import Aggregator, Collaborator
-
-__all__ = ["FLSpec", "Aggregator", "Collaborator"]
+from openfl.experimental.interface.fl_spec import FLSpec
+from openfl.experimental.interface.participants import Aggregator, Collaborator

--- a/openfl/experimental/interface/cli/aggregator.py
+++ b/openfl/experimental/interface/cli/aggregator.py
@@ -6,12 +6,8 @@ import sys
 import threading
 from logging import getLogger
 
-from click import echo
-from click import group
-from click import option
-from click import pass_context
 from click import Path as ClickPath
-from click import style
+from click import echo, group, option, pass_context, style
 
 from openfl.utilities import click_types
 from openfl.utilities.path_check import is_directory_traversal
@@ -92,10 +88,8 @@ def _generate_cert_request(fqdn):
 
 def generate_cert_request(fqdn):
     """Create aggregator certificate key pair."""
+    from openfl.cryptography.io import get_csr_hash, write_crt, write_key
     from openfl.cryptography.participant import generate_csr
-    from openfl.cryptography.io import write_crt
-    from openfl.cryptography.io import write_key
-    from openfl.cryptography.io import get_csr_hash
     from openfl.experimental.interface.cli.cli_helper import CERT_DIR
 
     if fqdn is None:
@@ -141,10 +135,7 @@ def certify(fqdn, silent):
     from click import confirm
 
     from openfl.cryptography.ca import sign_certificate
-    from openfl.cryptography.io import read_crt
-    from openfl.cryptography.io import read_csr
-    from openfl.cryptography.io import read_key
-    from openfl.cryptography.io import write_crt
+    from openfl.cryptography.io import read_crt, read_csr, read_key, write_crt
     from openfl.experimental.interface.cli.cli_helper import CERT_DIR
 
     if fqdn is None:

--- a/openfl/experimental/interface/cli/aggregator.py
+++ b/openfl/experimental/interface/cli/aggregator.py
@@ -20,31 +20,34 @@ logger = getLogger(__name__)
 @pass_context
 def aggregator(context):
     """Manage Federated Learning Aggregator."""
-    context.obj['group'] = 'aggregator'
+    context.obj["group"] = "aggregator"
 
 
-@aggregator.command(name='start')
+@aggregator.command(name="start")
 @option(
-    '-p',
-    '--plan',
+    "-p",
+    "--plan",
     required=False,
-    help='Federated learning plan [plan/plan.yaml]',
-    default='plan/plan.yaml',
-    type=ClickPath(exists=True))
+    help="Federated learning plan [plan/plan.yaml]",
+    default="plan/plan.yaml",
+    type=ClickPath(exists=True),
+)
 @option(
-    '-c',
-    '--authorized_cols',
+    "-c",
+    "--authorized_cols",
     required=False,
-    help='Authorized collaborator list [plan/cols.yaml]',
-    default='plan/cols.yaml',
-    type=ClickPath(exists=True))
+    help="Authorized collaborator list [plan/cols.yaml]",
+    default="plan/cols.yaml",
+    type=ClickPath(exists=True),
+)
 @option(
-    '-s',
-    '--secure',
+    "-s",
+    "--secure",
     required=False,
-    help='Enable Intel SGX Enclave',
+    help="Enable Intel SGX Enclave",
     is_flag=True,
-    default=False)
+    default=False,
+)
 def start_(plan, authorized_cols, secure):
     """Start the aggregator service."""
     import os
@@ -54,34 +57,38 @@ def start_(plan, authorized_cols, secure):
 
     if is_directory_traversal(plan):
         echo(
-            'Federated learning plan path is out of the openfl workspace scope.'
+            "Federated learning plan path is out of the openfl workspace scope."
         )
         sys.exit(1)
     if is_directory_traversal(authorized_cols):
         echo(
-            'Authorized collaborator list file path is out of the openfl workspace scope.'
+            "Authorized collaborator list file path is out of the openfl workspace scope."
         )
         sys.exit(1)
 
     plan = Plan.parse(
         plan_config_path=Path(plan).absolute(),
-        cols_config_path=Path(authorized_cols).absolute())
+        cols_config_path=Path(authorized_cols).absolute(),
+    )
 
-    if not os.path.exists('plan/data.yaml'):
+    if not os.path.exists("plan/data.yaml"):
         logger.warning(
-            'Aggregator private attributes are set to None as plan/data.yaml not found'
-            + ' in workspace.')
+            "Aggregator private attributes are set to None as plan/data.yaml not found"
+            + " in workspace."
+        )
     else:
         import yaml
         from yaml.loader import SafeLoader
-        with open('plan/data.yaml', 'r') as f:
+
+        with open("plan/data.yaml", "r") as f:
             data = yaml.load(f, Loader=SafeLoader)
             if data.get("aggregator", None) is None:
                 logger.warning(
-                    'Aggregator private attributes are set to None as no aggregator'
-                    + ' attributes found in plan/data.yaml.')
+                    "Aggregator private attributes are set to None as no aggregator"
+                    + " attributes found in plan/data.yaml."
+                )
 
-    logger.info('🧿 Starting the Aggregator Service.')
+    logger.info("🧿 Starting the Aggregator Service.")
 
     agg_server = plan.get_server()
     agg_server.is_server_started = False
@@ -94,14 +101,15 @@ def start_(plan, authorized_cols, secure):
             break
 
 
-@aggregator.command(name='generate-cert-request')
+@aggregator.command(name="generate-cert-request")
 @option(
-    '--fqdn',
+    "--fqdn",
     required=False,
     type=click_types.FQDN,
-    help=f'The fully qualified domain name of'
-    f' aggregator node [{getfqdn_env()}]',
-    default=getfqdn_env())
+    help=f"The fully qualified domain name of"
+    f" aggregator node [{getfqdn_env()}]",
+    default=getfqdn_env(),
+)
 def _generate_cert_request(fqdn):
     generate_cert_request(fqdn)
 
@@ -115,38 +123,43 @@ def generate_cert_request(fqdn):
     if fqdn is None:
         fqdn = getfqdn_env()
 
-    common_name = f'{fqdn}'.lower()
-    subject_alternative_name = f'DNS:{common_name}'
-    file_name = f'agg_{common_name}'
+    common_name = f"{fqdn}".lower()
+    subject_alternative_name = f"DNS:{common_name}"
+    file_name = f"agg_{common_name}"
 
-    echo(f'Creating AGGREGATOR certificate key pair with following settings: '
-         f'CN={style(common_name, fg="red")},'
-         f' SAN={style(subject_alternative_name, fg="red")}')
+    echo(
+        f"Creating AGGREGATOR certificate key pair with following settings: "
+        f'CN={style(common_name, fg="red")},'
+        f' SAN={style(subject_alternative_name, fg="red")}'
+    )
 
     server_private_key, server_csr = generate_csr(common_name, server=True)
 
-    (CERT_DIR / 'server').mkdir(parents=True, exist_ok=True)
+    (CERT_DIR / "server").mkdir(parents=True, exist_ok=True)
 
-    echo('  Writing AGGREGATOR certificate key pair to: ' +
-         style(f'{CERT_DIR}/server', fg='green'))
+    echo(
+        "  Writing AGGREGATOR certificate key pair to: "
+        + style(f"{CERT_DIR}/server", fg="green")
+    )
 
     # Print csr hash before writing csr to disk
     csr_hash = get_csr_hash(server_csr)
-    echo('The CSR Hash ' + style(f'{csr_hash}', fg='red'))
+    echo("The CSR Hash " + style(f"{csr_hash}", fg="red"))
 
     # Write aggregator csr and key to disk
-    write_crt(server_csr, CERT_DIR / 'server' / f'{file_name}.csr')
-    write_key(server_private_key, CERT_DIR / 'server' / f'{file_name}.key')
+    write_crt(server_csr, CERT_DIR / "server" / f"{file_name}.csr")
+    write_key(server_private_key, CERT_DIR / "server" / f"{file_name}.key")
 
 
-@aggregator.command(name='certify')
+@aggregator.command(name="certify")
 @option(
-    '-n',
-    '--fqdn',
+    "-n",
+    "--fqdn",
     type=click_types.FQDN,
-    help=f'The fully qualified domain name of aggregator node [{getfqdn_env()}]',
-    default=getfqdn_env())
-@option('-s', '--silent', help='Do not prompt', is_flag=True)
+    help=f"The fully qualified domain name of aggregator node [{getfqdn_env()}]",
+    default=getfqdn_env(),
+)
+@option("-s", "--silent", help="Do not prompt", is_flag=True)
 def _certify(fqdn, silent):
     certify(fqdn, silent)
 
@@ -164,31 +177,33 @@ def certify(fqdn, silent):
     if fqdn is None:
         fqdn = getfqdn_env()
 
-    common_name = f'{fqdn}'.lower()
-    file_name = f'agg_{common_name}'
-    cert_name = f'server/{file_name}'
-    signing_key_path = 'ca/signing-ca/private/signing-ca.key'
-    signing_crt_path = 'ca/signing-ca.crt'
+    common_name = f"{fqdn}".lower()
+    file_name = f"agg_{common_name}"
+    cert_name = f"server/{file_name}"
+    signing_key_path = "ca/signing-ca/private/signing-ca.key"
+    signing_crt_path = "ca/signing-ca.crt"
 
     # Load CSR
-    csr_path_absolute_path = Path(CERT_DIR / f'{cert_name}.csr').absolute()
+    csr_path_absolute_path = Path(CERT_DIR / f"{cert_name}.csr").absolute()
     if not csr_path_absolute_path.exists():
         echo(
-            style(
-                'Aggregator certificate signing request not found.', fg='red') +
-            ' Please run `fx aggregator generate-cert-request`'
-            ' to generate the certificate request.')
+            style("Aggregator certificate signing request not found.", fg="red")
+            + " Please run `fx aggregator generate-cert-request`"
+            " to generate the certificate request."
+        )
 
     csr, csr_hash = read_csr(csr_path_absolute_path)
 
     # Load private signing key
-    private_sign_key_absolute_path = Path(CERT_DIR /
-                                          signing_key_path).absolute()
+    private_sign_key_absolute_path = Path(
+        CERT_DIR / signing_key_path
+    ).absolute()
     if not private_sign_key_absolute_path.exists():
         echo(
-            style('Signing key not found.', fg='red') +
-            ' Please run `fx workspace certify`'
-            ' to initialize the local certificate authority.')
+            style("Signing key not found.", fg="red")
+            + " Please run `fx workspace certify`"
+            " to initialize the local certificate authority."
+        )
 
     signing_key = read_key(private_sign_key_absolute_path)
 
@@ -196,37 +211,45 @@ def certify(fqdn, silent):
     signing_crt_absolute_path = Path(CERT_DIR / signing_crt_path).absolute()
     if not signing_crt_absolute_path.exists():
         echo(
-            style('Signing certificate not found.', fg='red') +
-            ' Please run `fx workspace certify`'
-            ' to initialize the local certificate authority.')
+            style("Signing certificate not found.", fg="red")
+            + " Please run `fx workspace certify`"
+            " to initialize the local certificate authority."
+        )
 
     signing_crt = read_crt(signing_crt_absolute_path)
 
-    echo('The CSR Hash for file ' + style(f'{cert_name}.csr', fg='green') +
-         ' = ' + style(f'{csr_hash}', fg='red'))
+    echo(
+        "The CSR Hash for file "
+        + style(f"{cert_name}.csr", fg="green")
+        + " = "
+        + style(f"{csr_hash}", fg="red")
+    )
 
-    crt_path_absolute_path = Path(CERT_DIR / f'{cert_name}.crt').absolute()
+    crt_path_absolute_path = Path(CERT_DIR / f"{cert_name}.crt").absolute()
 
     if silent:
         echo(
-            ' Warning: manual check of certificate hashes is bypassed in silent mode.'
+            " Warning: manual check of certificate hashes is bypassed in silent mode."
         )
-        echo(' Signing AGGREGATOR certificate')
-        signed_agg_cert = sign_certificate(csr, signing_key,
-                                           signing_crt.subject)
+        echo(" Signing AGGREGATOR certificate")
+        signed_agg_cert = sign_certificate(
+            csr, signing_key, signing_crt.subject
+        )
         write_crt(signed_agg_cert, crt_path_absolute_path)
 
     else:
-        echo('Make sure the two hashes above are the same.')
-        if confirm('Do you want to sign this certificate?'):
+        echo("Make sure the two hashes above are the same.")
+        if confirm("Do you want to sign this certificate?"):
 
-            echo(' Signing AGGREGATOR certificate')
-            signed_agg_cert = sign_certificate(csr, signing_key,
-                                               signing_crt.subject)
+            echo(" Signing AGGREGATOR certificate")
+            signed_agg_cert = sign_certificate(
+                csr, signing_key, signing_crt.subject
+            )
             write_crt(signed_agg_cert, crt_path_absolute_path)
 
         else:
             echo(
-                style('Not signing certificate.', fg='red') +
-                ' Please check with this AGGREGATOR to get the correct'
-                ' certificate for this federation.')
+                style("Not signing certificate.", fg="red")
+                + " Please check with this AGGREGATOR to get the correct"
+                " certificate for this federation."
+            )

--- a/openfl/experimental/interface/cli/aggregator.py
+++ b/openfl/experimental/interface/cli/aggregator.py
@@ -24,15 +24,27 @@ def aggregator(context):
 
 
 @aggregator.command(name='start')
-@option('-p', '--plan', required=False,
-        help='Federated learning plan [plan/plan.yaml]',
-        default='plan/plan.yaml',
-        type=ClickPath(exists=True))
-@option('-c', '--authorized_cols', required=False,
-        help='Authorized collaborator list [plan/cols.yaml]',
-        default='plan/cols.yaml', type=ClickPath(exists=True))
-@option('-s', '--secure', required=False,
-        help='Enable Intel SGX Enclave', is_flag=True, default=False)
+@option(
+    '-p',
+    '--plan',
+    required=False,
+    help='Federated learning plan [plan/plan.yaml]',
+    default='plan/plan.yaml',
+    type=ClickPath(exists=True))
+@option(
+    '-c',
+    '--authorized_cols',
+    required=False,
+    help='Authorized collaborator list [plan/cols.yaml]',
+    default='plan/cols.yaml',
+    type=ClickPath(exists=True))
+@option(
+    '-s',
+    '--secure',
+    required=False,
+    help='Enable Intel SGX Enclave',
+    is_flag=True,
+    default=False)
 def start_(plan, authorized_cols, secure):
     """Start the aggregator service."""
     import os
@@ -41,14 +53,19 @@ def start_(plan, authorized_cols, secure):
     from openfl.experimental.federated.plan import Plan
 
     if is_directory_traversal(plan):
-        echo('Federated learning plan path is out of the openfl workspace scope.')
+        echo(
+            'Federated learning plan path is out of the openfl workspace scope.'
+        )
         sys.exit(1)
     if is_directory_traversal(authorized_cols):
-        echo('Authorized collaborator list file path is out of the openfl workspace scope.')
+        echo(
+            'Authorized collaborator list file path is out of the openfl workspace scope.'
+        )
         sys.exit(1)
 
-    plan = Plan.parse(plan_config_path=Path(plan).absolute(),
-                      cols_config_path=Path(authorized_cols).absolute())
+    plan = Plan.parse(
+        plan_config_path=Path(plan).absolute(),
+        cols_config_path=Path(authorized_cols).absolute())
 
     if not os.path.exists('plan/data.yaml'):
         logger.warning(
@@ -78,10 +95,13 @@ def start_(plan, authorized_cols, secure):
 
 
 @aggregator.command(name='generate-cert-request')
-@option('--fqdn', required=False, type=click_types.FQDN,
-        help=f'The fully qualified domain name of'
-             f' aggregator node [{getfqdn_env()}]',
-        default=getfqdn_env())
+@option(
+    '--fqdn',
+    required=False,
+    type=click_types.FQDN,
+    help=f'The fully qualified domain name of'
+    f' aggregator node [{getfqdn_env()}]',
+    default=getfqdn_env())
 def _generate_cert_request(fqdn):
     generate_cert_request(fqdn)
 
@@ -107,8 +127,8 @@ def generate_cert_request(fqdn):
 
     (CERT_DIR / 'server').mkdir(parents=True, exist_ok=True)
 
-    echo('  Writing AGGREGATOR certificate key pair to: ' + style(
-        f'{CERT_DIR}/server', fg='green'))
+    echo('  Writing AGGREGATOR certificate key pair to: ' +
+         style(f'{CERT_DIR}/server', fg='green'))
 
     # Print csr hash before writing csr to disk
     csr_hash = get_csr_hash(server_csr)
@@ -120,9 +140,12 @@ def generate_cert_request(fqdn):
 
 
 @aggregator.command(name='certify')
-@option('-n', '--fqdn', type=click_types.FQDN,
-        help=f'The fully qualified domain name of aggregator node [{getfqdn_env()}]',
-        default=getfqdn_env())
+@option(
+    '-n',
+    '--fqdn',
+    type=click_types.FQDN,
+    help=f'The fully qualified domain name of aggregator node [{getfqdn_env()}]',
+    default=getfqdn_env())
 @option('-s', '--silent', help='Do not prompt', is_flag=True)
 def _certify(fqdn, silent):
     certify(fqdn, silent)
@@ -150,41 +173,47 @@ def certify(fqdn, silent):
     # Load CSR
     csr_path_absolute_path = Path(CERT_DIR / f'{cert_name}.csr').absolute()
     if not csr_path_absolute_path.exists():
-        echo(style('Aggregator certificate signing request not found.', fg='red')
-             + ' Please run `fx aggregator generate-cert-request`'
-               ' to generate the certificate request.')
+        echo(
+            style(
+                'Aggregator certificate signing request not found.', fg='red') +
+            ' Please run `fx aggregator generate-cert-request`'
+            ' to generate the certificate request.')
 
     csr, csr_hash = read_csr(csr_path_absolute_path)
 
     # Load private signing key
-    private_sign_key_absolute_path = Path(CERT_DIR / signing_key_path).absolute()
+    private_sign_key_absolute_path = Path(CERT_DIR /
+                                          signing_key_path).absolute()
     if not private_sign_key_absolute_path.exists():
-        echo(style('Signing key not found.', fg='red')
-             + ' Please run `fx workspace certify`'
-               ' to initialize the local certificate authority.')
+        echo(
+            style('Signing key not found.', fg='red') +
+            ' Please run `fx workspace certify`'
+            ' to initialize the local certificate authority.')
 
     signing_key = read_key(private_sign_key_absolute_path)
 
     # Load signing cert
     signing_crt_absolute_path = Path(CERT_DIR / signing_crt_path).absolute()
     if not signing_crt_absolute_path.exists():
-        echo(style('Signing certificate not found.', fg='red')
-             + ' Please run `fx workspace certify`'
-               ' to initialize the local certificate authority.')
+        echo(
+            style('Signing certificate not found.', fg='red') +
+            ' Please run `fx workspace certify`'
+            ' to initialize the local certificate authority.')
 
     signing_crt = read_crt(signing_crt_absolute_path)
 
-    echo('The CSR Hash for file '
-         + style(f'{cert_name}.csr', fg='green')
-         + ' = '
-         + style(f'{csr_hash}', fg='red'))
+    echo('The CSR Hash for file ' + style(f'{cert_name}.csr', fg='green') +
+         ' = ' + style(f'{csr_hash}', fg='red'))
 
     crt_path_absolute_path = Path(CERT_DIR / f'{cert_name}.crt').absolute()
 
     if silent:
-        echo(' Warning: manual check of certificate hashes is bypassed in silent mode.')
+        echo(
+            ' Warning: manual check of certificate hashes is bypassed in silent mode.'
+        )
         echo(' Signing AGGREGATOR certificate')
-        signed_agg_cert = sign_certificate(csr, signing_key, signing_crt.subject)
+        signed_agg_cert = sign_certificate(csr, signing_key,
+                                           signing_crt.subject)
         write_crt(signed_agg_cert, crt_path_absolute_path)
 
     else:
@@ -192,10 +221,12 @@ def certify(fqdn, silent):
         if confirm('Do you want to sign this certificate?'):
 
             echo(' Signing AGGREGATOR certificate')
-            signed_agg_cert = sign_certificate(csr, signing_key, signing_crt.subject)
+            signed_agg_cert = sign_certificate(csr, signing_key,
+                                               signing_crt.subject)
             write_crt(signed_agg_cert, crt_path_absolute_path)
 
         else:
-            echo(style('Not signing certificate.', fg='red')
-                 + ' Please check with this AGGREGATOR to get the correct'
-                   ' certificate for this federation.')
+            echo(
+                style('Not signing certificate.', fg='red') +
+                ' Please check with this AGGREGATOR to get the correct'
+                ' certificate for this federation.')

--- a/openfl/experimental/interface/cli/cli_helper.py
+++ b/openfl/experimental/interface/cli/cli_helper.py
@@ -13,10 +13,10 @@ from yaml import FullLoader, load
 FX = argv[0]
 
 SITEPACKS = Path(__file__).parent.parent.parent.parent.parent
-WORKSPACE = SITEPACKS / 'openfl-workspace' / 'experimental'
-TUTORIALS = SITEPACKS / 'openfl-tutorials'
-OPENFL_USERDIR = Path.home() / '.openfl'
-CERT_DIR = Path('cert').absolute()
+WORKSPACE = SITEPACKS / "openfl-workspace" / "experimental"
+TUTORIALS = SITEPACKS / "openfl-tutorials"
+OPENFL_USERDIR = Path.home() / ".openfl"
+CERT_DIR = Path("cert").absolute()
 
 
 def pretty(o):
@@ -24,41 +24,43 @@ def pretty(o):
     m = max(map(len, o.keys()))
 
     for k, v in o.items():
-        echo(style(f'{k:<{m}} : ', fg='blue') + style(f'{v}', fg='cyan'))
+        echo(style(f"{k:<{m}} : ", fg="blue") + style(f"{v}", fg="cyan"))
 
 
 def tree(path):
     """Print current directory file tree."""
-    echo(f'+ {path}')
+    echo(f"+ {path}")
 
-    for path in sorted(path.rglob('*')):
+    for path in sorted(path.rglob("*")):
 
         depth = len(path.relative_to(path).parts)
-        space = '    ' * depth
+        space = "    " * depth
 
         if path.is_file():
-            echo(f'{space}f {path.name}')
+            echo(f"{space}f {path.name}")
         else:
-            echo(f'{space}d {path.name}')
+            echo(f"{space}d {path.name}")
 
 
-def print_tree(dir_path: Path,
-               level: int = -1,
-               limit_to_directories: bool = False,
-               length_limit: int = 1000):
+def print_tree(
+    dir_path: Path,
+    level: int = -1,
+    limit_to_directories: bool = False,
+    length_limit: int = 1000,
+):
     """Given a directory Path object print a visual tree structure."""
-    space = '    '
-    branch = '│   '
-    tee = '├── '
-    last = '└── '
+    space = "    "
+    branch = "│   "
+    tee = "├── "
+    last = "└── "
 
-    echo('\nNew experimental workspace directory structure:')
+    echo("\nNew experimental workspace directory structure:")
 
     dir_path = Path(dir_path)  # accept string coerceable to Path
     files = 0
     directories = 0
 
-    def inner(dir_path: Path, prefix: str = '', level=-1):
+    def inner(dir_path: Path, prefix: str = "", level=-1):
         nonlocal files, directories
         if not level:
             return  # 0, stop iterating
@@ -73,7 +75,8 @@ def print_tree(dir_path: Path,
                 directories += 1
                 extension = branch if pointer == tee else space
                 yield from inner(
-                    path, prefix=prefix + extension, level=level - 1)
+                    path, prefix=prefix + extension, level=level - 1
+                )
             elif not limit_to_directories:
                 yield prefix + pointer + path.name
                 files += 1
@@ -83,16 +86,18 @@ def print_tree(dir_path: Path,
     for line in islice(iterator, length_limit):
         echo(line)
     if next(iterator, None):
-        echo(f'... length_limit, {length_limit}, reached, counted:')
-    echo(f'\n{directories} directories' + (f', {files} files' if files else ''))
+        echo(f"... length_limit, {length_limit}, reached, counted:")
+    echo(f"\n{directories} directories" + (f", {files} files" if files else ""))
 
 
-def copytree(src,
-             dst,
-             symlinks=False,
-             ignore=None,
-             ignore_dangling_symlinks=False,
-             dirs_exist_ok=False):
+def copytree(
+    src,
+    dst,
+    symlinks=False,
+    ignore=None,
+    ignore_dangling_symlinks=False,
+    dirs_exist_ok=False,
+):
     """From Python 3.8 'shutil' which include 'dirs_exist_ok' option."""
     import os
     import shutil
@@ -111,7 +116,9 @@ def copytree(src,
 
         os.makedirs(dst, exist_ok=dirs_exist_ok)
         errors = []
-        use_srcentry = copy_function is shutil.copy2 or copy_function is shutil.copy
+        use_srcentry = (
+            copy_function is shutil.copy2 or copy_function is shutil.copy
+        )
 
         for srcentry in entries:
             if srcentry.name in ignored_names:
@@ -121,7 +128,7 @@ def copytree(src,
             srcobj = srcentry if use_srcentry else srcname
             try:
                 is_symlink = srcentry.is_symlink()
-                if is_symlink and os.name == 'nt':
+                if is_symlink and os.name == "nt":
                     lstat = srcentry.stat(follow_symlinks=False)
                     if lstat.st_reparse_tag == stat.IO_REPARSE_TAG_MOUNT_POINT:
                         is_symlink = False
@@ -130,10 +137,13 @@ def copytree(src,
                     if symlinks:
                         os.symlink(linkto, dstname)
                         shutil.copystat(
-                            srcobj, dstname, follow_symlinks=not symlinks)
+                            srcobj, dstname, follow_symlinks=not symlinks
+                        )
                     else:
-                        if (not os.path.exists(linkto) and
-                                ignore_dangling_symlinks):
+                        if (
+                            not os.path.exists(linkto)
+                            and ignore_dangling_symlinks
+                        ):
                             continue
                         if srcentry.is_dir():
                             copytree(
@@ -141,7 +151,8 @@ def copytree(src,
                                 dstname,
                                 symlinks,
                                 ignore,
-                                dirs_exist_ok=dirs_exist_ok)
+                                dirs_exist_ok=dirs_exist_ok,
+                            )
                         else:
                             copy_function(srcobj, dstname)
                 elif srcentry.is_dir():
@@ -150,7 +161,8 @@ def copytree(src,
                         dstname,
                         symlinks,
                         ignore,
-                        dirs_exist_ok=dirs_exist_ok)
+                        dirs_exist_ok=dirs_exist_ok,
+                    )
                 else:
                     copy_function(srcobj, dstname)
             except OSError as why:
@@ -160,7 +172,7 @@ def copytree(src,
         try:
             shutil.copystat(src, dst)
         except OSError as why:
-            if getattr(why, 'winerror', None) is None:
+            if getattr(why, "winerror", None) is None:
                 errors.append((src, dst, str(why)))
         if errors:
             raise Exception(errors)
@@ -172,21 +184,21 @@ def copytree(src,
 def get_workspace_parameter(name):
     """Get a parameter from the workspace config file (.workspace)."""
     # Update the .workspace file to show the current workspace plan
-    workspace_file = '.workspace'
+    workspace_file = ".workspace"
 
-    with open(workspace_file, 'r', encoding='utf-8') as f:
+    with open(workspace_file, "r", encoding="utf-8") as f:
         doc = load(f, Loader=FullLoader)
 
     if not doc:  # YAML is not correctly formatted
         doc = {}  # Create empty dictionary
 
     if name not in doc.keys() or not doc[name]:  # List doesn't exist
-        return ''
+        return ""
     else:
         return doc[name]
 
 
-def check_varenv(env: str = '', args: dict = None):
+def check_varenv(env: str = "", args: dict = None):
     """Update "args" (dictionary) with <env: env_value> if env has a defined value in the host."""
     if args is None:
         args = {}
@@ -197,23 +209,23 @@ def check_varenv(env: str = '', args: dict = None):
     return args
 
 
-def get_fx_path(curr_path=''):
+def get_fx_path(curr_path=""):
     """Return the absolute path to fx binary."""
     import os
     import re
 
-    match = re.search('lib', curr_path)
+    match = re.search("lib", curr_path)
     idx = match.end()
     path_prefix = curr_path[0:idx]
-    bin_path = re.sub('lib', 'bin', path_prefix)
-    fx_path = os.path.join(bin_path, 'fx')
+    bin_path = re.sub("lib", "bin", path_prefix)
+    fx_path = os.path.join(bin_path, "fx")
 
     return fx_path
 
 
 def remove_line_from_file(pkg, filename):
     """Remove line that contains `pkg` from the `filename` file."""
-    with open(filename, 'r+', encoding='utf-8') as f:
+    with open(filename, "r+", encoding="utf-8") as f:
         d = f.readlines()
         f.seek(0)
         for i in d:
@@ -224,7 +236,7 @@ def remove_line_from_file(pkg, filename):
 
 def replace_line_in_file(line, line_num_to_replace, filename):
     """Replace line at `line_num_to_replace` with `line`."""
-    with open(filename, 'r+', encoding='utf-8') as f:
+    with open(filename, "r+", encoding="utf-8") as f:
         d = f.readlines()
         f.seek(0)
         for idx, i in enumerate(d):

--- a/openfl/experimental/interface/cli/cli_helper.py
+++ b/openfl/experimental/interface/cli/cli_helper.py
@@ -42,7 +42,8 @@ def tree(path):
             echo(f'{space}d {path.name}')
 
 
-def print_tree(dir_path: Path, level: int = -1,
+def print_tree(dir_path: Path,
+               level: int = -1,
                limit_to_directories: bool = False,
                length_limit: int = 1000):
     """Given a directory Path object print a visual tree structure."""
@@ -71,8 +72,8 @@ def print_tree(dir_path: Path, level: int = -1,
                 yield prefix + pointer + path.name
                 directories += 1
                 extension = branch if pointer == tee else space
-                yield from inner(path, prefix=prefix + extension,
-                                 level=level - 1)
+                yield from inner(
+                    path, prefix=prefix + extension, level=level - 1)
             elif not limit_to_directories:
                 yield prefix + pointer + path.name
                 files += 1
@@ -86,8 +87,12 @@ def print_tree(dir_path: Path, level: int = -1,
     echo(f'\n{directories} directories' + (f', {files} files' if files else ''))
 
 
-def copytree(src, dst, symlinks=False, ignore=None,
-             ignore_dangling_symlinks=False, dirs_exist_ok=False):
+def copytree(src,
+             dst,
+             symlinks=False,
+             ignore=None,
+             ignore_dangling_symlinks=False,
+             dirs_exist_ok=False):
     """From Python 3.8 'shutil' which include 'dirs_exist_ok' option."""
     import os
     import shutil
@@ -124,20 +129,28 @@ def copytree(src, dst, symlinks=False, ignore=None,
                     linkto = os.readlink(srcname)
                     if symlinks:
                         os.symlink(linkto, dstname)
-                        shutil.copystat(srcobj, dstname,
-                                        follow_symlinks=not symlinks)
+                        shutil.copystat(
+                            srcobj, dstname, follow_symlinks=not symlinks)
                     else:
-                        if (not os.path.exists(linkto)
-                                and ignore_dangling_symlinks):
+                        if (not os.path.exists(linkto) and
+                                ignore_dangling_symlinks):
                             continue
                         if srcentry.is_dir():
-                            copytree(srcobj, dstname, symlinks, ignore,
-                                     dirs_exist_ok=dirs_exist_ok)
+                            copytree(
+                                srcobj,
+                                dstname,
+                                symlinks,
+                                ignore,
+                                dirs_exist_ok=dirs_exist_ok)
                         else:
                             copy_function(srcobj, dstname)
                 elif srcentry.is_dir():
-                    copytree(srcobj, dstname, symlinks, ignore,
-                             dirs_exist_ok=dirs_exist_ok)
+                    copytree(
+                        srcobj,
+                        dstname,
+                        symlinks,
+                        ignore,
+                        dirs_exist_ok=dirs_exist_ok)
                 else:
                     copy_function(srcobj, dstname)
             except OSError as why:

--- a/openfl/experimental/interface/cli/cli_helper.py
+++ b/openfl/experimental/interface/cli/cli_helper.py
@@ -3,15 +3,12 @@
 """Module with auxiliary CLI helper functions."""
 
 from itertools import islice
-from os import environ
-from os import stat
+from os import environ, stat
 from pathlib import Path
 from sys import argv
 
-from click import echo
-from click import style
-from yaml import FullLoader
-from yaml import load
+from click import echo, style
+from yaml import FullLoader, load
 
 FX = argv[0]
 
@@ -189,8 +186,8 @@ def check_varenv(env: str = '', args: dict = None):
 
 def get_fx_path(curr_path=''):
     """Return the absolute path to fx binary."""
-    import re
     import os
+    import re
 
     match = re.search('lib', curr_path)
     idx = match.end()

--- a/openfl/experimental/interface/cli/collaborator.py
+++ b/openfl/experimental/interface/cli/collaborator.py
@@ -2,19 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 """Collaborator module."""
 
-import sys
 import os
+import sys
 from logging import getLogger
 
-from click import echo
-from click import group
-from click import option
-from click import pass_context
 from click import Path as ClickPath
-from click import style
+from click import echo, group, option, pass_context, style
 
 from openfl.utilities.path_check import is_directory_traversal
-
 
 logger = getLogger(__name__)
 
@@ -113,10 +108,8 @@ def generate_cert_request(collaborator_name, silent, skip_package):
 
     Then create a package with the CSR to send for signing.
     """
+    from openfl.cryptography.io import get_csr_hash, write_crt, write_key
     from openfl.cryptography.participant import generate_csr
-    from openfl.cryptography.io import write_crt
-    from openfl.cryptography.io import write_key
-    from openfl.cryptography.io import get_csr_hash
     from openfl.experimental.interface.cli.cli_helper import CERT_DIR
 
     common_name = f"{collaborator_name}".lower()
@@ -147,14 +140,11 @@ def generate_cert_request(collaborator_name, silent, skip_package):
     write_key(client_private_key, CERT_DIR / "client" / f"{file_name}.key")
 
     if not skip_package:
-        from shutil import copytree
-        from shutil import ignore_patterns
-        from shutil import make_archive
-        from tempfile import mkdtemp
-        from os.path import basename
-        from os.path import join
-        from os import remove
         from glob import glob
+        from os import remove
+        from os.path import basename, join
+        from shutil import copytree, ignore_patterns, make_archive
+        from tempfile import mkdtemp
 
         from openfl.utilities.utils import rmtree
 
@@ -200,10 +190,9 @@ def register_collaborator(file_name):
 
     """
     from os.path import isfile
-    from yaml import dump
-    from yaml import FullLoader
-    from yaml import load
     from pathlib import Path
+
+    from yaml import FullLoader, dump, load
 
     col_name = find_certificate_name(file_name)
 
@@ -272,22 +261,17 @@ def certify_(collaborator_name, silent, request_pkg, import_):
 
 def certify(collaborator_name, silent, request_pkg=None, import_=False):
     """Sign/certify collaborator certificate key pair."""
-    from click import confirm
-    from pathlib import Path
-    from shutil import copy
-    from shutil import make_archive
-    from shutil import unpack_archive
     from glob import glob
-    from os.path import basename
-    from os.path import join
-    from os.path import splitext
     from os import remove
+    from os.path import basename, join, splitext
+    from pathlib import Path
+    from shutil import copy, make_archive, unpack_archive
     from tempfile import mkdtemp
+
+    from click import confirm
+
     from openfl.cryptography.ca import sign_certificate
-    from openfl.cryptography.io import read_crt
-    from openfl.cryptography.io import read_csr
-    from openfl.cryptography.io import read_key
-    from openfl.cryptography.io import write_crt
+    from openfl.cryptography.io import read_crt, read_csr, read_key, write_crt
     from openfl.experimental.interface.cli.cli_helper import CERT_DIR
     from openfl.utilities.utils import rmtree
 

--- a/openfl/experimental/interface/cli/collaborator.py
+++ b/openfl/experimental/interface/cli/collaborator.py
@@ -42,8 +42,7 @@ def collaborator(context):
     required=False,
     help='Enable Intel SGX Enclave',
     is_flag=True,
-    default=False
-)
+    default=False)
 def start_(plan, collaborator_name, secure, data_config="plan/data.yaml"):
     """Start a collaborator service."""
     from pathlib import Path
@@ -51,7 +50,9 @@ def start_(plan, collaborator_name, secure, data_config="plan/data.yaml"):
     from openfl.experimental.federated import Plan
 
     if plan and is_directory_traversal(plan):
-        echo("Federated learning plan path is out of the openfl workspace scope.")
+        echo(
+            "Federated learning plan path is out of the openfl workspace scope."
+        )
         sys.exit(1)
     if data_config and is_directory_traversal(data_config):
         echo(
@@ -116,20 +117,16 @@ def generate_cert_request(collaborator_name, silent, skip_package):
     subject_alternative_name = f"DNS:{common_name}"
     file_name = f"col_{common_name}"
 
-    echo(
-        f"Creating COLLABORATOR certificate key pair with following settings: "
-        f'CN={style(common_name, fg="red")},'
-        f' SAN={style(subject_alternative_name, fg="red")}'
-    )
+    echo(f"Creating COLLABORATOR certificate key pair with following settings: "
+         f'CN={style(common_name, fg="red")},'
+         f' SAN={style(subject_alternative_name, fg="red")}')
 
     client_private_key, client_csr = generate_csr(common_name, server=False)
 
     (CERT_DIR / "client").mkdir(parents=True, exist_ok=True)
 
-    echo(
-        "  Moving COLLABORATOR certificate to: "
-        + style(f"{CERT_DIR}/{file_name}", fg="green")
-    )
+    echo("  Moving COLLABORATOR certificate to: " +
+         style(f"{CERT_DIR}/{file_name}", fg="green"))
 
     # Print csr hash before writing csr to disk
     csr_hash = get_csr_hash(client_csr)
@@ -167,13 +164,10 @@ def generate_cert_request(collaborator_name, silent, skip_package):
         make_archive(archive_name, archive_type, tmp_dir)
         rmtree(tmp_dir)
 
-        echo(
-            f"Archive {archive_file_name} with certificate signing" f" request created"
-        )
-        echo(
-            "This file should be sent to the certificate authority"
-            " (typically hosted by the aggregator) for signing"
-        )
+        echo(f"Archive {archive_file_name} with certificate signing"
+             f" request created")
+        echo("This file should be sent to the certificate authority"
+             " (typically hosted by the aggregator) for signing")
 
 
 def find_certificate_name(file_name):
@@ -211,24 +205,16 @@ def register_collaborator(file_name):
         doc["collaborators"] = []  # Create empty list
 
     if col_name in doc["collaborators"]:
-        echo(
-            "\nCollaborator "
-            + style(f"{col_name}", fg="green")
-            + " is already in the "
-            + style(f"{cols_file}", fg="green")
-        )
+        echo("\nCollaborator " + style(f"{col_name}", fg="green") +
+             " is already in the " + style(f"{cols_file}", fg="green"))
 
     else:
         doc["collaborators"].append(col_name)
         with open(cols_file, "w", encoding="utf-8") as f:
             dump(doc, f)
 
-        echo(
-            "\nRegistering "
-            + style(f"{col_name}", fg="green")
-            + " in "
-            + style(f"{cols_file}", fg="green")
-        )
+        echo("\nRegistering " + style(f"{col_name}", fg="green") + " in " +
+             style(f"{cols_file}", fg="green"))
 
 
 @collaborator.command(name="certify")
@@ -284,13 +270,11 @@ def certify(collaborator_name, silent, request_pkg=None, import_=False):
             csr = glob(f"{CERT_DIR}/client/*.csr")[0]
         else:
             if collaborator_name is None:
-                echo(
-                    "collaborator_name can only be omitted if signing\n"
-                    "a zipped request package.\n"
-                    "\n"
-                    "Example: fx collaborator certify --request-pkg "
-                    "col_one_to_agg_cert_request.zip"
-                )
+                echo("collaborator_name can only be omitted if signing\n"
+                     "a zipped request package.\n"
+                     "\n"
+                     "Example: fx collaborator certify --request-pkg "
+                     "col_one_to_agg_cert_request.zip")
                 return
             csr = glob(f"{CERT_DIR}/client/col_{common_name}.csr")[0]
             copy(csr, CERT_DIR)
@@ -302,46 +286,42 @@ def certify(collaborator_name, silent, request_pkg=None, import_=False):
         # Load CSR
         if not Path(f"{cert_name}.csr").exists():
             echo(
-                style("Collaborator certificate signing request not found.", fg="red")
-                + " Please run `fx collaborator generate-cert-request`"
-                " to generate the certificate request."
-            )
+                style(
+                    "Collaborator certificate signing request not found.",
+                    fg="red") +
+                " Please run `fx collaborator generate-cert-request`"
+                " to generate the certificate request.")
 
         csr, csr_hash = read_csr(f"{cert_name}.csr")
 
         # Load private signing key
         if not Path(CERT_DIR / signing_key_path).exists():
             echo(
-                style("Signing key not found.", fg="red")
-                + " Please run `fx workspace certify`"
-                " to initialize the local certificate authority."
-            )
+                style("Signing key not found.", fg="red") +
+                " Please run `fx workspace certify`"
+                " to initialize the local certificate authority.")
 
         signing_key = read_key(CERT_DIR / signing_key_path)
 
         # Load signing cert
         if not Path(CERT_DIR / signing_crt_path).exists():
             echo(
-                style("Signing certificate not found.", fg="red")
-                + " Please run `fx workspace certify`"
-                " to initialize the local certificate authority."
-            )
+                style("Signing certificate not found.", fg="red") +
+                " Please run `fx workspace certify`"
+                " to initialize the local certificate authority.")
 
         signing_crt = read_crt(CERT_DIR / signing_crt_path)
 
-        echo(
-            "The CSR Hash for file "
-            + style(f"{file_name}.csr", fg="green")
-            + " = "
-            + style(f"{csr_hash}", fg="red")
-        )
+        echo("The CSR Hash for file " + style(f"{file_name}.csr", fg="green") +
+             " = " + style(f"{csr_hash}", fg="red"))
 
         if silent:
             echo(" Signing COLLABORATOR certificate")
             echo(
                 " Warning: manual check of certificate hashes is bypassed in silent mode."
             )
-            signed_col_cert = sign_certificate(csr, signing_key, signing_crt.subject)
+            signed_col_cert = sign_certificate(csr, signing_key,
+                                               signing_crt.subject)
             write_crt(signed_col_cert, f"{cert_name}.crt")
             register_collaborator(CERT_DIR / "client" / f"{file_name}.crt")
 
@@ -349,18 +329,16 @@ def certify(collaborator_name, silent, request_pkg=None, import_=False):
             echo("Make sure the two hashes above are the same.")
             if confirm("Do you want to sign this certificate?"):
                 echo(" Signing COLLABORATOR certificate")
-                signed_col_cert = sign_certificate(
-                    csr, signing_key, signing_crt.subject
-                )
+                signed_col_cert = sign_certificate(csr, signing_key,
+                                                   signing_crt.subject)
                 write_crt(signed_col_cert, f"{cert_name}.crt")
                 register_collaborator(CERT_DIR / "client" / f"{file_name}.crt")
 
             else:
                 echo(
-                    style("Not signing certificate.", fg="red")
-                    + " Please check with this collaborator to get the"
-                    " correct certificate for this federation."
-                )
+                    style("Not signing certificate.", fg="red") +
+                    " Please check with this collaborator to get the"
+                    " correct certificate for this federation.")
                 return
 
         if len(common_name) == 0:

--- a/openfl/experimental/interface/cli/experimental.py
+++ b/openfl/experimental/interface/cli/experimental.py
@@ -18,7 +18,8 @@ def experimental(context):
 @experimental.command(name="deactivate")
 def deactivate():
     """Deactivate experimental environment."""
-    settings = Path("~").expanduser().joinpath(".openfl",
-                                               "experimental").resolve()
+    settings = (
+        Path("~").expanduser().joinpath(".openfl", "experimental").resolve()
+    )
 
     os.remove(settings)

--- a/openfl/experimental/interface/cli/experimental.py
+++ b/openfl/experimental/interface/cli/experimental.py
@@ -5,8 +5,7 @@
 import os
 from pathlib import Path
 
-from click import group
-from click import pass_context
+from click import group, pass_context
 
 
 @group()

--- a/openfl/experimental/interface/cli/experimental.py
+++ b/openfl/experimental/interface/cli/experimental.py
@@ -18,7 +18,7 @@ def experimental(context):
 @experimental.command(name="deactivate")
 def deactivate():
     """Deactivate experimental environment."""
-    settings = Path("~").expanduser().joinpath(
-        ".openfl", "experimental").resolve()
+    settings = Path("~").expanduser().joinpath(".openfl",
+                                               "experimental").resolve()
 
     os.remove(settings)

--- a/openfl/experimental/interface/cli/plan.py
+++ b/openfl/experimental/interface/cli/plan.py
@@ -22,17 +22,31 @@ def plan(context):
 
 @plan.command()
 @pass_context
-@option('-p', '--plan_config', required=False,
-        help='Federated learning plan [plan/plan.yaml]',
-        default='plan/plan.yaml', type=ClickPath(exists=True))
-@option('-c', '--cols_config', required=False,
-        help='Authorized collaborator list [plan/cols.yaml]',
-        default='plan/cols.yaml', type=ClickPath(exists=True))
-@option('-d', '--data_config', required=False,
-        help='The data set/shard configuration file [plan/data.yaml]',
-        default='plan/data.yaml')
-@option('-a', '--aggregator_address', required=False,
-        help='The FQDN of the federation agregator')
+@option(
+    '-p',
+    '--plan_config',
+    required=False,
+    help='Federated learning plan [plan/plan.yaml]',
+    default='plan/plan.yaml',
+    type=ClickPath(exists=True))
+@option(
+    '-c',
+    '--cols_config',
+    required=False,
+    help='Authorized collaborator list [plan/cols.yaml]',
+    default='plan/cols.yaml',
+    type=ClickPath(exists=True))
+@option(
+    '-d',
+    '--data_config',
+    required=False,
+    help='The data set/shard configuration file [plan/data.yaml]',
+    default='plan/data.yaml')
+@option(
+    '-a',
+    '--aggregator_address',
+    required=False,
+    help='The FQDN of the federation agregator')
 def initialize(context, plan_config, cols_config, data_config,
                aggregator_address):
     """
@@ -55,15 +69,17 @@ def initialize(context, plan_config, cols_config, data_config,
     cols_config = Path(cols_config).absolute()
     data_config = Path(data_config).absolute()
 
-    plan = Plan.parse(plan_config_path=plan_config,
-                      cols_config_path=cols_config,
-                      data_config_path=data_config)
+    plan = Plan.parse(
+        plan_config_path=plan_config,
+        cols_config_path=cols_config,
+        data_config_path=data_config)
 
     plan_origin = Plan.parse(plan_config, resolve=False).config
 
-    if (plan_origin['network']['settings']['agg_addr'] == 'auto'
-            or aggregator_address):
-        plan_origin['network']['settings']['agg_addr'] = aggregator_address or getfqdn_env()
+    if (plan_origin['network']['settings']['agg_addr'] == 'auto' or
+            aggregator_address):
+        plan_origin['network']['settings'][
+            'agg_addr'] = aggregator_address or getfqdn_env()
 
         logger.warn(f'Patching Aggregator Addr in Plan'
                     f" 🠆 {plan_origin['network']['settings']['agg_addr']}")

--- a/openfl/experimental/interface/cli/plan.py
+++ b/openfl/experimental/interface/cli/plan.py
@@ -17,38 +17,43 @@ logger = getLogger(__name__)
 @pass_context
 def plan(context):
     """Manage Federated Learning Plans."""
-    context.obj['group'] = 'plan'
+    context.obj["group"] = "plan"
 
 
 @plan.command()
 @pass_context
 @option(
-    '-p',
-    '--plan_config',
+    "-p",
+    "--plan_config",
     required=False,
-    help='Federated learning plan [plan/plan.yaml]',
-    default='plan/plan.yaml',
-    type=ClickPath(exists=True))
+    help="Federated learning plan [plan/plan.yaml]",
+    default="plan/plan.yaml",
+    type=ClickPath(exists=True),
+)
 @option(
-    '-c',
-    '--cols_config',
+    "-c",
+    "--cols_config",
     required=False,
-    help='Authorized collaborator list [plan/cols.yaml]',
-    default='plan/cols.yaml',
-    type=ClickPath(exists=True))
+    help="Authorized collaborator list [plan/cols.yaml]",
+    default="plan/cols.yaml",
+    type=ClickPath(exists=True),
+)
 @option(
-    '-d',
-    '--data_config',
+    "-d",
+    "--data_config",
     required=False,
-    help='The data set/shard configuration file [plan/data.yaml]',
-    default='plan/data.yaml')
+    help="The data set/shard configuration file [plan/data.yaml]",
+    default="plan/data.yaml",
+)
 @option(
-    '-a',
-    '--aggregator_address',
+    "-a",
+    "--aggregator_address",
     required=False,
-    help='The FQDN of the federation agregator')
-def initialize(context, plan_config, cols_config, data_config,
-               aggregator_address):
+    help="The FQDN of the federation agregator",
+)
+def initialize(
+    context, plan_config, cols_config, data_config, aggregator_address
+):
     """
     Initialize Data Science plan.
 
@@ -62,7 +67,7 @@ def initialize(context, plan_config, cols_config, data_config,
 
     for p in [plan_config, cols_config, data_config]:
         if is_directory_traversal(p):
-            echo(f'{p} is out of the openfl workspace scope.')
+            echo(f"{p} is out of the openfl workspace scope.")
             sys.exit(1)
 
     plan_config = Path(plan_config).absolute()
@@ -72,26 +77,32 @@ def initialize(context, plan_config, cols_config, data_config,
     plan = Plan.parse(
         plan_config_path=plan_config,
         cols_config_path=cols_config,
-        data_config_path=data_config)
+        data_config_path=data_config,
+    )
 
     plan_origin = Plan.parse(plan_config, resolve=False).config
 
-    if (plan_origin['network']['settings']['agg_addr'] == 'auto' or
-            aggregator_address):
-        plan_origin['network']['settings'][
-            'agg_addr'] = aggregator_address or getfqdn_env()
+    if (
+        plan_origin["network"]["settings"]["agg_addr"] == "auto"
+        or aggregator_address
+    ):
+        plan_origin["network"]["settings"]["agg_addr"] = (
+            aggregator_address or getfqdn_env()
+        )
 
-        logger.warn(f'Patching Aggregator Addr in Plan'
-                    f" 🠆 {plan_origin['network']['settings']['agg_addr']}")
+        logger.warn(
+            f"Patching Aggregator Addr in Plan"
+            f" 🠆 {plan_origin['network']['settings']['agg_addr']}"
+        )
 
         Plan.dump(plan_config, plan_origin)
 
     plan.config = plan_origin
 
     # Record that plan with this hash has been initialized
-    if 'plans' not in context.obj:
-        context.obj['plans'] = []
-    context.obj['plans'].append(f'{plan_config.stem}_{plan.hash[:8]}')
+    if "plans" not in context.obj:
+        context.obj["plans"] = []
+    context.obj["plans"].append(f"{plan_config.stem}_{plan.hash[:8]}")
     logger.info(f"{context.obj['plans']}")
 
 

--- a/openfl/experimental/interface/cli/plan.py
+++ b/openfl/experimental/interface/cli/plan.py
@@ -5,11 +5,8 @@
 import sys
 from logging import getLogger
 
-from click import echo
-from click import group
-from click import option
-from click import pass_context
 from click import Path as ClickPath
+from click import echo, group, option, pass_context
 
 from openfl.utilities.path_check import is_directory_traversal
 

--- a/openfl/experimental/interface/cli/workspace.py
+++ b/openfl/experimental/interface/cli/workspace.py
@@ -22,7 +22,7 @@ logger = getLogger(__name__)
 @pass_context
 def workspace(context):
     """Manage Experimental Federated Learning Workspaces."""
-    context.obj['group'] = 'workspace'
+    context.obj["group"] = "workspace"
 
 
 def create_dirs(prefix):
@@ -31,16 +31,17 @@ def create_dirs(prefix):
 
     from openfl.experimental.interface.cli.cli_helper import WORKSPACE
 
-    echo('Creating Workspace Directories')
+    echo("Creating Workspace Directories")
 
-    (prefix / 'cert').mkdir(parents=True, exist_ok=True)  # certifications
-    (prefix / 'data').mkdir(parents=True, exist_ok=True)  # training data
-    (prefix / 'logs').mkdir(parents=True, exist_ok=True)  # training logs
-    (prefix / 'save').mkdir(
-        parents=True, exist_ok=True)  # model weight saves / initialization
-    (prefix / 'src').mkdir(parents=True, exist_ok=True)  # model code
+    (prefix / "cert").mkdir(parents=True, exist_ok=True)  # certifications
+    (prefix / "data").mkdir(parents=True, exist_ok=True)  # training data
+    (prefix / "logs").mkdir(parents=True, exist_ok=True)  # training logs
+    (prefix / "save").mkdir(
+        parents=True, exist_ok=True
+    )  # model weight saves / initialization
+    (prefix / "src").mkdir(parents=True, exist_ok=True)  # model code
 
-    copyfile(WORKSPACE / 'workspace' / '.workspace', prefix / '.workspace')
+    copyfile(WORKSPACE / "workspace" / ".workspace", prefix / ".workspace")
 
 
 def create_temp(prefix, template):
@@ -49,7 +50,7 @@ def create_temp(prefix, template):
 
     from openfl.experimental.interface.cli.cli_helper import WORKSPACE, copytree
 
-    echo('Creating Workspace Templates')
+    echo("Creating Workspace Templates")
     # Use the specified template if it's a Path, otherwise use WORKSPACE/template
     source = template if isinstance(template, Path) else WORKSPACE / template
 
@@ -57,7 +58,8 @@ def create_temp(prefix, template):
         src=source,
         dst=prefix,
         dirs_exist_ok=True,
-        ignore=ignore_patterns('__pycache__'))  # from template workspace
+        ignore=ignore_patterns("__pycache__"),
+    )  # from template workspace
     apply_template_plan(prefix, template)
 
 
@@ -67,54 +69,67 @@ def get_templates():
 
     return [
         d.name
-        for d in WORKSPACE.glob('*')
-        if d.is_dir() and d.name not in ['__pycache__', 'workspace']
+        for d in WORKSPACE.glob("*")
+        if d.is_dir() and d.name not in ["__pycache__", "workspace"]
     ]
 
 
-@workspace.command(name='create')
+@workspace.command(name="create")
 @option(
-    '--prefix', required=True, help='Workspace name or path', type=ClickPath())
+    "--prefix", required=True, help="Workspace name or path", type=ClickPath()
+)
 @option(
-    '--custom_template',
+    "--custom_template",
     required=False,
-    help='Path to custom template',
-    type=ClickPath(exists=True))
+    help="Path to custom template",
+    type=ClickPath(exists=True),
+)
 @option(
-    '--notebook',
+    "--notebook",
     required=False,
-    help='Path to jupyter notebook',
-    type=ClickPath(exists=True))
+    help="Path to jupyter notebook",
+    type=ClickPath(exists=True),
+)
 @option(
-    '--template_output_dir',
+    "--template_output_dir",
     required=False,
-    help='Destination directory to save your Jupyter Notebook workspace.',
-    type=ClickPath(exists=False, file_okay=False, dir_okay=True))
-@option('--template', required=False, type=Choice(get_templates()))
+    help="Destination directory to save your Jupyter Notebook workspace.",
+    type=ClickPath(exists=False, file_okay=False, dir_okay=True),
+)
+@option("--template", required=False, type=Choice(get_templates()))
 def create_(prefix, custom_template, template, notebook, template_output_dir):
     """Create the experimental workspace."""
     if is_directory_traversal(prefix):
-        echo('Workspace name or path is out of the openfl workspace scope.')
+        echo("Workspace name or path is out of the openfl workspace scope.")
         sys.exit(1)
 
     if custom_template and template and notebook:
         raise ValueError(
-            'Please provide either `template`, `custom_template` or ' +
-            '`notebook`. Not all are necessary')
-    elif ((custom_template and template) or (template and notebook) or
-          (custom_template and notebook)):
-        raise ValueError('Please provide only one of the following options: ' +
-                         '`template`, `custom_template`, or `notebook`.')
+            "Please provide either `template`, `custom_template` or "
+            + "`notebook`. Not all are necessary"
+        )
+    elif (
+        (custom_template and template)
+        or (template and notebook)
+        or (custom_template and notebook)
+    ):
+        raise ValueError(
+            "Please provide only one of the following options: "
+            + "`template`, `custom_template`, or `notebook`."
+        )
 
     if not (custom_template or template or notebook):
-        raise ValueError('Please provide one of the following options: ' +
-                         '`template`, `custom_template`, or `notebook`.')
+        raise ValueError(
+            "Please provide one of the following options: "
+            + "`template`, `custom_template`, or `notebook`."
+        )
 
     if notebook:
         if not template_output_dir:
             raise ValueError(
-                'Please provide output_workspace which is Destination directory to '
-                + 'save your Jupyter Notebook workspace.')
+                "Please provide output_workspace which is Destination directory to "
+                + "save your Jupyter Notebook workspace."
+            )
 
         from openfl.experimental.workspace_export import WorkspaceExport
 
@@ -126,11 +141,13 @@ def create_(prefix, custom_template, template, notebook, template_output_dir):
         create(prefix, template_output_dir)
 
         logger.warning(
-            'The user should review the generated workspace for completeness ' +
-            'before proceeding')
+            "The user should review the generated workspace for completeness "
+            + "before proceeding"
+        )
     else:
         template = (
-            Path(custom_template).resolve() if custom_template else template)
+            Path(custom_template).resolve() if custom_template else template
+        )
         create(prefix, template)
 
 
@@ -140,7 +157,10 @@ def create(prefix, template):
     from subprocess import check_call
     from sys import executable
 
-    from openfl.experimental.interface.cli.cli_helper import OPENFL_USERDIR, print_tree
+    from openfl.experimental.interface.cli.cli_helper import (
+        OPENFL_USERDIR,
+        print_tree,
+    )
 
     if not OPENFL_USERDIR.exists():
         OPENFL_USERDIR.mkdir()
@@ -150,45 +170,55 @@ def create(prefix, template):
     create_dirs(prefix)
     create_temp(prefix, template)
 
-    requirements_filename = 'requirements.txt'
+    requirements_filename = "requirements.txt"
 
-    if not os.path.exists(f'{str(prefix)}/plan/data.yaml'):
+    if not os.path.exists(f"{str(prefix)}/plan/data.yaml"):
         echo(
             style(
-                'Participant private attributes shall be set to None as plan/data.yaml'
-                + ' was not found in the workspace.',
-                fg='yellow'))
+                "Participant private attributes shall be set to None as plan/data.yaml"
+                + " was not found in the workspace.",
+                fg="yellow",
+            )
+        )
 
-    if isfile(f'{str(prefix)}/{requirements_filename}'):
-        check_call([
-            executable, '-m', 'pip', 'install', '-r',
-            f'{prefix}/requirements.txt'
-        ],
-                   shell=False)
-        echo(f'Successfully installed packages from {prefix}/requirements.txt.')
+    if isfile(f"{str(prefix)}/{requirements_filename}"):
+        check_call(
+            [
+                executable,
+                "-m",
+                "pip",
+                "install",
+                "-r",
+                f"{prefix}/requirements.txt",
+            ],
+            shell=False,
+        )
+        echo(f"Successfully installed packages from {prefix}/requirements.txt.")
     else:
-        echo('No additional requirements for workspace defined. Skipping...')
+        echo("No additional requirements for workspace defined. Skipping...")
     prefix_hash = _get_dir_hash(str(prefix.absolute()))
     with open(
-            OPENFL_USERDIR / f'requirements.{prefix_hash}.txt',
-            'w',
-            encoding='utf-8') as f:
-        check_call([executable, '-m', 'pip', 'freeze'], shell=False, stdout=f)
+        OPENFL_USERDIR / f"requirements.{prefix_hash}.txt",
+        "w",
+        encoding="utf-8",
+    ) as f:
+        check_call([executable, "-m", "pip", "freeze"], shell=False, stdout=f)
 
     print_tree(prefix, level=3)
 
 
-@workspace.command(name='export')
+@workspace.command(name="export")
 @option(
-    '-o',
-    '--pip-install-options',
+    "-o",
+    "--pip-install-options",
     required=False,
     type=str,
     multiple=True,
     default=tuple,
-    help='Options for remote pip install. '
-    'You may pass several options in quotation marks alongside with arguments, '
-    'e.g. -o "--find-links source.site"')
+    help="Options for remote pip install. "
+    "You may pass several options in quotation marks alongside with arguments, "
+    'e.g. -o "--find-links source.site"',
+)
 def export_(pip_install_options: Tuple[str]):
     """Export federated learning workspace."""
     from os import getcwd, makedirs
@@ -203,13 +233,14 @@ def export_(pip_install_options: Tuple[str]):
 
     echo(
         style(
-            'This command will archive the contents of \'plan\' and \'src\' directory, user'
-            +
-            ' should review that these does not contain any information which is private and'
-            + ' not to be shared.',
-            fg='yellow'))
+            "This command will archive the contents of 'plan' and 'src' directory, user"
+            + " should review that these does not contain any information which is private and"
+            + " not to be shared.",
+            fg="yellow",
+        )
+    )
 
-    plan_file = Path('plan/plan.yaml').absolute()
+    plan_file = Path("plan/plan.yaml").absolute()
     try:
         freeze_plan(plan_file)
     except FileNotFoundError:
@@ -217,50 +248,55 @@ def export_(pip_install_options: Tuple[str]):
 
     # Dump requirements.txt
     dump_requirements_file(
-        prefixes=pip_install_options, keep_original_prefixes=True)
+        prefixes=pip_install_options, keep_original_prefixes=True
+    )
 
-    archive_type = 'zip'
+    archive_type = "zip"
     archive_name = basename(getcwd())
-    archive_file_name = archive_name + '.' + archive_type
+    archive_file_name = archive_name + "." + archive_type
 
     # Aggregator workspace
-    tmp_dir = join(mkdtemp(), 'openfl', archive_name)
+    tmp_dir = join(mkdtemp(), "openfl", archive_name)
 
-    ignore = ignore_patterns('__pycache__', '*.crt', '*.key', '*.csr', '*.srl',
-                             '*.pem', '*.pbuf')
+    ignore = ignore_patterns(
+        "__pycache__", "*.crt", "*.key", "*.csr", "*.srl", "*.pem", "*.pbuf"
+    )
 
     # We only export the minimum required files to set up a collaborator
-    makedirs(f'{tmp_dir}/save', exist_ok=True)
-    makedirs(f'{tmp_dir}/logs', exist_ok=True)
-    makedirs(f'{tmp_dir}/data', exist_ok=True)
-    copytree('./src', f'{tmp_dir}/src', ignore=ignore)  # code
-    copytree('./plan', f'{tmp_dir}/plan', ignore=ignore)  # plan
-    copy2('./requirements.txt', f'{tmp_dir}/requirements.txt')  # requirements
+    makedirs(f"{tmp_dir}/save", exist_ok=True)
+    makedirs(f"{tmp_dir}/logs", exist_ok=True)
+    makedirs(f"{tmp_dir}/data", exist_ok=True)
+    copytree("./src", f"{tmp_dir}/src", ignore=ignore)  # code
+    copytree("./plan", f"{tmp_dir}/plan", ignore=ignore)  # plan
+    copy2("./requirements.txt", f"{tmp_dir}/requirements.txt")  # requirements
 
     try:
-        copy2('.workspace', tmp_dir)  # .workspace
+        copy2(".workspace", tmp_dir)  # .workspace
     except FileNotFoundError:
-        echo('\'.workspace\' file not found.')
-        if confirm('Create a default \'.workspace\' file?'):
-            copy2(WORKSPACE / 'workspace' / '.workspace', tmp_dir)
+        echo("'.workspace' file not found.")
+        if confirm("Create a default '.workspace' file?"):
+            copy2(WORKSPACE / "workspace" / ".workspace", tmp_dir)
         else:
-            echo('To proceed, you must have a \'.workspace\' '
-                 'file in the current directory.')
+            echo(
+                "To proceed, you must have a '.workspace' "
+                "file in the current directory."
+            )
             raise
 
     # Create Zip archive of directory
-    echo('\n 🗜️ Preparing workspace distribution zip file')
+    echo("\n 🗜️ Preparing workspace distribution zip file")
     make_archive(archive_name, archive_type, tmp_dir)
     rmtree(tmp_dir)
-    echo(f'\n ✔️ Workspace exported to archive: {archive_file_name}')
+    echo(f"\n ✔️ Workspace exported to archive: {archive_file_name}")
 
 
-@workspace.command(name='import')
+@workspace.command(name="import")
 @option(
-    '--archive',
+    "--archive",
     required=True,
-    help='Zip file containing workspace to import',
-    type=ClickPath(exists=True))
+    help="Zip file containing workspace to import",
+    type=ClickPath(exists=True),
+)
 def import_(archive):
     """Import federated learning workspace."""
     from os import chdir
@@ -271,26 +307,29 @@ def import_(archive):
 
     archive = Path(archive).absolute()
 
-    dir_path = basename(archive).split('.')[0]
+    dir_path = basename(archive).split(".")[0]
     unpack_archive(archive, extract_dir=dir_path)
     chdir(dir_path)
 
-    requirements_filename = 'requirements.txt'
+    requirements_filename = "requirements.txt"
 
     if isfile(requirements_filename):
-        check_call([executable, '-m', 'pip', 'install', '--upgrade', 'pip'],
-                   shell=False)
         check_call(
-            [executable, '-m', 'pip', 'install', '-r', requirements_filename],
-            shell=False)
+            [executable, "-m", "pip", "install", "--upgrade", "pip"],
+            shell=False,
+        )
+        check_call(
+            [executable, "-m", "pip", "install", "-r", requirements_filename],
+            shell=False,
+        )
     else:
-        echo('No ' + requirements_filename + ' file found.')
+        echo("No " + requirements_filename + " file found.")
 
-    echo(f'Workspace {archive} has been imported.')
-    echo('You may need to copy your PKI certificates to join the federation.')
+    echo(f"Workspace {archive} has been imported.")
+    echo("You may need to copy your PKI certificates to join the federation.")
 
 
-@workspace.command(name='certify')
+@workspace.command(name="certify")
 def certify_():
     """Create certificate authority for federation."""
     certify()
@@ -307,128 +346,148 @@ def certify():
     )
     from openfl.experimental.interface.cli.cli_helper import CERT_DIR
 
-    echo('Setting Up Certificate Authority...\n')
+    echo("Setting Up Certificate Authority...\n")
 
-    echo('1.  Create Root CA')
-    echo('1.1 Create Directories')
+    echo("1.  Create Root CA")
+    echo("1.1 Create Directories")
 
-    (CERT_DIR / 'ca/root-ca/private').mkdir(
-        parents=True, exist_ok=True, mode=0o700)
-    (CERT_DIR / 'ca/root-ca/db').mkdir(parents=True, exist_ok=True)
+    (CERT_DIR / "ca/root-ca/private").mkdir(
+        parents=True, exist_ok=True, mode=0o700
+    )
+    (CERT_DIR / "ca/root-ca/db").mkdir(parents=True, exist_ok=True)
 
-    echo('1.2 Create Database')
+    echo("1.2 Create Database")
 
     with open(
-            CERT_DIR / 'ca/root-ca/db/root-ca.db', 'w', encoding='utf-8') as f:
+        CERT_DIR / "ca/root-ca/db/root-ca.db", "w", encoding="utf-8"
+    ) as f:
         pass  # write empty file
     with open(
-            CERT_DIR / 'ca/root-ca/db/root-ca.db.attr', 'w',
-            encoding='utf-8') as f:
+        CERT_DIR / "ca/root-ca/db/root-ca.db.attr", "w", encoding="utf-8"
+    ) as f:
         pass  # write empty file
 
     with open(
-            CERT_DIR / 'ca/root-ca/db/root-ca.crt.srl', 'w',
-            encoding='utf-8') as f:
-        f.write('01')  # write file with '01'
+        CERT_DIR / "ca/root-ca/db/root-ca.crt.srl", "w", encoding="utf-8"
+    ) as f:
+        f.write("01")  # write file with '01'
     with open(
-            CERT_DIR / 'ca/root-ca/db/root-ca.crl.srl', 'w',
-            encoding='utf-8') as f:
-        f.write('01')  # write file with '01'
+        CERT_DIR / "ca/root-ca/db/root-ca.crl.srl", "w", encoding="utf-8"
+    ) as f:
+        f.write("01")  # write file with '01'
 
-    echo('1.3 Create CA Request and Certificate')
+    echo("1.3 Create CA Request and Certificate")
 
-    root_crt_path = 'ca/root-ca.crt'
-    root_key_path = 'ca/root-ca/private/root-ca.key'
+    root_crt_path = "ca/root-ca.crt"
+    root_key_path = "ca/root-ca/private/root-ca.key"
 
     root_private_key, root_cert = generate_root_cert()
 
     # Write root CA certificate to disk
-    with open(CERT_DIR / root_crt_path, 'wb') as f:
-        f.write(root_cert.public_bytes(encoding=serialization.Encoding.PEM,))
+    with open(CERT_DIR / root_crt_path, "wb") as f:
+        f.write(
+            root_cert.public_bytes(
+                encoding=serialization.Encoding.PEM,
+            )
+        )
 
-    with open(CERT_DIR / root_key_path, 'wb') as f:
+    with open(CERT_DIR / root_key_path, "wb") as f:
         f.write(
             root_private_key.private_bytes(
                 encoding=serialization.Encoding.PEM,
                 format=serialization.PrivateFormat.TraditionalOpenSSL,
-                encryption_algorithm=serialization.NoEncryption()))
+                encryption_algorithm=serialization.NoEncryption(),
+            )
+        )
 
-    echo('2.  Create Signing Certificate')
-    echo('2.1 Create Directories')
+    echo("2.  Create Signing Certificate")
+    echo("2.1 Create Directories")
 
-    (CERT_DIR / 'ca/signing-ca/private').mkdir(
-        parents=True, exist_ok=True, mode=0o700)
-    (CERT_DIR / 'ca/signing-ca/db').mkdir(parents=True, exist_ok=True)
+    (CERT_DIR / "ca/signing-ca/private").mkdir(
+        parents=True, exist_ok=True, mode=0o700
+    )
+    (CERT_DIR / "ca/signing-ca/db").mkdir(parents=True, exist_ok=True)
 
-    echo('2.2 Create Database')
+    echo("2.2 Create Database")
 
     with open(
-            CERT_DIR / 'ca/signing-ca/db/signing-ca.db', 'w',
-            encoding='utf-8') as f:
+        CERT_DIR / "ca/signing-ca/db/signing-ca.db", "w", encoding="utf-8"
+    ) as f:
         pass  # write empty file
     with open(
-            CERT_DIR / 'ca/signing-ca/db/signing-ca.db.attr', 'w',
-            encoding='utf-8') as f:
+        CERT_DIR / "ca/signing-ca/db/signing-ca.db.attr", "w", encoding="utf-8"
+    ) as f:
         pass  # write empty file
 
     with open(
-            CERT_DIR / 'ca/signing-ca/db/signing-ca.crt.srl', 'w',
-            encoding='utf-8') as f:
-        f.write('01')  # write file with '01'
+        CERT_DIR / "ca/signing-ca/db/signing-ca.crt.srl", "w", encoding="utf-8"
+    ) as f:
+        f.write("01")  # write file with '01'
     with open(
-            CERT_DIR / 'ca/signing-ca/db/signing-ca.crl.srl', 'w',
-            encoding='utf-8') as f:
-        f.write('01')  # write file with '01'
+        CERT_DIR / "ca/signing-ca/db/signing-ca.crl.srl", "w", encoding="utf-8"
+    ) as f:
+        f.write("01")  # write file with '01'
 
-    echo('2.3 Create Signing Certificate CSR')
+    echo("2.3 Create Signing Certificate CSR")
 
-    signing_csr_path = 'ca/signing-ca.csr'
-    signing_crt_path = 'ca/signing-ca.crt'
-    signing_key_path = 'ca/signing-ca/private/signing-ca.key'
+    signing_csr_path = "ca/signing-ca.csr"
+    signing_crt_path = "ca/signing-ca.crt"
+    signing_key_path = "ca/signing-ca/private/signing-ca.key"
 
     signing_private_key, signing_csr = generate_signing_csr()
 
     # Write Signing CA CSR to disk
-    with open(CERT_DIR / signing_csr_path, 'wb') as f:
-        f.write(signing_csr.public_bytes(encoding=serialization.Encoding.PEM,))
+    with open(CERT_DIR / signing_csr_path, "wb") as f:
+        f.write(
+            signing_csr.public_bytes(
+                encoding=serialization.Encoding.PEM,
+            )
+        )
 
-    with open(CERT_DIR / signing_key_path, 'wb') as f:
+    with open(CERT_DIR / signing_key_path, "wb") as f:
         f.write(
             signing_private_key.private_bytes(
                 encoding=serialization.Encoding.PEM,
                 format=serialization.PrivateFormat.TraditionalOpenSSL,
-                encryption_algorithm=serialization.NoEncryption()))
+                encryption_algorithm=serialization.NoEncryption(),
+            )
+        )
 
-    echo('2.4 Sign Signing Certificate CSR')
+    echo("2.4 Sign Signing Certificate CSR")
 
     signing_cert = sign_certificate(
-        signing_csr, root_private_key, root_cert.subject, ca=True)
+        signing_csr, root_private_key, root_cert.subject, ca=True
+    )
 
-    with open(CERT_DIR / signing_crt_path, 'wb') as f:
-        f.write(signing_cert.public_bytes(encoding=serialization.Encoding.PEM,))
+    with open(CERT_DIR / signing_crt_path, "wb") as f:
+        f.write(
+            signing_cert.public_bytes(
+                encoding=serialization.Encoding.PEM,
+            )
+        )
 
-    echo('3   Create Certificate Chain')
+    echo("3   Create Certificate Chain")
 
     # create certificate chain file by combining root-ca and signing-ca
-    with open(CERT_DIR / 'cert_chain.crt', 'w', encoding='utf-8') as d:
-        with open(CERT_DIR / 'ca/root-ca.crt', encoding='utf-8') as s:
+    with open(CERT_DIR / "cert_chain.crt", "w", encoding="utf-8") as d:
+        with open(CERT_DIR / "ca/root-ca.crt", encoding="utf-8") as s:
             d.write(s.read())
-        with open(CERT_DIR / 'ca/signing-ca.crt') as s:
+        with open(CERT_DIR / "ca/signing-ca.crt") as s:
             d.write(s.read())
 
-    echo('\nDone.')
+    echo("\nDone.")
 
 
 # FIXME: Function is not in use
 
 
 def _get_requirements_dict(txtfile):
-    with open(txtfile, 'r', encoding='utf-8') as snapshot:
+    with open(txtfile, "r", encoding="utf-8") as snapshot:
         snapshot_dict = {}
         for line in snapshot:
             try:
                 # 'pip freeze' generates requirements with exact versions
-                k, v = line.split('==')
+                k, v = line.split("==")
                 snapshot_dict[k] = v
             except ValueError:
                 snapshot_dict[line] = None
@@ -437,8 +496,9 @@ def _get_requirements_dict(txtfile):
 
 def _get_dir_hash(path):
     from hashlib import sha256
+
     hash_ = sha256()
-    hash_.update(path.encode('utf-8'))
+    hash_.update(path.encode("utf-8"))
     hash_ = hash_.hexdigest()
     return hash_
 
@@ -455,6 +515,6 @@ def apply_template_plan(prefix, template):
     # Use the specified template if it's a Path, otherwise use WORKSPACE/template
     source = template if isinstance(template, Path) else WORKSPACE / template
 
-    template_plan = Plan.parse(source / 'plan' / 'plan.yaml')
+    template_plan = Plan.parse(source / "plan" / "plan.yaml")
 
-    Plan.dump(prefix / 'plan' / 'plan.yaml', template_plan.config)
+    Plan.dump(prefix / "plan" / "plan.yaml", template_plan.config)

--- a/openfl/experimental/interface/cli/workspace.py
+++ b/openfl/experimental/interface/cli/workspace.py
@@ -47,8 +47,7 @@ def create_temp(prefix, template):
     """Create workspace templates."""
     from shutil import ignore_patterns
 
-    from openfl.experimental.interface.cli.cli_helper import (WORKSPACE,
-                                                              copytree)
+    from openfl.experimental.interface.cli.cli_helper import WORKSPACE, copytree
 
     echo('Creating Workspace Templates')
     # Use the specified template if it's a Path, otherwise use WORKSPACE/template
@@ -141,8 +140,7 @@ def create(prefix, template):
     from subprocess import check_call
     from sys import executable
 
-    from openfl.experimental.interface.cli.cli_helper import (OPENFL_USERDIR,
-                                                              print_tree)
+    from openfl.experimental.interface.cli.cli_helper import OPENFL_USERDIR, print_tree
 
     if not OPENFL_USERDIR.exists():
         OPENFL_USERDIR.mkdir()
@@ -301,8 +299,12 @@ def certify_():
 def certify():
     """Create certificate authority for federation."""
     from cryptography.hazmat.primitives import serialization
-    from openfl.cryptography.ca import (generate_root_cert,
-                                        generate_signing_csr, sign_certificate)
+
+    from openfl.cryptography.ca import (
+        generate_root_cert,
+        generate_signing_csr,
+        sign_certificate,
+    )
     from openfl.experimental.interface.cli.cli_helper import CERT_DIR
 
     echo('Setting Up Certificate Authority...\n')

--- a/openfl/experimental/interface/cli/workspace.py
+++ b/openfl/experimental/interface/cli/workspace.py
@@ -2,20 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 """Workspace module."""
 
-import sys
 import os
+import sys
+from logging import getLogger
 from pathlib import Path
 from typing import Tuple
-from logging import getLogger
 
 from click import Choice
-from click import confirm
-from click import echo
-from click import style
-from click import group
-from click import option
-from click import pass_context
 from click import Path as ClickPath
+from click import confirm, echo, group, option, pass_context, style
 
 from openfl.utilities.path_check import is_directory_traversal
 from openfl.utilities.workspace import dump_requirements_file
@@ -51,8 +46,8 @@ def create_temp(prefix, template):
     """Create workspace templates."""
     from shutil import ignore_patterns
 
-    from openfl.experimental.interface.cli.cli_helper import copytree
-    from openfl.experimental.interface.cli.cli_helper import WORKSPACE
+    from openfl.experimental.interface.cli.cli_helper import (WORKSPACE,
+                                                              copytree)
 
     echo('Creating Workspace Templates')
     # Use the specified template if it's a Path, otherwise use WORKSPACE/template
@@ -141,10 +136,8 @@ def create(prefix, template):
     from subprocess import check_call
     from sys import executable
 
-    from openfl.experimental.interface.cli.cli_helper import (
-        OPENFL_USERDIR,
-        print_tree
-    )
+    from openfl.experimental.interface.cli.cli_helper import (OPENFL_USERDIR,
+                                                              print_tree)
 
     if not OPENFL_USERDIR.exists():
         OPENFL_USERDIR.mkdir()
@@ -182,17 +175,13 @@ def create(prefix, template):
              'e.g. -o "--find-links source.site"')
 def export_(pip_install_options: Tuple[str]):
     """Export federated learning workspace."""
-    from os import getcwd
-    from os import makedirs
-    from os.path import basename
-    from os.path import join
-    from shutil import copy2
-    from shutil import copytree
-    from shutil import ignore_patterns
-    from shutil import make_archive
+    from os import getcwd, makedirs
+    from os.path import basename, join
+    from shutil import copy2, copytree, ignore_patterns, make_archive
     from tempfile import mkdtemp
 
     from plan import freeze_plan
+
     from openfl.experimental.interface.cli.cli_helper import WORKSPACE
     from openfl.utilities.utils import rmtree
 
@@ -252,8 +241,7 @@ def export_(pip_install_options: Tuple[str]):
 def import_(archive):
     """Import federated learning workspace."""
     from os import chdir
-    from os.path import basename
-    from os.path import isfile
+    from os.path import basename, isfile
     from shutil import unpack_archive
     from subprocess import check_call
     from sys import executable
@@ -289,10 +277,8 @@ def certify_():
 def certify():
     """Create certificate authority for federation."""
     from cryptography.hazmat.primitives import serialization
-
-    from openfl.cryptography.ca import generate_root_cert
-    from openfl.cryptography.ca import generate_signing_csr
-    from openfl.cryptography.ca import sign_certificate
+    from openfl.cryptography.ca import (generate_root_cert,
+                                        generate_signing_csr, sign_certificate)
     from openfl.experimental.interface.cli.cli_helper import CERT_DIR
 
     echo('Setting Up Certificate Authority...\n')

--- a/openfl/experimental/interface/fl_spec.py
+++ b/openfl/experimental/interface/fl_spec.py
@@ -10,9 +10,15 @@ from typing import Callable, List, Type
 
 from openfl.experimental.runtime import Runtime
 from openfl.experimental.utilities import (
-    MetaflowInterface, SerializationError, aggregator_to_collaborator,
-    checkpoint, collaborator_to_aggregator, filter_attributes,
-    generate_artifacts, should_transfer)
+    MetaflowInterface,
+    SerializationError,
+    aggregator_to_collaborator,
+    checkpoint,
+    collaborator_to_aggregator,
+    filter_attributes,
+    generate_artifacts,
+    should_transfer,
+)
 
 
 class FLSpec:

--- a/openfl/experimental/interface/fl_spec.py
+++ b/openfl/experimental/interface/fl_spec.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2020-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
 """openfl.experimental.interface.flspec module."""
 
 from __future__ import annotations
@@ -10,13 +9,10 @@ from copy import deepcopy
 from typing import Callable, List, Type
 
 from openfl.experimental.runtime import Runtime
-from openfl.experimental.utilities import (MetaflowInterface,
-                                           SerializationError,
-                                           aggregator_to_collaborator,
-                                           checkpoint,
-                                           collaborator_to_aggregator,
-                                           filter_attributes,
-                                           generate_artifacts, should_transfer)
+from openfl.experimental.utilities import (
+    MetaflowInterface, SerializationError, aggregator_to_collaborator,
+    checkpoint, collaborator_to_aggregator, filter_attributes,
+    generate_artifacts, should_transfer)
 
 
 class FLSpec:
@@ -47,8 +43,7 @@ class FLSpec:
         # Submit flow to Runtime
         if str(self._runtime) == "LocalRuntime":
             self._metaflow_interface = MetaflowInterface(
-                self.__class__, self.runtime.backend
-            )
+                self.__class__, self.runtime.backend)
             self._run_id = self._metaflow_interface.create_run()
             # Initialize aggregator private attributes
             self.runtime.initialize_aggregator()
@@ -77,8 +72,7 @@ class FLSpec:
                         "\n or for more information about the original error,"
                         "\nPlease see the official Ray documentation"
                         "\nhttps://docs.ray.io/en/releases-2.2.0/ray-core/\
-                        objects/serialization.html"
-                    )
+                        objects/serialization.html")
                     raise SerializationError(str(e) + msg)
                 else:
                     raise e
@@ -117,7 +111,8 @@ class FLSpec:
             return_objs.append(backup)
         return return_objs
 
-    def _is_at_transition_point(self, f: Callable, parent_func: Callable) -> bool:
+    def _is_at_transition_point(self, f: Callable,
+                                parent_func: Callable) -> bool:
         """
         Has the collaborator finished its current sequence?
 
@@ -128,12 +123,15 @@ class FLSpec:
         if parent_func.__name__ in self._foreach_methods:
             self._foreach_methods.append(f.__name__)
             if should_transfer(f, parent_func):
-                print(f"Should transfer from {parent_func.__name__} to {f.__name__}")
+                print(
+                    f"Should transfer from {parent_func.__name__} to {f.__name__}"
+                )
                 self.execute_next = f.__name__
                 return True
         return False
 
-    def _display_transition_logs(self, f: Callable, parent_func: Callable) -> None:
+    def _display_transition_logs(self, f: Callable,
+                                 parent_func: Callable) -> None:
         """
         Prints aggregator to collaborators or
         collaborators to aggregator state transition logs
@@ -157,18 +155,17 @@ class FLSpec:
         for col in selected_collaborators:
             clone = FLSpec._clones[col]
             clone.input = col
-            if ("exclude" in kwargs and hasattr(clone, kwargs["exclude"][0])) or (
-                "include" in kwargs and hasattr(clone, kwargs["include"][0])
-            ):
+            if ("exclude" in kwargs and hasattr(clone, kwargs["exclude"][0])
+               ) or ("include" in kwargs and
+                     hasattr(clone, kwargs["include"][0])):
                 filter_attributes(clone, f, **kwargs)
             artifacts_iter, _ = generate_artifacts(ctx=self)
             for name, attr in artifacts_iter():
                 setattr(clone, name, deepcopy(attr))
             clone._foreach_methods = self._foreach_methods
 
-    def restore_instance_snapshot(
-        self, ctx: FLSpec, instance_snapshot: List[FLSpec]
-    ):
+    def restore_instance_snapshot(self, ctx: FLSpec,
+                                  instance_snapshot: List[FLSpec]):
         """Restores attributes from backup (in instance snapshot) to ctx"""
         for backup in instance_snapshot:
             artifacts_iter, _ = generate_artifacts(ctx=backup)
@@ -224,7 +221,7 @@ class FLSpec:
 
             if "foreach" in kwargs:
                 self.filter_exclude_include(f, **kwargs)
-            # if "foreach" in kwargs:
+                # if "foreach" in kwargs:
                 self.execute_task_args = (self, f, parent_func, FLSpec._clones,
                                           agg_to_collab_ss, kwargs)
             else:

--- a/openfl/experimental/interface/fl_spec.py
+++ b/openfl/experimental/interface/fl_spec.py
@@ -49,7 +49,8 @@ class FLSpec:
         # Submit flow to Runtime
         if str(self._runtime) == "LocalRuntime":
             self._metaflow_interface = MetaflowInterface(
-                self.__class__, self.runtime.backend)
+                self.__class__, self.runtime.backend
+            )
             self._run_id = self._metaflow_interface.create_run()
             # Initialize aggregator private attributes
             self.runtime.initialize_aggregator()
@@ -78,7 +79,8 @@ class FLSpec:
                         "\n or for more information about the original error,"
                         "\nPlease see the official Ray documentation"
                         "\nhttps://docs.ray.io/en/releases-2.2.0/ray-core/\
-                        objects/serialization.html")
+                        objects/serialization.html"
+                    )
                     raise SerializationError(str(e) + msg)
                 else:
                     raise e
@@ -117,8 +119,9 @@ class FLSpec:
             return_objs.append(backup)
         return return_objs
 
-    def _is_at_transition_point(self, f: Callable,
-                                parent_func: Callable) -> bool:
+    def _is_at_transition_point(
+        self, f: Callable, parent_func: Callable
+    ) -> bool:
         """
         Has the collaborator finished its current sequence?
 
@@ -136,8 +139,9 @@ class FLSpec:
                 return True
         return False
 
-    def _display_transition_logs(self, f: Callable,
-                                 parent_func: Callable) -> None:
+    def _display_transition_logs(
+        self, f: Callable, parent_func: Callable
+    ) -> None:
         """
         Prints aggregator to collaborators or
         collaborators to aggregator state transition logs
@@ -161,17 +165,18 @@ class FLSpec:
         for col in selected_collaborators:
             clone = FLSpec._clones[col]
             clone.input = col
-            if ("exclude" in kwargs and hasattr(clone, kwargs["exclude"][0])
-               ) or ("include" in kwargs and
-                     hasattr(clone, kwargs["include"][0])):
+            if (
+                "exclude" in kwargs and hasattr(clone, kwargs["exclude"][0])
+            ) or ("include" in kwargs and hasattr(clone, kwargs["include"][0])):
                 filter_attributes(clone, f, **kwargs)
             artifacts_iter, _ = generate_artifacts(ctx=self)
             for name, attr in artifacts_iter():
                 setattr(clone, name, deepcopy(attr))
             clone._foreach_methods = self._foreach_methods
 
-    def restore_instance_snapshot(self, ctx: FLSpec,
-                                  instance_snapshot: List[FLSpec]):
+    def restore_instance_snapshot(
+        self, ctx: FLSpec, instance_snapshot: List[FLSpec]
+    ):
         """Restores attributes from backup (in instance snapshot) to ctx"""
         for backup in instance_snapshot:
             artifacts_iter, _ = generate_artifacts(ctx=backup)
@@ -185,7 +190,7 @@ class FLSpec:
         """
         FLSpec._reset_clones()
         FLSpec._create_clones(self, self.runtime.collaborators)
-        selected_collaborators = self.__getattribute__(kwargs['foreach'])
+        selected_collaborators = self.__getattribute__(kwargs["foreach"])
 
         for col in selected_collaborators:
             clone = FLSpec._clones[col]
@@ -228,8 +233,14 @@ class FLSpec:
             if "foreach" in kwargs:
                 self.filter_exclude_include(f, **kwargs)
                 # if "foreach" in kwargs:
-                self.execute_task_args = (self, f, parent_func, FLSpec._clones,
-                                          agg_to_collab_ss, kwargs)
+                self.execute_task_args = (
+                    self,
+                    f,
+                    parent_func,
+                    FLSpec._clones,
+                    agg_to_collab_ss,
+                    kwargs,
+                )
             else:
                 self.execute_task_args = (self, f, parent_func, kwargs)
 

--- a/openfl/experimental/interface/fl_spec.py
+++ b/openfl/experimental/interface/fl_spec.py
@@ -7,18 +7,16 @@ from __future__ import annotations
 
 import inspect
 from copy import deepcopy
-from typing import Type, List, Callable
-from openfl.experimental.utilities import (
-    MetaflowInterface,
-    SerializationError,
-    generate_artifacts,
-    aggregator_to_collaborator,
-    collaborator_to_aggregator,
-    should_transfer,
-    filter_attributes,
-    checkpoint
-)
+from typing import Callable, List, Type
+
 from openfl.experimental.runtime import Runtime
+from openfl.experimental.utilities import (MetaflowInterface,
+                                           SerializationError,
+                                           aggregator_to_collaborator,
+                                           checkpoint,
+                                           collaborator_to_aggregator,
+                                           filter_attributes,
+                                           generate_artifacts, should_transfer)
 
 
 class FLSpec:

--- a/openfl/experimental/interface/participants.py
+++ b/openfl/experimental/interface/participants.py
@@ -43,12 +43,14 @@ class Collaborator(Participant):
     Defines a collaborator participant
     """
 
-    def __init__(self,
-                 name: str = "",
-                 private_attributes_callable: Callable = None,
-                 num_cpus: int = 0,
-                 num_gpus: int = 0.0,
-                 **kwargs):
+    def __init__(
+        self,
+        name: str = "",
+        private_attributes_callable: Callable = None,
+        num_cpus: int = 0,
+        num_gpus: int = 0.0,
+        **kwargs
+    ):
         """
         Create collaborator object with custom resources and a callable
         function to assign private attributes
@@ -80,7 +82,8 @@ class Collaborator(Participant):
         else:
             if not callable(private_attributes_callable):
                 raise Exception(
-                    "private_attributes_callable  parameter must be a callable")
+                    "private_attributes_callable  parameter must be a callable"
+                )
             else:
                 self.private_attributes_callable = private_attributes_callable
 
@@ -95,7 +98,8 @@ class Collaborator(Participant):
         """
         if self.private_attributes_callable is not None:
             self.private_attributes = self.private_attributes_callable(
-                **self.kwargs)
+                **self.kwargs
+            )
 
     def __set_collaborator_attrs_to_clone(self, clone: Any) -> None:
         """
@@ -117,7 +121,8 @@ class Collaborator(Participant):
         for attr_name in self.private_attributes:
             if hasattr(clone, attr_name):
                 self.private_attributes.update(
-                    {attr_name: getattr(clone, attr_name)})
+                    {attr_name: getattr(clone, attr_name)}
+                )
                 delattr(clone, attr_name)
 
     def execute_func(self, ctx: Any, f_name: str, callback: Callable) -> Any:
@@ -138,12 +143,14 @@ class Aggregator(Participant):
     Defines an aggregator participant
     """
 
-    def __init__(self,
-                 name: str = "",
-                 private_attributes_callable: Callable = None,
-                 num_cpus: int = 0,
-                 num_gpus: int = 0.0,
-                 **kwargs):
+    def __init__(
+        self,
+        name: str = "",
+        private_attributes_callable: Callable = None,
+        num_cpus: int = 0,
+        num_gpus: int = 0.0,
+        **kwargs
+    ):
         """
         Create aggregator object with custom resources and a callable
         function to assign private attributes
@@ -175,7 +182,8 @@ class Aggregator(Participant):
         else:
             if not callable(private_attributes_callable):
                 raise Exception(
-                    "private_attributes_callable parameter must be a callable")
+                    "private_attributes_callable parameter must be a callable"
+                )
             else:
                 self.private_attributes_callable = private_attributes_callable
 
@@ -190,7 +198,8 @@ class Aggregator(Participant):
         """
         if self.private_attributes_callable is not None:
             self.private_attributes = self.private_attributes_callable(
-                **self.kwargs)
+                **self.kwargs
+            )
 
     def __set_agg_attrs_to_clone(self, clone: Any) -> None:
         """
@@ -212,14 +221,17 @@ class Aggregator(Participant):
         for attr_name in self.private_attributes:
             if hasattr(clone, attr_name):
                 self.private_attributes.update(
-                    {attr_name: getattr(clone, attr_name)})
+                    {attr_name: getattr(clone, attr_name)}
+                )
                 delattr(clone, attr_name)
 
-    def execute_func(self,
-                     ctx: Any,
-                     f_name: str,
-                     callback: Callable,
-                     clones: Optional[Any] = None) -> Any:
+    def execute_func(
+        self,
+        ctx: Any,
+        f_name: str,
+        callback: Callable,
+        clones: Optional[Any] = None,
+    ) -> Any:
         """
         Execute remote function f
         """

--- a/openfl/experimental/interface/participants.py
+++ b/openfl/experimental/interface/participants.py
@@ -1,12 +1,12 @@
 # Copyright (C) 2020-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
 """openfl.experimental.interface.participants module."""
 
 from typing import Any, Callable, Dict, Optional
 
 
 class Participant:
+
     def __init__(self, name: str = ""):
         self.private_attributes = {}
         self._name = name.lower()
@@ -43,14 +43,12 @@ class Collaborator(Participant):
     Defines a collaborator participant
     """
 
-    def __init__(
-        self,
-        name: str = "",
-        private_attributes_callable: Callable = None,
-        num_cpus: int = 0,
-        num_gpus: int = 0.0,
-        **kwargs
-    ):
+    def __init__(self,
+                 name: str = "",
+                 private_attributes_callable: Callable = None,
+                 num_cpus: int = 0,
+                 num_gpus: int = 0.0,
+                 **kwargs):
         """
         Create collaborator object with custom resources and a callable
         function to assign private attributes
@@ -82,8 +80,7 @@ class Collaborator(Participant):
         else:
             if not callable(private_attributes_callable):
                 raise Exception(
-                    "private_attributes_callable  parameter must be a callable"
-                )
+                    "private_attributes_callable  parameter must be a callable")
             else:
                 self.private_attributes_callable = private_attributes_callable
 
@@ -97,7 +94,8 @@ class Collaborator(Participant):
         the callable specified by user
         """
         if self.private_attributes_callable is not None:
-            self.private_attributes = self.private_attributes_callable(**self.kwargs)
+            self.private_attributes = self.private_attributes_callable(
+                **self.kwargs)
 
     def __set_collaborator_attrs_to_clone(self, clone: Any) -> None:
         """
@@ -118,7 +116,8 @@ class Collaborator(Participant):
         # parameters from clone, then delete attributes from clone.
         for attr_name in self.private_attributes:
             if hasattr(clone, attr_name):
-                self.private_attributes.update({attr_name: getattr(clone, attr_name)})
+                self.private_attributes.update(
+                    {attr_name: getattr(clone, attr_name)})
                 delattr(clone, attr_name)
 
     def execute_func(self, ctx: Any, f_name: str, callback: Callable) -> Any:
@@ -139,14 +138,12 @@ class Aggregator(Participant):
     Defines an aggregator participant
     """
 
-    def __init__(
-        self,
-        name: str = "",
-        private_attributes_callable: Callable = None,
-        num_cpus: int = 0,
-        num_gpus: int = 0.0,
-        **kwargs
-    ):
+    def __init__(self,
+                 name: str = "",
+                 private_attributes_callable: Callable = None,
+                 num_cpus: int = 0,
+                 num_gpus: int = 0.0,
+                 **kwargs):
         """
         Create aggregator object with custom resources and a callable
         function to assign private attributes
@@ -178,8 +175,7 @@ class Aggregator(Participant):
         else:
             if not callable(private_attributes_callable):
                 raise Exception(
-                    "private_attributes_callable parameter must be a callable"
-                )
+                    "private_attributes_callable parameter must be a callable")
             else:
                 self.private_attributes_callable = private_attributes_callable
 
@@ -193,7 +189,8 @@ class Aggregator(Participant):
         the callable specified by user
         """
         if self.private_attributes_callable is not None:
-            self.private_attributes = self.private_attributes_callable(**self.kwargs)
+            self.private_attributes = self.private_attributes_callable(
+                **self.kwargs)
 
     def __set_agg_attrs_to_clone(self, clone: Any) -> None:
         """
@@ -214,10 +211,14 @@ class Aggregator(Participant):
         # parameters from clone, then delete attributes from clone.
         for attr_name in self.private_attributes:
             if hasattr(clone, attr_name):
-                self.private_attributes.update({attr_name: getattr(clone, attr_name)})
+                self.private_attributes.update(
+                    {attr_name: getattr(clone, attr_name)})
                 delattr(clone, attr_name)
 
-    def execute_func(self, ctx: Any, f_name: str, callback: Callable,
+    def execute_func(self,
+                     ctx: Any,
+                     f_name: str,
+                     callback: Callable,
                      clones: Optional[Any] = None) -> Any:
         """
         Execute remote function f

--- a/openfl/experimental/interface/participants.py
+++ b/openfl/experimental/interface/participants.py
@@ -3,8 +3,7 @@
 
 """openfl.experimental.interface.participants module."""
 
-from typing import Dict, Any
-from typing import Callable, Optional
+from typing import Any, Callable, Dict, Optional
 
 
 class Participant:

--- a/openfl/experimental/placement/__init__.py
+++ b/openfl/experimental/placement/__init__.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2020-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
 """openfl.experimental.placement package."""
 
 from .placement import aggregator, collaborator

--- a/openfl/experimental/placement/__init__.py
+++ b/openfl/experimental/placement/__init__.py
@@ -2,6 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 """openfl.experimental.placement package."""
 
-from .placement import aggregator, collaborator
-
-__all__ = ["aggregator", "collaborator"]
+# FIXME: Unnecessary recursion.
+from openfl.experimental.placement.placement import aggregator, collaborator

--- a/openfl/experimental/placement/placement.py
+++ b/openfl/experimental/placement/placement.py
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import functools
-from openfl.experimental.utilities import RedirectStdStreamContext
 from typing import Callable
+
+from openfl.experimental.utilities import RedirectStdStreamContext
 
 
 def aggregator(f: Callable = None) -> Callable:

--- a/openfl/experimental/protocols/interceptors.py
+++ b/openfl/experimental/protocols/interceptors.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2020-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
 """gRPC interceptors module."""
 import collections
 
@@ -48,12 +47,10 @@ def _create_generic_interceptor(intercept_call):
 
 
 class _ClientCallDetails(
-    collections.namedtuple(
-        '_ClientCallDetails',
-        ('method', 'timeout', 'metadata', 'credentials')
-    ),
-    grpc.ClientCallDetails
-):
+        collections.namedtuple(
+            '_ClientCallDetails',
+            ('method', 'timeout', 'metadata', 'credentials')),
+        grpc.ClientCallDetails):
     pass
 
 

--- a/openfl/experimental/protocols/interceptors.py
+++ b/openfl/experimental/protocols/interceptors.py
@@ -6,38 +6,47 @@ import collections
 import grpc
 
 
-class _GenericClientInterceptor(grpc.UnaryUnaryClientInterceptor,
-                                grpc.UnaryStreamClientInterceptor,
-                                grpc.StreamUnaryClientInterceptor,
-                                grpc.StreamStreamClientInterceptor):
+class _GenericClientInterceptor(
+    grpc.UnaryUnaryClientInterceptor,
+    grpc.UnaryStreamClientInterceptor,
+    grpc.StreamUnaryClientInterceptor,
+    grpc.StreamStreamClientInterceptor,
+):
 
     def __init__(self, interceptor_function):
         self._fn = interceptor_function
 
     def intercept_unary_unary(self, continuation, client_call_details, request):
         new_details, new_request_iterator, postprocess = self._fn(
-            client_call_details, iter((request,)), False, False)
+            client_call_details, iter((request,)), False, False
+        )
         response = continuation(new_details, next(new_request_iterator))
         return postprocess(response) if postprocess else response
 
-    def intercept_unary_stream(self, continuation, client_call_details,
-                               request):
+    def intercept_unary_stream(
+        self, continuation, client_call_details, request
+    ):
         new_details, new_request_iterator, postprocess = self._fn(
-            client_call_details, iter((request,)), False, True)
+            client_call_details, iter((request,)), False, True
+        )
         response_it = continuation(new_details, next(new_request_iterator))
         return postprocess(response_it) if postprocess else response_it
 
-    def intercept_stream_unary(self, continuation, client_call_details,
-                               request_iterator):
+    def intercept_stream_unary(
+        self, continuation, client_call_details, request_iterator
+    ):
         new_details, new_request_iterator, postprocess = self._fn(
-            client_call_details, request_iterator, True, False)
+            client_call_details, request_iterator, True, False
+        )
         response = continuation(new_details, new_request_iterator)
         return postprocess(response) if postprocess else response
 
-    def intercept_stream_stream(self, continuation, client_call_details,
-                                request_iterator):
+    def intercept_stream_stream(
+        self, continuation, client_call_details, request_iterator
+    ):
         new_details, new_request_iterator, postprocess = self._fn(
-            client_call_details, request_iterator, True, True)
+            client_call_details, request_iterator, True, True
+        )
         response_it = continuation(new_details, new_request_iterator)
         return postprocess(response_it) if postprocess else response_it
 
@@ -47,29 +56,39 @@ def _create_generic_interceptor(intercept_call):
 
 
 class _ClientCallDetails(
-        collections.namedtuple(
-            '_ClientCallDetails',
-            ('method', 'timeout', 'metadata', 'credentials')),
-        grpc.ClientCallDetails):
+    collections.namedtuple(
+        "_ClientCallDetails", ("method", "timeout", "metadata", "credentials")
+    ),
+    grpc.ClientCallDetails,
+):
     pass
 
 
 def headers_adder(headers):
     """Create interceptor with added headers."""
 
-    def intercept_call(client_call_details, request_iterator, request_streaming,
-                       response_streaming):
+    def intercept_call(
+        client_call_details,
+        request_iterator,
+        request_streaming,
+        response_streaming,
+    ):
         metadata = []
         if client_call_details.metadata is not None:
             metadata = list(client_call_details.metadata)
         for header, value in headers.items():
-            metadata.append((
-                header,
-                value,
-            ))
+            metadata.append(
+                (
+                    header,
+                    value,
+                )
+            )
         client_call_details = _ClientCallDetails(
-            client_call_details.method, client_call_details.timeout, metadata,
-            client_call_details.credentials)
+            client_call_details.method,
+            client_call_details.timeout,
+            metadata,
+            client_call_details.credentials,
+        )
         return client_call_details, request_iterator, None
 
     return _create_generic_interceptor(intercept_call)

--- a/openfl/experimental/protocols/utils.py
+++ b/openfl/experimental/protocols/utils.py
@@ -25,23 +25,21 @@ def model_proto_to_bytes_and_metadata(model_proto):
             'int_to_float': proto.int_to_float,
             'int_list': proto.int_list,
             'bool_list': proto.bool_list
-        }
-            for proto in tensor_proto.transformer_metadata
-        ]
+        } for proto in tensor_proto.transformer_metadata]
         if round_number is None:
             round_number = tensor_proto.round_number
         else:
             assert round_number == tensor_proto.round_number, (
                 f'Round numbers in model are inconsistent: {round_number} '
-                f'and {tensor_proto.round_number}'
-            )
+                f'and {tensor_proto.round_number}')
     return bytes_dict, metadata_dict, round_number
 
 
 def bytes_and_metadata_to_model_proto(bytes_dict, model_id, model_version,
                                       is_delta, metadata_dict):
     """Convert bytes and metadata to model protobuf."""
-    model_header = ModelHeader(id=model_id, version=model_version, is_delta=is_delta)  # NOQA:F821
+    model_header = ModelHeader(
+        id=model_id, version=model_version, is_delta=is_delta)  # NOQA:F821
 
     tensor_protos = []
     for key, data_bytes in bytes_dict.items():
@@ -62,14 +60,17 @@ def bytes_and_metadata_to_model_proto(bytes_dict, model_id, model_version,
                 bool_list = metadata.get('bool_list')
             else:
                 bool_list = []
-            metadata_protos.append(base_pb2.MetadataProto(
-                int_to_float=int_to_float,
-                int_list=int_list,
-                bool_list=bool_list,
-            ))
-        tensor_protos.append(TensorProto(name=key,  # NOQA:F821
-                                         data_bytes=data_bytes,
-                                         transformer_metadata=metadata_protos))
+            metadata_protos.append(
+                base_pb2.MetadataProto(
+                    int_to_float=int_to_float,
+                    int_list=int_list,
+                    bool_list=bool_list,
+                ))
+        tensor_protos.append(
+            TensorProto(
+                name=key,  # NOQA:F821
+                data_bytes=data_bytes,
+                transformer_metadata=metadata_protos))
     return base_pb2.ModelProto(header=model_header, tensors=tensor_protos)
 
 
@@ -91,11 +92,12 @@ def construct_named_tensor(tensor_key, nparray, transformer_metadata, lossless):
             bool_list = metadata.get('bool_list')
         else:
             bool_list = []
-        metadata_protos.append(base_pb2.MetadataProto(
-            int_to_float=int_to_float,
-            int_list=int_list,
-            bool_list=bool_list,
-        ))
+        metadata_protos.append(
+            base_pb2.MetadataProto(
+                int_to_float=int_to_float,
+                int_list=int_list,
+                bool_list=bool_list,
+            ))
 
     tensor_name, origin, round_number, report, tags = tensor_key
 
@@ -110,21 +112,24 @@ def construct_named_tensor(tensor_key, nparray, transformer_metadata, lossless):
     )
 
 
-def construct_proto(tensor_dict, model_id, model_version, is_delta, compression_pipeline):
+def construct_proto(tensor_dict, model_id, model_version, is_delta,
+                    compression_pipeline):
     """Construct proto."""
     # compress the arrays in the tensor_dict, and form the model proto
     # TODO: Hold-out tensors from the compression pipeline.
     bytes_dict = {}
     metadata_dict = {}
     for key, array in tensor_dict.items():
-        bytes_dict[key], metadata_dict[key] = compression_pipeline.forward(data=array)
+        bytes_dict[key], metadata_dict[key] = compression_pipeline.forward(
+            data=array)
 
     # convert the compressed_tensor_dict and metadata to protobuf, and make the new model proto
-    model_proto = bytes_and_metadata_to_model_proto(bytes_dict=bytes_dict,
-                                                    model_id=model_id,
-                                                    model_version=model_version,
-                                                    is_delta=is_delta,
-                                                    metadata_dict=metadata_dict)
+    model_proto = bytes_and_metadata_to_model_proto(
+        bytes_dict=bytes_dict,
+        model_id=model_id,
+        model_version=model_version,
+        is_delta=is_delta,
+        metadata_dict=metadata_dict)
     return model_proto
 
 
@@ -136,12 +141,13 @@ def construct_model_proto(tensor_dict, round_number, tensor_pipe):
     for key, nparray in tensor_dict.items():
         bytes_data, transformer_metadata = tensor_pipe.forward(data=nparray)
         tensor_key = TensorKey(key, 'agg', round_number, False, ('model',))
-        named_tensors.append(construct_named_tensor(
-            tensor_key,
-            bytes_data,
-            transformer_metadata,
-            lossless=True,
-        ))
+        named_tensors.append(
+            construct_named_tensor(
+                tensor_key,
+                bytes_data,
+                transformer_metadata,
+                lossless=True,
+            ))
 
     return base_pb2.ModelProto(tensors=named_tensors)
 
@@ -149,15 +155,16 @@ def construct_model_proto(tensor_dict, round_number, tensor_pipe):
 def deconstruct_model_proto(model_proto, compression_pipeline):
     """Deconstruct model proto."""
     # extract the tensor_dict and metadata
-    bytes_dict, metadata_dict, round_number = model_proto_to_bytes_and_metadata(model_proto)
+    bytes_dict, metadata_dict, round_number = model_proto_to_bytes_and_metadata(
+        model_proto)
 
     # decompress the tensors
     # TODO: Handle tensors meant to be held-out from the compression pipeline
     #  (currently none are held out).
     tensor_dict = {}
     for key in bytes_dict:
-        tensor_dict[key] = compression_pipeline.backward(data=bytes_dict[key],
-                                                         transformer_metadata=metadata_dict[key])
+        tensor_dict[key] = compression_pipeline.backward(
+            data=bytes_dict[key], transformer_metadata=metadata_dict[key])
     return tensor_dict, round_number
 
 
@@ -179,8 +186,8 @@ def deconstruct_proto(model_proto, compression_pipeline):
     #  (currently none are held out).
     tensor_dict = {}
     for key in bytes_dict:
-        tensor_dict[key] = compression_pipeline.backward(data=bytes_dict[key],
-                                                         transformer_metadata=metadata_dict[key])
+        tensor_dict[key] = compression_pipeline.backward(
+            data=bytes_dict[key], transformer_metadata=metadata_dict[key])
     return tensor_dict
 
 
@@ -233,7 +240,8 @@ def datastream_to_proto(proto, stream, logger=None):
             logger.debug(f'datastream_to_proto parsed a {type(proto)}.')
         return proto
     else:
-        raise RuntimeError(f'Received empty stream message of type {type(proto)}')
+        raise RuntimeError(
+            f'Received empty stream message of type {type(proto)}')
 
 
 def proto_to_datastream(proto, logger, max_buffer_size=(2 * 1024 * 1024)):
@@ -249,10 +257,12 @@ def proto_to_datastream(proto, logger, max_buffer_size=(2 * 1024 * 1024)):
     npbytes = proto.SerializeToString()
     data_size = len(npbytes)
     buffer_size = data_size if max_buffer_size > data_size else max_buffer_size
-    logger.debug(f'Setting stream chunks with size {buffer_size} for proto of type {type(proto)}')
+    logger.debug(
+        f'Setting stream chunks with size {buffer_size} for proto of type {type(proto)}'
+    )
 
     for i in range(0, data_size, buffer_size):
-        chunk = npbytes[i: i + buffer_size]
+        chunk = npbytes[i:i + buffer_size]
         reply = base_pb2.DataStream(npbytes=chunk, size=len(chunk))
         yield reply
 

--- a/openfl/experimental/protocols/utils.py
+++ b/openfl/experimental/protocols/utils.py
@@ -21,43 +21,49 @@ def model_proto_to_bytes_and_metadata(model_proto):
     round_number = None
     for tensor_proto in model_proto.tensors:
         bytes_dict[tensor_proto.name] = tensor_proto.data_bytes
-        metadata_dict[tensor_proto.name] = [{
-            'int_to_float': proto.int_to_float,
-            'int_list': proto.int_list,
-            'bool_list': proto.bool_list
-        } for proto in tensor_proto.transformer_metadata]
+        metadata_dict[tensor_proto.name] = [
+            {
+                "int_to_float": proto.int_to_float,
+                "int_list": proto.int_list,
+                "bool_list": proto.bool_list,
+            }
+            for proto in tensor_proto.transformer_metadata
+        ]
         if round_number is None:
             round_number = tensor_proto.round_number
         else:
             assert round_number == tensor_proto.round_number, (
-                f'Round numbers in model are inconsistent: {round_number} '
-                f'and {tensor_proto.round_number}')
+                f"Round numbers in model are inconsistent: {round_number} "
+                f"and {tensor_proto.round_number}"
+            )
     return bytes_dict, metadata_dict, round_number
 
 
-def bytes_and_metadata_to_model_proto(bytes_dict, model_id, model_version,
-                                      is_delta, metadata_dict):
+def bytes_and_metadata_to_model_proto(
+    bytes_dict, model_id, model_version, is_delta, metadata_dict
+):
     """Convert bytes and metadata to model protobuf."""
     model_header = ModelHeader(
-        id=model_id, version=model_version, is_delta=is_delta)  # NOQA:F821
+        id=model_id, version=model_version, is_delta=is_delta
+    )  # NOQA:F821
 
     tensor_protos = []
     for key, data_bytes in bytes_dict.items():
         transformer_metadata = metadata_dict[key]
         metadata_protos = []
         for metadata in transformer_metadata:
-            if metadata.get('int_to_float') is not None:
-                int_to_float = metadata.get('int_to_float')
+            if metadata.get("int_to_float") is not None:
+                int_to_float = metadata.get("int_to_float")
             else:
                 int_to_float = {}
 
-            if metadata.get('int_list') is not None:
-                int_list = metadata.get('int_list')
+            if metadata.get("int_list") is not None:
+                int_list = metadata.get("int_list")
             else:
                 int_list = []
 
-            if metadata.get('bool_list') is not None:
-                bool_list = metadata.get('bool_list')
+            if metadata.get("bool_list") is not None:
+                bool_list = metadata.get("bool_list")
             else:
                 bool_list = []
             metadata_protos.append(
@@ -65,12 +71,15 @@ def bytes_and_metadata_to_model_proto(bytes_dict, model_id, model_version,
                     int_to_float=int_to_float,
                     int_list=int_list,
                     bool_list=bool_list,
-                ))
+                )
+            )
         tensor_protos.append(
             TensorProto(
                 name=key,  # NOQA:F821
                 data_bytes=data_bytes,
-                transformer_metadata=metadata_protos))
+                transformer_metadata=metadata_protos,
+            )
+        )
     return base_pb2.ModelProto(header=model_header, tensors=tensor_protos)
 
 
@@ -78,18 +87,18 @@ def construct_named_tensor(tensor_key, nparray, transformer_metadata, lossless):
     """Construct named tensor."""
     metadata_protos = []
     for metadata in transformer_metadata:
-        if metadata.get('int_to_float') is not None:
-            int_to_float = metadata.get('int_to_float')
+        if metadata.get("int_to_float") is not None:
+            int_to_float = metadata.get("int_to_float")
         else:
             int_to_float = {}
 
-        if metadata.get('int_list') is not None:
-            int_list = metadata.get('int_list')
+        if metadata.get("int_list") is not None:
+            int_list = metadata.get("int_list")
         else:
             int_list = []
 
-        if metadata.get('bool_list') is not None:
-            bool_list = metadata.get('bool_list')
+        if metadata.get("bool_list") is not None:
+            bool_list = metadata.get("bool_list")
         else:
             bool_list = []
         metadata_protos.append(
@@ -97,7 +106,8 @@ def construct_named_tensor(tensor_key, nparray, transformer_metadata, lossless):
                 int_to_float=int_to_float,
                 int_list=int_list,
                 bool_list=bool_list,
-            ))
+            )
+        )
 
     tensor_name, origin, round_number, report, tags = tensor_key
 
@@ -112,8 +122,9 @@ def construct_named_tensor(tensor_key, nparray, transformer_metadata, lossless):
     )
 
 
-def construct_proto(tensor_dict, model_id, model_version, is_delta,
-                    compression_pipeline):
+def construct_proto(
+    tensor_dict, model_id, model_version, is_delta, compression_pipeline
+):
     """Construct proto."""
     # compress the arrays in the tensor_dict, and form the model proto
     # TODO: Hold-out tensors from the compression pipeline.
@@ -121,7 +132,8 @@ def construct_proto(tensor_dict, model_id, model_version, is_delta,
     metadata_dict = {}
     for key, array in tensor_dict.items():
         bytes_dict[key], metadata_dict[key] = compression_pipeline.forward(
-            data=array)
+            data=array
+        )
 
     # convert the compressed_tensor_dict and metadata to protobuf, and make the new model proto
     model_proto = bytes_and_metadata_to_model_proto(
@@ -129,7 +141,8 @@ def construct_proto(tensor_dict, model_id, model_version, is_delta,
         model_id=model_id,
         model_version=model_version,
         is_delta=is_delta,
-        metadata_dict=metadata_dict)
+        metadata_dict=metadata_dict,
+    )
     return model_proto
 
 
@@ -140,14 +153,15 @@ def construct_model_proto(tensor_dict, round_number, tensor_pipe):
     named_tensors = []
     for key, nparray in tensor_dict.items():
         bytes_data, transformer_metadata = tensor_pipe.forward(data=nparray)
-        tensor_key = TensorKey(key, 'agg', round_number, False, ('model',))
+        tensor_key = TensorKey(key, "agg", round_number, False, ("model",))
         named_tensors.append(
             construct_named_tensor(
                 tensor_key,
                 bytes_data,
                 transformer_metadata,
                 lossless=True,
-            ))
+            )
+        )
 
     return base_pb2.ModelProto(tensors=named_tensors)
 
@@ -156,7 +170,8 @@ def deconstruct_model_proto(model_proto, compression_pipeline):
     """Deconstruct model proto."""
     # extract the tensor_dict and metadata
     bytes_dict, metadata_dict, round_number = model_proto_to_bytes_and_metadata(
-        model_proto)
+        model_proto
+    )
 
     # decompress the tensors
     # TODO: Handle tensors meant to be held-out from the compression pipeline
@@ -164,7 +179,8 @@ def deconstruct_model_proto(model_proto, compression_pipeline):
     tensor_dict = {}
     for key in bytes_dict:
         tensor_dict[key] = compression_pipeline.backward(
-            data=bytes_dict[key], transformer_metadata=metadata_dict[key])
+            data=bytes_dict[key], transformer_metadata=metadata_dict[key]
+        )
     return tensor_dict, round_number
 
 
@@ -187,7 +203,8 @@ def deconstruct_proto(model_proto, compression_pipeline):
     tensor_dict = {}
     for key in bytes_dict:
         tensor_dict[key] = compression_pipeline.backward(
-            data=bytes_dict[key], transformer_metadata=metadata_dict[key])
+            data=bytes_dict[key], transformer_metadata=metadata_dict[key]
+        )
     return tensor_dict
 
 
@@ -200,7 +217,7 @@ def load_proto(fpath):
     Returns:
         protobuf: A protobuf of the model
     """
-    with open(fpath, 'rb') as f:
+    with open(fpath, "rb") as f:
         loaded = f.read()
         model = base_pb2.ModelProto().FromString(loaded)
         return model
@@ -215,7 +232,7 @@ def dump_proto(model_proto, fpath):
 
     """
     s = model_proto.SerializeToString()
-    with open(fpath, 'wb') as f:
+    with open(fpath, "wb") as f:
         f.write(s)
 
 
@@ -230,18 +247,19 @@ def datastream_to_proto(proto, stream, logger=None):
     Returns:
         protobuf: A protobuf of the model
     """
-    npbytes = b''
+    npbytes = b""
     for chunk in stream:
         npbytes += chunk.npbytes
 
     if len(npbytes) > 0:
         proto.ParseFromString(npbytes)
         if logger is not None:
-            logger.debug(f'datastream_to_proto parsed a {type(proto)}.')
+            logger.debug(f"datastream_to_proto parsed a {type(proto)}.")
         return proto
     else:
         raise RuntimeError(
-            f'Received empty stream message of type {type(proto)}')
+            f"Received empty stream message of type {type(proto)}"
+        )
 
 
 def proto_to_datastream(proto, logger, max_buffer_size=(2 * 1024 * 1024)):
@@ -258,11 +276,11 @@ def proto_to_datastream(proto, logger, max_buffer_size=(2 * 1024 * 1024)):
     data_size = len(npbytes)
     buffer_size = data_size if max_buffer_size > data_size else max_buffer_size
     logger.debug(
-        f'Setting stream chunks with size {buffer_size} for proto of type {type(proto)}'
+        f"Setting stream chunks with size {buffer_size} for proto of type {type(proto)}"
     )
 
     for i in range(0, data_size, buffer_size):
-        chunk = npbytes[i:i + buffer_size]
+        chunk = npbytes[i : i + buffer_size]
         reply = base_pb2.DataStream(npbytes=chunk, size=len(chunk))
         yield reply
 

--- a/openfl/experimental/runtime/__init__.py
+++ b/openfl/experimental/runtime/__init__.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """ openfl.experimental.runtime package Runtime class."""
 
-from .federated_runtime import FederatedRuntime
-from .local_runtime import LocalRuntime
-from .runtime import Runtime
-
-__all__ = ["FederatedRuntime", "LocalRuntime", "Runtime"]
+from openfl.experimental.runtime.federated_runtime import FederatedRuntime
+from openfl.experimental.runtime.local_runtime import LocalRuntime
+from openfl.experimental.runtime.runtime import Runtime

--- a/openfl/experimental/runtime/__init__.py
+++ b/openfl/experimental/runtime/__init__.py
@@ -3,9 +3,8 @@
 
 """ openfl.experimental.runtime package Runtime class."""
 
-from .runtime import Runtime
-from .local_runtime import LocalRuntime
 from .federated_runtime import FederatedRuntime
-
+from .local_runtime import LocalRuntime
+from .runtime import Runtime
 
 __all__ = ["FederatedRuntime", "LocalRuntime", "Runtime"]

--- a/openfl/experimental/runtime/__init__.py
+++ b/openfl/experimental/runtime/__init__.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2020-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
 """ openfl.experimental.runtime package Runtime class."""
 
 from .federated_runtime import FederatedRuntime

--- a/openfl/experimental/runtime/federated_runtime.py
+++ b/openfl/experimental/runtime/federated_runtime.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from openfl.experimental.runtime import Runtime
+from openfl.experimental.runtime.runtime import Runtime
 
 if TYPE_CHECKING:
     from openfl.experimental.interface import Aggregator

--- a/openfl/experimental/runtime/federated_runtime.py
+++ b/openfl/experimental/runtime/federated_runtime.py
@@ -4,15 +4,16 @@
 """ openfl.experimental.runtime package LocalRuntime class."""
 
 from __future__ import annotations
-from openfl.experimental.runtime import Runtime
+
 from typing import TYPE_CHECKING
+
+from openfl.experimental.runtime import Runtime
 
 if TYPE_CHECKING:
     from openfl.experimental.interface import Aggregator
     from openfl.experimental.interface import Collaborator
 
-from typing import List
-from typing import Type
+from typing import List, Type
 
 
 class FederatedRuntime(Runtime):

--- a/openfl/experimental/runtime/federated_runtime.py
+++ b/openfl/experimental/runtime/federated_runtime.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2020-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
 """ openfl.experimental.runtime package LocalRuntime class."""
 
 from __future__ import annotations
@@ -17,6 +16,7 @@ from typing import List, Type
 
 
 class FederatedRuntime(Runtime):
+
     def __init__(
         self,
         aggregator: str = None,

--- a/openfl/experimental/runtime/local_runtime.py
+++ b/openfl/experimental/runtime/local_runtime.py
@@ -4,29 +4,29 @@
 """ openfl.experimental.runtime package LocalRuntime class."""
 
 from __future__ import annotations
-from copy import deepcopy
-import importlib
-import ray
-import os
+
 import gc
-from openfl.experimental.runtime import Runtime
-from typing import TYPE_CHECKING, Optional
+import importlib
 import math
+import os
+from copy import deepcopy
+from typing import TYPE_CHECKING, Optional
+
+import ray
+
+from openfl.experimental.runtime import Runtime
 
 if TYPE_CHECKING:
     from openfl.experimental.interface import Aggregator, Collaborator, FLSpec
 
-from openfl.experimental.utilities import (
-    ResourcesNotAvailableError,
-    aggregator_to_collaborator,
-    generate_artifacts,
-    filter_attributes,
-    checkpoint,
-    get_number_of_gpus,
-    check_resource_allocation,
-)
-from typing import List, Any
-from typing import Dict, Type, Callable
+from typing import Any, Callable, Dict, List, Type
+
+from openfl.experimental.utilities import (ResourcesNotAvailableError,
+                                           aggregator_to_collaborator,
+                                           check_resource_allocation,
+                                           checkpoint, filter_attributes,
+                                           generate_artifacts,
+                                           get_number_of_gpus)
 
 
 class RayExecutor:
@@ -620,9 +620,7 @@ class LocalRuntime(Runtime):
             flspec_obj: updated FLSpec (flow) object
         """
 
-        from openfl.experimental.interface import (
-            FLSpec,
-        )
+        from openfl.experimental.interface import FLSpec
 
         flspec_obj._foreach_methods.append(f.__name__)
         selected_collaborators = getattr(flspec_obj, kwargs["foreach"])
@@ -682,9 +680,7 @@ class LocalRuntime(Runtime):
             selected_collaborators : all collaborators
         """
 
-        from openfl.experimental.interface import (
-            FLSpec,
-        )
+        from openfl.experimental.interface import FLSpec
 
         for col in selected_collaborators:
             clone = FLSpec._clones[col]

--- a/openfl/experimental/runtime/local_runtime.py
+++ b/openfl/experimental/runtime/local_runtime.py
@@ -20,12 +20,15 @@ if TYPE_CHECKING:
 
 from typing import Any, Callable, Dict, List, Type
 
-from openfl.experimental.utilities import (ResourcesNotAvailableError,
-                                           aggregator_to_collaborator,
-                                           check_resource_allocation,
-                                           checkpoint, filter_attributes,
-                                           generate_artifacts,
-                                           get_number_of_gpus)
+from openfl.experimental.utilities import (
+    ResourcesNotAvailableError,
+    aggregator_to_collaborator,
+    check_resource_allocation,
+    checkpoint,
+    filter_attributes,
+    generate_artifacts,
+    get_number_of_gpus,
+)
 
 
 class RayExecutor:

--- a/openfl/experimental/runtime/local_runtime.py
+++ b/openfl/experimental/runtime/local_runtime.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Optional
 
 import ray
 
-from openfl.experimental.runtime import Runtime
+from openfl.experimental.runtime.runtime import Runtime
 
 if TYPE_CHECKING:
     from openfl.experimental.interface import Aggregator, Collaborator, FLSpec

--- a/openfl/experimental/runtime/runtime.py
+++ b/openfl/experimental/runtime/runtime.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2020-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
 """ openfl.experimental.runtime module Runtime class."""
 from __future__ import annotations
 
@@ -13,6 +12,7 @@ from typing import Callable, List
 
 
 class Runtime:
+
     def __init__(self):
         """
         Base interface for runtimes that can run FLSpec flows
@@ -42,14 +42,12 @@ class Runtime:
         """Set Runtime collaborators"""
         raise NotImplementedError
 
-    def execute_task(
-        self,
-        flspec_obj: FLSpec,
-        f: Callable,
-        parent_func: Callable,
-        instance_snapshot: List[FLSpec] = [],
-        **kwargs
-    ):
+    def execute_task(self,
+                     flspec_obj: FLSpec,
+                     f: Callable,
+                     parent_func: Callable,
+                     instance_snapshot: List[FLSpec] = [],
+                     **kwargs):
         """
         Performs the execution of a task as defined by the
         implementation and underlying backend (single_process, ray, etc)

--- a/openfl/experimental/runtime/runtime.py
+++ b/openfl/experimental/runtime/runtime.py
@@ -42,12 +42,14 @@ class Runtime:
         """Set Runtime collaborators"""
         raise NotImplementedError
 
-    def execute_task(self,
-                     flspec_obj: FLSpec,
-                     f: Callable,
-                     parent_func: Callable,
-                     instance_snapshot: List[FLSpec] = [],
-                     **kwargs):
+    def execute_task(
+        self,
+        flspec_obj: FLSpec,
+        f: Callable,
+        parent_func: Callable,
+        instance_snapshot: List[FLSpec] = [],
+        **kwargs,
+    ):
         """
         Performs the execution of a task as defined by the
         implementation and underlying backend (single_process, ray, etc)

--- a/openfl/experimental/runtime/runtime.py
+++ b/openfl/experimental/runtime/runtime.py
@@ -3,11 +3,13 @@
 
 """ openfl.experimental.runtime module Runtime class."""
 from __future__ import annotations
+
 from typing import TYPE_CHECKING
+
 if TYPE_CHECKING:
     from openfl.experimental.interface import Aggregator, Collaborator, FLSpec
-from typing import List
-from typing import Callable
+
+from typing import Callable, List
 
 
 class Runtime:

--- a/openfl/experimental/transport/__init__.py
+++ b/openfl/experimental/transport/__init__.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
 """openfl.experimental.transport package."""
 from .grpc import AggregatorGRPCClient, AggregatorGRPCServer
 

--- a/openfl/experimental/transport/__init__.py
+++ b/openfl/experimental/transport/__init__.py
@@ -4,6 +4,6 @@
 from .grpc import AggregatorGRPCClient, AggregatorGRPCServer
 
 __all__ = [
-    'AggregatorGRPCServer',
-    'AggregatorGRPCClient',
+    "AggregatorGRPCServer",
+    "AggregatorGRPCClient",
 ]

--- a/openfl/experimental/transport/__init__.py
+++ b/openfl/experimental/transport/__init__.py
@@ -1,9 +1,7 @@
 # Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 """openfl.experimental.transport package."""
-from .grpc import AggregatorGRPCClient, AggregatorGRPCServer
-
-__all__ = [
-    "AggregatorGRPCServer",
-    "AggregatorGRPCClient",
-]
+from openfl.experimental.transport.grpc import (
+    AggregatorGRPCClient,
+    AggregatorGRPCServer,
+)

--- a/openfl/experimental/transport/__init__.py
+++ b/openfl/experimental/transport/__init__.py
@@ -2,9 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """openfl.experimental.transport package."""
-from .grpc import AggregatorGRPCClient
-from .grpc import AggregatorGRPCServer
-
+from .grpc import AggregatorGRPCClient, AggregatorGRPCServer
 
 __all__ = [
     'AggregatorGRPCServer',

--- a/openfl/experimental/transport/grpc/__init__.py
+++ b/openfl/experimental/transport/grpc/__init__.py
@@ -2,16 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 """openfl.experimental.transport.grpc package."""
 
-from .aggregator_client import AggregatorGRPCClient
-from .aggregator_server import AggregatorGRPCServer
+from openfl.experimental.transport.grpc.aggregator_client import (
+    AggregatorGRPCClient,
+)
+from openfl.experimental.transport.grpc.aggregator_server import (
+    AggregatorGRPCServer,
+)
 
 
+# FIXME: Not the right place for exceptions
 class ShardNotFoundError(Exception):
     """Indicates that director has no information about that shard."""
-
-
-__all__ = [
-    "AggregatorGRPCServer",
-    "AggregatorGRPCClient",
-    "ShardNotFoundError",
-]

--- a/openfl/experimental/transport/grpc/__init__.py
+++ b/openfl/experimental/transport/grpc/__init__.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
 """openfl.experimental.transport.grpc package."""
 
 from .aggregator_client import AggregatorGRPCClient

--- a/openfl/experimental/transport/grpc/__init__.py
+++ b/openfl/experimental/transport/grpc/__init__.py
@@ -11,7 +11,7 @@ class ShardNotFoundError(Exception):
 
 
 __all__ = [
-    'AggregatorGRPCServer',
-    'AggregatorGRPCClient',
-    'ShardNotFoundError',
+    "AggregatorGRPCServer",
+    "AggregatorGRPCClient",
+    "ShardNotFoundError",
 ]

--- a/openfl/experimental/transport/grpc/aggregator_client.py
+++ b/openfl/experimental/transport/grpc/aggregator_client.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2020-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
 """AggregatorGRPCClient module."""
 
 import time
@@ -30,21 +29,21 @@ class ConstantBackoff:
         time.sleep(self.reconnect_interval)
 
 
-class RetryOnRpcErrorClientInterceptor(
-    grpc.UnaryUnaryClientInterceptor, grpc.StreamUnaryClientInterceptor
-):
+class RetryOnRpcErrorClientInterceptor(grpc.UnaryUnaryClientInterceptor,
+                                       grpc.StreamUnaryClientInterceptor):
     """Retry gRPC connection on failure."""
 
     def __init__(
-            self,
-            sleeping_policy,
-            status_for_retry: Optional[Tuple[grpc.StatusCode]] = None,
+        self,
+        sleeping_policy,
+        status_for_retry: Optional[Tuple[grpc.StatusCode]] = None,
     ):
         """Initialize function for gRPC retry."""
         self.sleeping_policy = sleeping_policy
         self.status_for_retry = status_for_retry
 
-    def _intercept_call(self, continuation, client_call_details, request_or_iterator):
+    def _intercept_call(self, continuation, client_call_details,
+                        request_or_iterator):
         """Intercept the call to the gRPC server."""
         while True:
             response = continuation(client_call_details, request_or_iterator)
@@ -52,11 +51,10 @@ class RetryOnRpcErrorClientInterceptor(
             if isinstance(response, grpc.RpcError):
 
                 # If status code is not in retryable status codes
-                self.sleeping_policy.logger.info(f'Response code: {response.code()}')
-                if (
-                        self.status_for_retry
-                        and response.code() not in self.status_for_retry
-                ):
+                self.sleeping_policy.logger.info(
+                    f'Response code: {response.code()}')
+                if (self.status_for_retry and
+                        response.code() not in self.status_for_retry):
                     return response
 
                 self.sleeping_policy.sleep()
@@ -67,14 +65,15 @@ class RetryOnRpcErrorClientInterceptor(
         """Wrap intercept call for unary->unary RPC."""
         return self._intercept_call(continuation, client_call_details, request)
 
-    def intercept_stream_unary(
-            self, continuation, client_call_details, request_iterator
-    ):
+    def intercept_stream_unary(self, continuation, client_call_details,
+                               request_iterator):
         """Wrap intercept call for stream->unary RPC."""
-        return self._intercept_call(continuation, client_call_details, request_iterator)
+        return self._intercept_call(continuation, client_call_details,
+                                    request_iterator)
 
 
 def _atomic_connection(func):
+
     def wrapper(self, *args, **kwargs):
         self.reconnect()
         response = func(self, *args, **kwargs)
@@ -85,6 +84,7 @@ def _atomic_connection(func):
 
 
 def _resend_data_on_reconnection(func):
+
     def wrapper(self, *args, **kwargs):
         while True:
             try:
@@ -133,13 +133,11 @@ class AggregatorGRPCClient:
                 'gRPC is running on insecure channel with TLS disabled.')
             self.channel = self.create_insecure_channel(self.uri)
         else:
-            self.channel = self.create_tls_channel(
-                self.uri,
-                self.root_certificate,
-                self.disable_client_auth,
-                self.certificate,
-                self.private_key
-            )
+            self.channel = self.create_tls_channel(self.uri,
+                                                   self.root_certificate,
+                                                   self.disable_client_auth,
+                                                   self.certificate,
+                                                   self.private_key)
 
         self.header = None
         self.aggregator_uuid = aggregator_uuid
@@ -147,18 +145,16 @@ class AggregatorGRPCClient:
         self.single_col_cert_common_name = single_col_cert_common_name
 
         # Adding an interceptor for RPC Errors
-        self.interceptors = (
-            RetryOnRpcErrorClientInterceptor(
-                sleeping_policy=ConstantBackoff(
-                    logger=self.logger,
-                    reconnect_interval=int(kwargs.get('client_reconnect_interval', 1)),
-                    uri=self.uri),
-                status_for_retry=(grpc.StatusCode.UNAVAILABLE,),
-            ),
-        )
+        self.interceptors = (RetryOnRpcErrorClientInterceptor(
+            sleeping_policy=ConstantBackoff(
+                logger=self.logger,
+                reconnect_interval=int(
+                    kwargs.get('client_reconnect_interval', 1)),
+                uri=self.uri),
+            status_for_retry=(grpc.StatusCode.UNAVAILABLE,),
+        ),)
         self.stub = aggregator_pb2_grpc.AggregatorStub(
-            grpc.intercept_channel(self.channel, *self.interceptors)
-        )
+            grpc.intercept_channel(self.channel, *self.interceptors))
 
     def create_insecure_channel(self, uri):
         """
@@ -210,16 +206,14 @@ class AggregatorGRPCClient:
             certificate_chain=certificate_b,
         )
 
-        return grpc.secure_channel(
-            uri, credentials, options=channel_options)
+        return grpc.secure_channel(uri, credentials, options=channel_options)
 
     def _set_header(self, collaborator_name):
         self.header = aggregator_pb2.MessageHeader(
             sender=collaborator_name,
             receiver=self.aggregator_uuid,
             federation_uuid=self.federation_uuid,
-            single_col_cert_common_name=self.single_col_cert_common_name or ''
-        )
+            single_col_cert_common_name=self.single_col_cert_common_name or '')
 
     def validate_response(self, reply, collaborator_name):
         """Validate the aggregator response."""
@@ -228,18 +222,12 @@ class AggregatorGRPCClient:
         check_equal(reply.header.sender, self.aggregator_uuid, self.logger)
 
         # check that federation id matches
-        check_equal(
-            reply.header.federation_uuid,
-            self.federation_uuid,
-            self.logger
-        )
+        check_equal(reply.header.federation_uuid, self.federation_uuid,
+                    self.logger)
 
         # check that there is aggrement on the single_col_cert_common_name
-        check_equal(
-            reply.header.single_col_cert_common_name,
-            self.single_col_cert_common_name or '',
-            self.logger
-        )
+        check_equal(reply.header.single_col_cert_common_name,
+                    self.single_col_cert_common_name or '', self.logger)
 
     def disconnect(self):
         """Close the gRPC channel."""
@@ -254,19 +242,16 @@ class AggregatorGRPCClient:
         if not self.tls:
             self.channel = self.create_insecure_channel(self.uri)
         else:
-            self.channel = self.create_tls_channel(
-                self.uri,
-                self.root_certificate,
-                self.disable_client_auth,
-                self.certificate,
-                self.private_key
-            )
+            self.channel = self.create_tls_channel(self.uri,
+                                                   self.root_certificate,
+                                                   self.disable_client_auth,
+                                                   self.certificate,
+                                                   self.private_key)
 
         self.logger.debug(f'Connecting to gRPC at {self.uri}')
 
         self.stub = aggregator_pb2_grpc.AggregatorStub(
-            grpc.intercept_channel(self.channel, *self.interceptors)
-        )
+            grpc.intercept_channel(self.channel, *self.interceptors))
 
     @_atomic_connection
     @_resend_data_on_reconnection
@@ -279,8 +264,7 @@ class AggregatorGRPCClient:
             collab_name=collaborator_name,
             round_number=round_number,
             next_step=next_step,
-            execution_environment=clone_bytes
-        )
+            execution_environment=clone_bytes)
 
         response = self.stub.SendTaskResults(request)
         self.validate_response(response, collaborator_name)
@@ -298,11 +282,13 @@ class AggregatorGRPCClient:
         self.validate_response(response, collaborator_name)
 
         return (response.round_number, response.function_name,
-                response.execution_environment, response.sleep_time, response.quit)
+                response.execution_environment, response.sleep_time,
+                response.quit)
 
     @_atomic_connection
     @_resend_data_on_reconnection
-    def call_checkpoint(self, collaborator_name, clone_bytes, function, stream_buffer):
+    def call_checkpoint(self, collaborator_name, clone_bytes, function,
+                        stream_buffer):
         """Perform checkpoint for collaborator task."""
         self._set_header(collaborator_name)
 

--- a/openfl/experimental/transport/grpc/aggregator_client.py
+++ b/openfl/experimental/transport/grpc/aggregator_client.py
@@ -9,9 +9,10 @@ from typing import Optional, Tuple
 import grpc
 
 from openfl.experimental.protocols import aggregator_pb2, aggregator_pb2_grpc
+from openfl.experimental.transport.grpc.grpc_channel_options import (
+    channel_options,
+)
 from openfl.utilities import check_equal
-
-from .grpc_channel_options import channel_options
 
 
 class ConstantBackoff:

--- a/openfl/experimental/transport/grpc/aggregator_client.py
+++ b/openfl/experimental/transport/grpc/aggregator_client.py
@@ -5,13 +5,11 @@
 
 import time
 from logging import getLogger
-from typing import Optional
-from typing import Tuple
+from typing import Optional, Tuple
 
 import grpc
 
-from openfl.experimental.protocols import aggregator_pb2
-from openfl.experimental.protocols import aggregator_pb2_grpc
+from openfl.experimental.protocols import aggregator_pb2, aggregator_pb2_grpc
 from openfl.utilities import check_equal
 
 from .grpc_channel_options import channel_options

--- a/openfl/experimental/transport/grpc/aggregator_server.py
+++ b/openfl/experimental/transport/grpc/aggregator_server.py
@@ -5,18 +5,14 @@
 
 import logging
 from concurrent.futures import ThreadPoolExecutor
-from random import random
 from multiprocessing import cpu_count
+from random import random
 from time import sleep
 
-from grpc import server
-from grpc import ssl_server_credentials
-from grpc import StatusCode
+from grpc import StatusCode, server, ssl_server_credentials
 
-from openfl.experimental.protocols import aggregator_pb2
-from openfl.experimental.protocols import aggregator_pb2_grpc
-from openfl.utilities import check_equal
-from openfl.utilities import check_is_in
+from openfl.experimental.protocols import aggregator_pb2, aggregator_pb2_grpc
+from openfl.utilities import check_equal, check_is_in
 
 from .grpc_channel_options import channel_options
 

--- a/openfl/experimental/transport/grpc/aggregator_server.py
+++ b/openfl/experimental/transport/grpc/aggregator_server.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2020-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
 """AggregatorGRPCServer module."""
 
 import logging
@@ -72,8 +71,8 @@ class AggregatorGRPCServer(aggregator_pb2_grpc.AggregatorServicer):
 
         """
         if self.tls:
-            common_name = context.auth_context()[
-                'x509_common_name'][0].decode('utf-8')
+            common_name = context.auth_context()['x509_common_name'][0].decode(
+                'utf-8')
             collaborator_common_name = request.header.sender
             if not self.aggregator.valid_collaborator_cn_and_id(
                     common_name, collaborator_common_name):
@@ -96,8 +95,8 @@ class AggregatorGRPCServer(aggregator_pb2_grpc.AggregatorServicer):
             sender=self.aggregator.uuid,
             receiver=collaborator_name,
             federation_uuid=self.aggregator.federation_uuid,
-            single_col_cert_common_name=self.aggregator.single_col_cert_common_name
-        )
+            single_col_cert_common_name=self.aggregator
+            .single_col_cert_common_name)
 
     def check_request(self, request):
         """
@@ -108,21 +107,19 @@ class AggregatorGRPCServer(aggregator_pb2_grpc.AggregatorServicer):
                 Request sent from a collaborator that requires validation
         """
         # TODO improve this check. the sender name could be spoofed
-        check_is_in(request.header.sender, self.aggregator.authorized_cols, self.logger)
+        check_is_in(request.header.sender, self.aggregator.authorized_cols,
+                    self.logger)
 
         # check that the message is for me
         check_equal(request.header.receiver, self.aggregator.uuid, self.logger)
 
         # check that the message is for my federation
-        check_equal(
-            request.header.federation_uuid, self.aggregator.federation_uuid, self.logger)
+        check_equal(request.header.federation_uuid,
+                    self.aggregator.federation_uuid, self.logger)
 
         # check that we agree on the single cert common name
-        check_equal(
-            request.header.single_col_cert_common_name,
-            self.aggregator.single_col_cert_common_name,
-            self.logger
-        )
+        check_equal(request.header.single_col_cert_common_name,
+                    self.aggregator.single_col_cert_common_name, self.logger)
 
     def SendTaskResults(self, request, context):  # NOQA:N802
         """
@@ -140,13 +137,12 @@ class AggregatorGRPCServer(aggregator_pb2_grpc.AggregatorServicer):
         next_step = request.next_step,
         execution_environment = request.execution_environment
 
-        _ = self.aggregator.send_task_results(
-            collaborator_name, round_number[0], next_step, execution_environment
-        )
+        _ = self.aggregator.send_task_results(collaborator_name,
+                                              round_number[0], next_step,
+                                              execution_environment)
 
         return aggregator_pb2.TaskResultsResponse(
-            header=self.get_header(collaborator_name)
-        )
+            header=self.get_header(collaborator_name))
 
     def GetTasks(self, request, context):  # NOQA:N802
         """
@@ -160,8 +156,7 @@ class AggregatorGRPCServer(aggregator_pb2_grpc.AggregatorServicer):
         self.check_request(request)
         collaborator_name = request.header.sender
 
-        rn, f, ee, st, q = self.aggregator.get_tasks(
-            request.header.sender)
+        rn, f, ee, st, q = self.aggregator.get_tasks(request.header.sender)
 
         return aggregator_pb2.GetTasksResponse(
             header=self.get_header(collaborator_name),
@@ -169,8 +164,7 @@ class AggregatorGRPCServer(aggregator_pb2_grpc.AggregatorServicer):
             function_name=f,
             execution_environment=ee,
             sleep_time=st,
-            quit=q
-        )
+            quit=q)
 
     def CallCheckpoint(self, request, context):  # NOQA:N802
         """
@@ -188,18 +182,17 @@ class AggregatorGRPCServer(aggregator_pb2_grpc.AggregatorServicer):
         function = request.function
         stream_buffer = request.stream_buffer
 
-        self.aggregator.call_checkpoint(
-            execution_environment, function, stream_buffer
-        )
+        self.aggregator.call_checkpoint(execution_environment, function,
+                                        stream_buffer)
 
         return aggregator_pb2.CheckpointResponse(
-            header=self.get_header(collaborator_name)
-        )
+            header=self.get_header(collaborator_name))
 
     def get_server(self):
         """Return gRPC server."""
-        self.server = server(ThreadPoolExecutor(max_workers=cpu_count()),
-                             options=channel_options)
+        self.server = server(
+            ThreadPoolExecutor(max_workers=cpu_count()),
+            options=channel_options)
 
         aggregator_pb2_grpc.add_AggregatorServicer_to_server(self, self.server)
 
@@ -225,8 +218,7 @@ class AggregatorGRPCServer(aggregator_pb2_grpc.AggregatorServicer):
             self.server_credentials = ssl_server_credentials(
                 ((private_key_b, certificate_b),),
                 root_certificates=root_certificate_b,
-                require_client_auth=not self.disable_client_auth
-            )
+                require_client_auth=not self.disable_client_auth)
 
             self.server.add_secure_port(self.uri, self.server_credentials)
 

--- a/openfl/experimental/transport/grpc/aggregator_server.py
+++ b/openfl/experimental/transport/grpc/aggregator_server.py
@@ -21,15 +21,17 @@ logger = logging.getLogger(__name__)
 class AggregatorGRPCServer(aggregator_pb2_grpc.AggregatorServicer):
     """gRPC server class for the Aggregator."""
 
-    def __init__(self,
-                 aggregator,
-                 agg_port,
-                 tls=True,
-                 disable_client_auth=False,
-                 root_certificate=None,
-                 certificate=None,
-                 private_key=None,
-                 **kwargs):
+    def __init__(
+        self,
+        aggregator,
+        agg_port,
+        tls=True,
+        disable_client_auth=False,
+        root_certificate=None,
+        certificate=None,
+        private_key=None,
+        **kwargs,
+    ):
         """
         Class initializer.
 
@@ -46,7 +48,7 @@ class AggregatorGRPCServer(aggregator_pb2_grpc.AggregatorServicer):
             kwargs (dict): Additional arguments to pass into function
         """
         self.aggregator = aggregator
-        self.uri = f'[::]:{agg_port}'
+        self.uri = f"[::]:{agg_port}"
         self.tls = tls
         self.disable_client_auth = disable_client_auth
         self.root_certificate = root_certificate
@@ -71,17 +73,20 @@ class AggregatorGRPCServer(aggregator_pb2_grpc.AggregatorServicer):
 
         """
         if self.tls:
-            common_name = context.auth_context()['x509_common_name'][0].decode(
-                'utf-8')
+            common_name = context.auth_context()["x509_common_name"][0].decode(
+                "utf-8"
+            )
             collaborator_common_name = request.header.sender
             if not self.aggregator.valid_collaborator_cn_and_id(
-                    common_name, collaborator_common_name):
+                common_name, collaborator_common_name
+            ):
                 # Random delay in authentication failures
                 sleep(5 * random())
                 context.abort(
                     StatusCode.UNAUTHENTICATED,
-                    f'Invalid collaborator. CN: |{common_name}| '
-                    f'collaborator_common_name: |{collaborator_common_name}|')
+                    f"Invalid collaborator. CN: |{common_name}| "
+                    f"collaborator_common_name: |{collaborator_common_name}|",
+                )
 
     def get_header(self, collaborator_name):
         """
@@ -95,8 +100,8 @@ class AggregatorGRPCServer(aggregator_pb2_grpc.AggregatorServicer):
             sender=self.aggregator.uuid,
             receiver=collaborator_name,
             federation_uuid=self.aggregator.federation_uuid,
-            single_col_cert_common_name=self.aggregator
-            .single_col_cert_common_name)
+            single_col_cert_common_name=self.aggregator.single_col_cert_common_name,
+        )
 
     def check_request(self, request):
         """
@@ -107,19 +112,26 @@ class AggregatorGRPCServer(aggregator_pb2_grpc.AggregatorServicer):
                 Request sent from a collaborator that requires validation
         """
         # TODO improve this check. the sender name could be spoofed
-        check_is_in(request.header.sender, self.aggregator.authorized_cols,
-                    self.logger)
+        check_is_in(
+            request.header.sender, self.aggregator.authorized_cols, self.logger
+        )
 
         # check that the message is for me
         check_equal(request.header.receiver, self.aggregator.uuid, self.logger)
 
         # check that the message is for my federation
-        check_equal(request.header.federation_uuid,
-                    self.aggregator.federation_uuid, self.logger)
+        check_equal(
+            request.header.federation_uuid,
+            self.aggregator.federation_uuid,
+            self.logger,
+        )
 
         # check that we agree on the single cert common name
-        check_equal(request.header.single_col_cert_common_name,
-                    self.aggregator.single_col_cert_common_name, self.logger)
+        check_equal(
+            request.header.single_col_cert_common_name,
+            self.aggregator.single_col_cert_common_name,
+            self.logger,
+        )
 
     def SendTaskResults(self, request, context):  # NOQA:N802
         """
@@ -133,16 +145,17 @@ class AggregatorGRPCServer(aggregator_pb2_grpc.AggregatorServicer):
         self.validate_collaborator(request, context)
         self.check_request(request)
         collaborator_name = request.header.sender
-        round_number = request.round_number,
-        next_step = request.next_step,
+        round_number = (request.round_number,)
+        next_step = (request.next_step,)
         execution_environment = request.execution_environment
 
-        _ = self.aggregator.send_task_results(collaborator_name,
-                                              round_number[0], next_step,
-                                              execution_environment)
+        _ = self.aggregator.send_task_results(
+            collaborator_name, round_number[0], next_step, execution_environment
+        )
 
         return aggregator_pb2.TaskResultsResponse(
-            header=self.get_header(collaborator_name))
+            header=self.get_header(collaborator_name)
+        )
 
     def GetTasks(self, request, context):  # NOQA:N802
         """
@@ -164,7 +177,8 @@ class AggregatorGRPCServer(aggregator_pb2_grpc.AggregatorServicer):
             function_name=f,
             execution_environment=ee,
             sleep_time=st,
-            quit=q)
+            quit=q,
+        )
 
     def CallCheckpoint(self, request, context):  # NOQA:N802
         """
@@ -182,43 +196,47 @@ class AggregatorGRPCServer(aggregator_pb2_grpc.AggregatorServicer):
         function = request.function
         stream_buffer = request.stream_buffer
 
-        self.aggregator.call_checkpoint(execution_environment, function,
-                                        stream_buffer)
+        self.aggregator.call_checkpoint(
+            execution_environment, function, stream_buffer
+        )
 
         return aggregator_pb2.CheckpointResponse(
-            header=self.get_header(collaborator_name))
+            header=self.get_header(collaborator_name)
+        )
 
     def get_server(self):
         """Return gRPC server."""
         self.server = server(
-            ThreadPoolExecutor(max_workers=cpu_count()),
-            options=channel_options)
+            ThreadPoolExecutor(max_workers=cpu_count()), options=channel_options
+        )
 
         aggregator_pb2_grpc.add_AggregatorServicer_to_server(self, self.server)
 
         if not self.tls:
 
             self.logger.warn(
-                'gRPC is running on insecure channel with TLS disabled.')
+                "gRPC is running on insecure channel with TLS disabled."
+            )
             port = self.server.add_insecure_port(self.uri)
-            self.logger.info(f'Insecure port: {port}')
+            self.logger.info(f"Insecure port: {port}")
 
         else:
 
-            with open(self.private_key, 'rb') as f:
+            with open(self.private_key, "rb") as f:
                 private_key_b = f.read()
-            with open(self.certificate, 'rb') as f:
+            with open(self.certificate, "rb") as f:
                 certificate_b = f.read()
-            with open(self.root_certificate, 'rb') as f:
+            with open(self.root_certificate, "rb") as f:
                 root_certificate_b = f.read()
 
             if self.disable_client_auth:
-                self.logger.warn('Client-side authentication is disabled.')
+                self.logger.warn("Client-side authentication is disabled.")
 
             self.server_credentials = ssl_server_credentials(
                 ((private_key_b, certificate_b),),
                 root_certificates=root_certificate_b,
-                require_client_auth=not self.disable_client_auth)
+                require_client_auth=not self.disable_client_auth,
+            )
 
             self.server.add_secure_port(self.uri, self.server_credentials)
 
@@ -228,7 +246,7 @@ class AggregatorGRPCServer(aggregator_pb2_grpc.AggregatorServicer):
         """Start an aggregator gRPC service."""
         self.get_server()
 
-        self.logger.info('Starting Aggregator gRPC Server')
+        self.logger.info("Starting Aggregator gRPC Server")
         self.server.start()
         self.is_server_started = True
         try:

--- a/openfl/experimental/transport/grpc/aggregator_server.py
+++ b/openfl/experimental/transport/grpc/aggregator_server.py
@@ -11,9 +11,10 @@ from time import sleep
 from grpc import StatusCode, server, ssl_server_credentials
 
 from openfl.experimental.protocols import aggregator_pb2, aggregator_pb2_grpc
+from openfl.experimental.transport.grpc.grpc_channel_options import (
+    channel_options,
+)
 from openfl.utilities import check_equal, check_is_in
-
-from .grpc_channel_options import channel_options
 
 logger = logging.getLogger(__name__)
 

--- a/openfl/experimental/transport/grpc/exceptions.py
+++ b/openfl/experimental/transport/grpc/exceptions.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2020-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
 """Exceptions that occur during service interaction."""
 
 

--- a/openfl/experimental/transport/grpc/grpc_channel_options.py
+++ b/openfl/experimental/transport/grpc/grpc_channel_options.py
@@ -1,11 +1,9 @@
 # Copyright (C) 2020-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-max_metadata_size = 32 * 2 ** 20
-max_message_length = 2 ** 30
+max_metadata_size = 32 * 2**20
+max_message_length = 2**30
 
-channel_options = [
-    ('grpc.max_metadata_size', max_metadata_size),
-    ('grpc.max_send_message_length', max_message_length),
-    ('grpc.max_receive_message_length', max_message_length)
-]
+channel_options = [('grpc.max_metadata_size', max_metadata_size),
+                   ('grpc.max_send_message_length', max_message_length),
+                   ('grpc.max_receive_message_length', max_message_length)]

--- a/openfl/experimental/transport/grpc/grpc_channel_options.py
+++ b/openfl/experimental/transport/grpc/grpc_channel_options.py
@@ -4,6 +4,8 @@
 max_metadata_size = 32 * 2**20
 max_message_length = 2**30
 
-channel_options = [('grpc.max_metadata_size', max_metadata_size),
-                   ('grpc.max_send_message_length', max_message_length),
-                   ('grpc.max_receive_message_length', max_message_length)]
+channel_options = [
+    ("grpc.max_metadata_size", max_metadata_size),
+    ("grpc.max_send_message_length", max_message_length),
+    ("grpc.max_receive_message_length", max_message_length),
+]

--- a/openfl/experimental/utilities/__init__.py
+++ b/openfl/experimental/utilities/__init__.py
@@ -2,46 +2,27 @@
 # SPDX-License-Identifier: Apache-2.0
 """openfl.experimental.utilities package."""
 
-from .exceptions import (
+from openfl.experimental.utilities.exceptions import (
     ResourcesAllocationError,
     ResourcesNotAvailableError,
     SerializationError,
 )
-from .metaflow_utils import MetaflowInterface
-from .resources import get_number_of_gpus
-from .runtime_utils import (
+from openfl.experimental.utilities.metaflow_utils import MetaflowInterface
+from openfl.experimental.utilities.resources import get_number_of_gpus
+from openfl.experimental.utilities.runtime_utils import (
     check_resource_allocation,
     checkpoint,
     filter_attributes,
     generate_artifacts,
     parse_attrs,
 )
-from .stream_redirect import (
+from openfl.experimental.utilities.stream_redirect import (
     RedirectStdStream,
     RedirectStdStreamBuffer,
     RedirectStdStreamContext,
 )
-from .transitions import (
+from openfl.experimental.utilities.transitions import (
     aggregator_to_collaborator,
     collaborator_to_aggregator,
     should_transfer,
 )
-
-__all__ = [
-    "MetaflowInterface",
-    "should_transfer",
-    "aggregator_to_collaborator",
-    "collaborator_to_aggregator",
-    "SerializationError",
-    "ResourcesNotAvailableError",
-    "ResourcesAllocationError",
-    "RedirectStdStreamBuffer",
-    "RedirectStdStream",
-    "RedirectStdStreamContext",
-    "get_number_of_gpus",
-    "parse_attrs",
-    "generate_artifacts",
-    "filter_attributes",
-    "checkpoint",
-    "check_resource_allocation",
-]

--- a/openfl/experimental/utilities/__init__.py
+++ b/openfl/experimental/utilities/__init__.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2020-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
 """openfl.experimental.utilities package."""
 
 from .exceptions import (ResourcesAllocationError, ResourcesNotAvailableError,

--- a/openfl/experimental/utilities/__init__.py
+++ b/openfl/experimental/utilities/__init__.py
@@ -3,31 +3,16 @@
 
 """openfl.experimental.utilities package."""
 
+from .exceptions import (ResourcesAllocationError, ResourcesNotAvailableError,
+                         SerializationError)
 from .metaflow_utils import MetaflowInterface
-from .transitions import (
-    should_transfer,
-    aggregator_to_collaborator,
-    collaborator_to_aggregator,
-)
-from .exceptions import (
-    SerializationError,
-    ResourcesNotAvailableError,
-    ResourcesAllocationError,
-)
-from .stream_redirect import (
-    RedirectStdStreamBuffer,
-    RedirectStdStream,
-    RedirectStdStreamContext,
-)
 from .resources import get_number_of_gpus
-from .runtime_utils import (
-    parse_attrs,
-    generate_artifacts,
-    filter_attributes,
-    checkpoint,
-    check_resource_allocation,
-)
-
+from .runtime_utils import (check_resource_allocation, checkpoint,
+                            filter_attributes, generate_artifacts, parse_attrs)
+from .stream_redirect import (RedirectStdStream, RedirectStdStreamBuffer,
+                              RedirectStdStreamContext)
+from .transitions import (aggregator_to_collaborator,
+                          collaborator_to_aggregator, should_transfer)
 
 __all__ = [
     "MetaflowInterface",

--- a/openfl/experimental/utilities/__init__.py
+++ b/openfl/experimental/utilities/__init__.py
@@ -2,16 +2,30 @@
 # SPDX-License-Identifier: Apache-2.0
 """openfl.experimental.utilities package."""
 
-from .exceptions import (ResourcesAllocationError, ResourcesNotAvailableError,
-                         SerializationError)
+from .exceptions import (
+    ResourcesAllocationError,
+    ResourcesNotAvailableError,
+    SerializationError,
+)
 from .metaflow_utils import MetaflowInterface
 from .resources import get_number_of_gpus
-from .runtime_utils import (check_resource_allocation, checkpoint,
-                            filter_attributes, generate_artifacts, parse_attrs)
-from .stream_redirect import (RedirectStdStream, RedirectStdStreamBuffer,
-                              RedirectStdStreamContext)
-from .transitions import (aggregator_to_collaborator,
-                          collaborator_to_aggregator, should_transfer)
+from .runtime_utils import (
+    check_resource_allocation,
+    checkpoint,
+    filter_attributes,
+    generate_artifacts,
+    parse_attrs,
+)
+from .stream_redirect import (
+    RedirectStdStream,
+    RedirectStdStreamBuffer,
+    RedirectStdStreamContext,
+)
+from .transitions import (
+    aggregator_to_collaborator,
+    collaborator_to_aggregator,
+    should_transfer,
+)
 
 __all__ = [
     "MetaflowInterface",

--- a/openfl/experimental/utilities/exceptions.py
+++ b/openfl/experimental/utilities/exceptions.py
@@ -1,19 +1,23 @@
 # Copyright (C) 2020-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+
 class SerializationError(Exception):
+
     def __init__(self, *args: object) -> None:
         super().__init__(*args)
         pass
 
 
 class ResourcesNotAvailableError(Exception):
+
     def __init__(self, *args: object) -> None:
         super().__init__(*args)
         pass
 
 
 class ResourcesAllocationError(Exception):
+
     def __init__(self, *args: object) -> None:
         super().__init__(*args)
         pass

--- a/openfl/experimental/utilities/metaflow_utils.py
+++ b/openfl/experimental/utilities/metaflow_utils.py
@@ -9,6 +9,7 @@ import fcntl
 import hashlib
 from datetime import datetime
 from pathlib import Path
+
 # getsource only used to determine structure of FlowGraph
 from typing import TYPE_CHECKING
 
@@ -16,10 +17,12 @@ import cloudpickle as pickle
 import ray
 from dill.source import getsource  # nosec
 from metaflow.datastore import DATASTORES, FlowDataStore
-from metaflow.datastore.exceptions import (DataException,
-                                           UnpicklableArtifactException)
-from metaflow.datastore.task_datastore import (TaskDataStore, only_if_not_done,
-                                               require_mode)
+from metaflow.datastore.exceptions import DataException, UnpicklableArtifactException
+from metaflow.datastore.task_datastore import (
+    TaskDataStore,
+    only_if_not_done,
+    require_mode,
+)
 from metaflow.graph import DAGNode, FlowGraph, StepVisitor, deindent_docstring
 from metaflow.metaflow_environment import MetaflowEnvironment
 from metaflow.mflog import RUNTIME_LOG_SOURCE
@@ -38,9 +41,17 @@ from typing import Any, Generator, Type
 
 from metaflow import __version__ as mf_version
 from metaflow.plugins.cards.card_modules.basic import (
-    CSS_PATH, JS_PATH, RENDER_TEMPLATE_PATH, DagComponent, DefaultCard,
-    PageComponent, SectionComponent, TaskInfoComponent, read_file,
-    transform_flow_graph)
+    CSS_PATH,
+    JS_PATH,
+    RENDER_TEMPLATE_PATH,
+    DagComponent,
+    DefaultCard,
+    PageComponent,
+    SectionComponent,
+    TaskInfoComponent,
+    read_file,
+    transform_flow_graph,
+)
 
 
 class SystemMutex:

--- a/openfl/experimental/utilities/metaflow_utils.py
+++ b/openfl/experimental/utilities/metaflow_utils.py
@@ -4,58 +4,49 @@
 """openfl.experimental.utilities.metaflow_utils module."""
 
 from __future__ import annotations
-from datetime import datetime
-from metaflow.metaflow_environment import MetaflowEnvironment
-from metaflow.plugins import LocalMetadataProvider
-from metaflow.datastore import FlowDataStore, DATASTORES
-from metaflow.graph import DAGNode, FlowGraph, StepVisitor
-from metaflow.graph import deindent_docstring
-from metaflow.datastore.task_datastore import TaskDataStore
-from metaflow.datastore.exceptions import (
-    DataException,
-    UnpicklableArtifactException,
-)
-from metaflow.datastore.task_datastore import only_if_not_done, require_mode
-import cloudpickle as pickle
-import ray
+
 import ast
-from pathlib import Path
-from metaflow.runtime import TruncatedBuffer, mflog_msg, MAX_LOG_SIZE
-from metaflow.mflog import RUNTIME_LOG_SOURCE
-from metaflow.task import MetaDatum
 import fcntl
 import hashlib
-from dill.source import getsource  # nosec
+from datetime import datetime
+from pathlib import Path
 # getsource only used to determine structure of FlowGraph
 from typing import TYPE_CHECKING
+
+import cloudpickle as pickle
+import ray
+from dill.source import getsource  # nosec
+from metaflow.datastore import DATASTORES, FlowDataStore
+from metaflow.datastore.exceptions import (DataException,
+                                           UnpicklableArtifactException)
+from metaflow.datastore.task_datastore import (TaskDataStore, only_if_not_done,
+                                               require_mode)
+from metaflow.graph import DAGNode, FlowGraph, StepVisitor, deindent_docstring
+from metaflow.metaflow_environment import MetaflowEnvironment
+from metaflow.mflog import RUNTIME_LOG_SOURCE
+from metaflow.plugins import LocalMetadataProvider
+from metaflow.runtime import MAX_LOG_SIZE, TruncatedBuffer, mflog_msg
+from metaflow.task import MetaDatum
+
 if TYPE_CHECKING:
     from openfl.experimental.interface import FLSpec
-from io import StringIO
-from typing import Generator, Any, Type
 
-from metaflow.plugins.cards.card_modules.basic import (
-    DefaultCard,
-    TaskInfoComponent,
-)
-from metaflow.plugins.cards.card_modules.basic import (
-    DagComponent,
-    SectionComponent,
-    PageComponent,
-)
-from metaflow.plugins.cards.card_modules.basic import (
-    RENDER_TEMPLATE_PATH,
-    JS_PATH,
-    CSS_PATH,
-)
-from metaflow.plugins.cards.card_modules.basic import (
-    read_file,
-    transform_flow_graph,
-)
-from metaflow import __version__ as mf_version
-
-import json
 import base64
+import json
 import uuid
+from io import StringIO
+from typing import Any, Generator, Type
+
+from metaflow import __version__ as mf_version
+from metaflow.plugins.cards.card_modules.basic import (CSS_PATH, JS_PATH,
+                                                       RENDER_TEMPLATE_PATH,
+                                                       DagComponent,
+                                                       DefaultCard,
+                                                       PageComponent,
+                                                       SectionComponent,
+                                                       TaskInfoComponent,
+                                                       read_file,
+                                                       transform_flow_graph)
 
 
 class SystemMutex:

--- a/openfl/experimental/utilities/metaflow_utils.py
+++ b/openfl/experimental/utilities/metaflow_utils.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2020-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
 """openfl.experimental.utilities.metaflow_utils module."""
 
 from __future__ import annotations
@@ -38,24 +37,21 @@ from io import StringIO
 from typing import Any, Generator, Type
 
 from metaflow import __version__ as mf_version
-from metaflow.plugins.cards.card_modules.basic import (CSS_PATH, JS_PATH,
-                                                       RENDER_TEMPLATE_PATH,
-                                                       DagComponent,
-                                                       DefaultCard,
-                                                       PageComponent,
-                                                       SectionComponent,
-                                                       TaskInfoComponent,
-                                                       read_file,
-                                                       transform_flow_graph)
+from metaflow.plugins.cards.card_modules.basic import (
+    CSS_PATH, JS_PATH, RENDER_TEMPLATE_PATH, DagComponent, DefaultCard,
+    PageComponent, SectionComponent, TaskInfoComponent, read_file,
+    transform_flow_graph)
 
 
 class SystemMutex:
+
     def __init__(self, name):
         self.name = name
 
     def __enter__(self):
-        lock_id = hashlib.new('md5', self.name.encode("utf8"),
-                              usedforsecurity=False).hexdigest()  # nosec
+        lock_id = hashlib.new(
+            'md5', self.name.encode("utf8"),
+            usedforsecurity=False).hexdigest()  # nosec
         # MD5sum used for concurrency purposes, not security
         self.fp = open(f"/tmp/.lock-{lock_id}.lck", "wb")
         fcntl.flock(self.fp.fileno(), fcntl.LOCK_EX)
@@ -66,6 +62,7 @@ class SystemMutex:
 
 
 class Flow:
+
     def __init__(self, name):
         """Mock flow for metaflow internals"""
         self.name = name
@@ -73,6 +70,7 @@ class Flow:
 
 @ray.remote
 class Counter(object):
+
     def __init__(self):
         self.value = 0
 
@@ -85,14 +83,14 @@ class Counter(object):
 
 
 class DAGnode(DAGNode):
+
     def __init__(self, func_ast, decos, doc):
         self.name = func_ast.name
         self.func_lineno = func_ast.lineno
         self.decorators = decos
         self.doc = deindent_docstring(doc)
         self.parallel_step = any(
-            getattr(deco, "IS_PARALLEL", False) for deco in decos
-        )
+            getattr(deco, "IS_PARALLEL", False) for deco in decos)
 
         # these attributes are populated by _parse
         self.tail_next_lineno = 0
@@ -177,6 +175,7 @@ class DAGnode(DAGNode):
 
 
 class StepVisitor(StepVisitor):
+
     def __init__(self, nodes, flow):
         super().__init__(nodes, flow)
 
@@ -187,6 +186,7 @@ class StepVisitor(StepVisitor):
 
 
 class FlowGraph(FlowGraph):
+
     def __init__(self, flow):
         self.name = flow.__name__
         self.nodes = self._create_nodes(flow)
@@ -198,8 +198,7 @@ class FlowGraph(FlowGraph):
         module = __import__(flow.__module__)
         tree = ast.parse(getsource(module)).body
         root = [
-            n
-            for n in tree
+            n for n in tree
             if isinstance(n, ast.ClassDef) and n.name == self.name
         ][0]
         nodes = {}
@@ -208,6 +207,7 @@ class FlowGraph(FlowGraph):
 
 
 class TaskDataStore(TaskDataStore):
+
     def __init__(
         self,
         flow_datastore,
@@ -261,17 +261,14 @@ class TaskDataStore(TaskDataStore):
         def pickle_iter():
             for name, obj in artifacts_iter:
                 do_v4 = (
-                    force_v4 and force_v4
-                    if isinstance(force_v4, bool)
-                    else force_v4.get(name, False)
-                )
+                    force_v4 and force_v4 if isinstance(force_v4, bool) else
+                    force_v4.get(name, False))
                 if do_v4:
                     encode_type = "gzip+pickle-v4"
                     if encode_type not in self._encodings:
                         raise DataException(
                             f"Artifact {name} requires a serialization encoding that "
-                            + "requires Python 3.4 or newer."
-                        )
+                            + "requires Python 3.4 or newer.")
                     try:
                         blob = pickle.dumps(obj, protocol=4)
                     except TypeError:
@@ -284,10 +281,9 @@ class TaskDataStore(TaskDataStore):
                         encode_type = "gzip+pickle-v4"
                         if encode_type not in self._encodings:
                             raise DataException(
-                                f"Artifact {name} is very large (over 2GB). "
-                                + "You need to use Python 3.4 or newer if you want to "
-                                + "serialize large objects."
-                            )
+                                f"Artifact {name} is very large (over 2GB). " +
+                                "You need to use Python 3.4 or newer if you want to "
+                                + "serialize large objects.")
                         try:
                             blob = pickle.dumps(obj, protocol=4)
                         except TypeError:
@@ -305,13 +301,13 @@ class TaskDataStore(TaskDataStore):
 
         # Use the content-addressed store to store all artifacts
         save_result = self._ca_store.save_blobs(
-            pickle_iter(), len_hint=len_hint
-        )
+            pickle_iter(), len_hint=len_hint)
         for name, result in zip(artifact_names, save_result):
             self._objects[name] = result.key
 
 
 class FlowDataStore(FlowDataStore):
+
     def __init__(
         self,
         flow_name,
@@ -356,6 +352,7 @@ class FlowDataStore(FlowDataStore):
 
 
 class MetaflowInterface:
+
     def __init__(self, flow: Type[FLSpec], backend: str = "ray"):
         """
         Wrapper class for the metaflow tooling modified to work with the
@@ -427,14 +424,9 @@ class MetaflowInterface:
                 self.counter += 1
                 return self.counter
 
-    def save_artifacts(
-        self,
-        data_pairs: Generator[str, Any],
-        task_name: str,
-        task_id: int,
-        buffer_out: Type[StringIO],
-        buffer_err: Type[StringIO]
-    ) -> None:
+    def save_artifacts(self, data_pairs: Generator[str, Any], task_name: str,
+                       task_id: int, buffer_out: Type[StringIO],
+                       buffer_err: Type[StringIO]) -> None:
         """
         Use metaflow task datastore to save flow attributes, stdout, and stderr
         for a specific task (identified by the task_name + task_id)
@@ -450,8 +442,7 @@ class MetaflowInterface:
 
         """
         task_datastore = self.flow_datastore.get_task_datastore(
-            self.run_id, task_name, str(task_id), attempt=0, mode="w"
-        )
+            self.run_id, task_name, str(task_id), attempt=0, mode="w")
         task_datastore.init_task()
         task_datastore.save_artifacts(data_pairs)
 
@@ -497,17 +488,14 @@ class MetaflowInterface:
     def load_artifacts(self, artifact_names, task_name, task_id):
         """Use metaflow task datastore to load flow attributes"""
         task_datastore = self.flow_datastore.get_task_datastore(
-            self.run_id, task_name, str(task_id), attempt=0, mode="r"
-        )
+            self.run_id, task_name, str(task_id), attempt=0, mode="r")
         return task_datastore.load_artifacts(artifact_names)
 
-    def emit_log(
-            self,
-            msgbuffer_out: Type[StringIO],
-            msgbuffer_err: Type[StringIO],
-            task_datastore: Type[TaskDataStore],
-            system_msg: bool = False
-    ) -> None:
+    def emit_log(self,
+                 msgbuffer_out: Type[StringIO],
+                 msgbuffer_err: Type[StringIO],
+                 task_datastore: Type[TaskDataStore],
+                 system_msg: bool = False) -> None:
         """
         This function writes the stdout and stderr to Metaflow TaskDatastore
         Args:
@@ -521,14 +509,12 @@ class MetaflowInterface:
         for std_output in msgbuffer_out.readlines():
             timestamp = datetime.utcnow()
             stdout_buffer.write(
-                mflog_msg(std_output, now=timestamp), system_msg=system_msg
-            )
+                mflog_msg(std_output, now=timestamp), system_msg=system_msg)
 
         for std_error in msgbuffer_err.readlines():
             timestamp = datetime.utcnow()
             stderr_buffer.write(
-                mflog_msg(std_error, now=timestamp), system_msg=system_msg
-            )
+                mflog_msg(std_error, now=timestamp), system_msg=system_msg)
 
         task_datastore.save_logs(
             RUNTIME_LOG_SOURCE,
@@ -567,13 +553,18 @@ class DefaultCard(DefaultCard):
         ).render()
         pt = self._get_mustache()
         data_dict = {
-            "task_data": base64.b64encode(
-                json.dumps(final_component_dict).encode("utf-8")
-            ).decode("utf-8"),
-            "javascript": JS_DATA,
-            "title": task,
-            "css": CSS_DATA,
-            "card_data_id": uuid.uuid4(),
+            "task_data":
+                base64.b64encode(
+                    json.dumps(final_component_dict).encode("utf-8")
+                ).decode("utf-8"),
+            "javascript":
+                JS_DATA,
+            "title":
+                task,
+            "css":
+                CSS_DATA,
+            "card_data_id":
+                uuid.uuid4(),
         }
         return pt.render(RENDER_TEMPLATE, data_dict)
 
@@ -619,8 +610,8 @@ class TaskInfoComponent(TaskInfoComponent):
         }
 
         dag_component = SectionComponent(
-            title="DAG", contents=[DagComponent(data=self._graph).render()]
-        ).render()
+            title="DAG",
+            contents=[DagComponent(data=self._graph).render()]).render()
 
         page_contents = []
         page_contents.append(dag_component)

--- a/openfl/experimental/utilities/resources.py
+++ b/openfl/experimental/utilities/resources.py
@@ -24,6 +24,7 @@ def get_number_of_gpus() -> int:
         stdout = op.stdout.decode().strip()
         return len(stdout.split("\n"))
     except FileNotFoundError:
-        logger.warning(f'No GPUs found! If this is a mistake please try running "{command}" '
-                       + 'manually.')
+        logger.warning(
+            f'No GPUs found! If this is a mistake please try running "{command}" '
+            + 'manually.')
         return 0

--- a/openfl/experimental/utilities/resources.py
+++ b/openfl/experimental/utilities/resources.py
@@ -26,5 +26,6 @@ def get_number_of_gpus() -> int:
     except FileNotFoundError:
         logger.warning(
             f'No GPUs found! If this is a mistake please try running "{command}" '
-            + 'manually.')
+            + "manually."
+        )
         return 0

--- a/openfl/experimental/utilities/resources.py
+++ b/openfl/experimental/utilities/resources.py
@@ -3,7 +3,7 @@
 """openfl.experimental.utilities.resources module."""
 
 from logging import getLogger
-from subprocess import run, PIPE
+from subprocess import PIPE, run
 
 logger = getLogger(__name__)
 

--- a/openfl/experimental/utilities/runtime_utils.py
+++ b/openfl/experimental/utilities/runtime_utils.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2020-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
 """openfl.experimental.utilities package."""
 
 import inspect
@@ -18,13 +17,9 @@ def parse_attrs(ctx, exclude=[], reserved_words=["next", "runtime", "input"]):
     cls_attrs = []
     valid_artifacts = []
     for i in inspect.getmembers(ctx):
-        if (
-            not hasattr(i[1], "task")
-            and not i[0].startswith("_")
-            and i[0] not in reserved_words
-            and i[0] not in exclude
-            and i not in inspect.getmembers(type(ctx))
-        ):
+        if (not hasattr(i[1], "task") and not i[0].startswith("_") and
+                i[0] not in reserved_words and i[0] not in exclude and
+                i not in inspect.getmembers(type(ctx))):
             if not isinstance(i[1], MethodType):
                 cls_attrs.append(i[0])
                 valid_artifacts.append((i[0], i[1]))
@@ -58,8 +53,7 @@ def filter_attributes(ctx, f, **kwargs):
         for in_attr in kwargs["include"]:
             if in_attr not in cls_attrs:
                 raise RuntimeError(
-                    f"argument '{in_attr}' not found in flow task {f.__name__}"
-                )
+                    f"argument '{in_attr}' not found in flow task {f.__name__}")
         for attr in cls_attrs:
             if attr not in kwargs["include"]:
                 delattr(ctx, attr)
@@ -68,8 +62,7 @@ def filter_attributes(ctx, f, **kwargs):
         for in_attr in kwargs["exclude"]:
             if in_attr not in cls_attrs:
                 raise RuntimeError(
-                    f"argument '{in_attr}' not found in flow task {f.__name__}"
-                )
+                    f"argument '{in_attr}' not found in flow task {f.__name__}")
         for attr in cls_attrs:
             if attr in kwargs["exclude"] and hasattr(ctx, attr):
                 delattr(ctx, attr)
@@ -88,8 +81,7 @@ def checkpoint(ctx, parent_func, chkpnt_reserved_words=["next", "runtime"]):
         # all objects will be serialized using Metaflow interface
         print(f"Saving data artifacts for {parent_func.__name__}")
         artifacts_iter, _ = generate_artifacts(
-            ctx=ctx, reserved_words=chkpnt_reserved_words
-        )
+            ctx=ctx, reserved_words=chkpnt_reserved_words)
         task_id = ctx._metaflow_interface.create_task(parent_func.__name__)
         ctx._metaflow_interface.save_artifacts(
             artifacts_iter(),
@@ -116,21 +108,20 @@ def old_check_resource_allocation(num_gpus, each_participant_gpu_usage):
     # funtion raise an error.
     for gpu in np.ones(num_gpus, dtype=int):
         for i, (participant_name, participant_gpu_usage) in enumerate(
-            each_participant_gpu_usage.items()
-        ):
+                each_participant_gpu_usage.items()):
             if gpu == 0:
                 break
             if gpu < participant_gpu_usage:
                 remaining_gpu_memory.update({participant_name: gpu})
                 each_participant_gpu_usage = dict(
-                    itertools.islice(each_participant_gpu_usage.items(), i)
-                )
+                    itertools.islice(each_participant_gpu_usage.items(), i))
             else:
                 gpu -= participant_gpu_usage
     if len(remaining_gpu_memory) > 0:
         raise ResourcesAllocationError(
             f"Failed to allocate Participant {list(remaining_gpu_memory.keys())} "
-            + "to specified GPU. Please try allocating lesser GPU resources to participants"
+            +
+            "to specified GPU. Please try allocating lesser GPU resources to participants"
         )
 
 
@@ -141,9 +132,8 @@ def check_resource_allocation(num_gpus, each_participant_gpu_usage):
     for gpu in np.ones(num_gpus, dtype=int):
         # buffer to cycle though since need_assigned will change sizes as we assign participants
         current_dict = need_assigned.copy()
-        for i, (participant_name, participant_gpu_usage) in enumerate(
-            current_dict.items()
-        ):
+        for i, (participant_name,
+                participant_gpu_usage) in enumerate(current_dict.items()):
             if gpu == 0:
                 break
             if gpu < participant_gpu_usage:
@@ -158,6 +148,6 @@ def check_resource_allocation(num_gpus, each_participant_gpu_usage):
     # assigned
     if len(need_assigned) > 0:
         raise ResourcesAllocationError(
-            f"Failed to allocate Participant {list(need_assigned.keys())} "
-            + "to specified GPU. Please try allocating lesser GPU resources to participants"
+            f"Failed to allocate Participant {list(need_assigned.keys())} " +
+            "to specified GPU. Please try allocating lesser GPU resources to participants"
         )

--- a/openfl/experimental/utilities/runtime_utils.py
+++ b/openfl/experimental/utilities/runtime_utils.py
@@ -17,9 +17,13 @@ def parse_attrs(ctx, exclude=[], reserved_words=["next", "runtime", "input"]):
     cls_attrs = []
     valid_artifacts = []
     for i in inspect.getmembers(ctx):
-        if (not hasattr(i[1], "task") and not i[0].startswith("_") and
-                i[0] not in reserved_words and i[0] not in exclude and
-                i not in inspect.getmembers(type(ctx))):
+        if (
+            not hasattr(i[1], "task")
+            and not i[0].startswith("_")
+            and i[0] not in reserved_words
+            and i[0] not in exclude
+            and i not in inspect.getmembers(type(ctx))
+        ):
             if not isinstance(i[1], MethodType):
                 cls_attrs.append(i[0])
                 valid_artifacts.append((i[0], i[1]))
@@ -53,7 +57,8 @@ def filter_attributes(ctx, f, **kwargs):
         for in_attr in kwargs["include"]:
             if in_attr not in cls_attrs:
                 raise RuntimeError(
-                    f"argument '{in_attr}' not found in flow task {f.__name__}")
+                    f"argument '{in_attr}' not found in flow task {f.__name__}"
+                )
         for attr in cls_attrs:
             if attr not in kwargs["include"]:
                 delattr(ctx, attr)
@@ -62,7 +67,8 @@ def filter_attributes(ctx, f, **kwargs):
         for in_attr in kwargs["exclude"]:
             if in_attr not in cls_attrs:
                 raise RuntimeError(
-                    f"argument '{in_attr}' not found in flow task {f.__name__}")
+                    f"argument '{in_attr}' not found in flow task {f.__name__}"
+                )
         for attr in cls_attrs:
             if attr in kwargs["exclude"] and hasattr(ctx, attr):
                 delattr(ctx, attr)
@@ -81,7 +87,8 @@ def checkpoint(ctx, parent_func, chkpnt_reserved_words=["next", "runtime"]):
         # all objects will be serialized using Metaflow interface
         print(f"Saving data artifacts for {parent_func.__name__}")
         artifacts_iter, _ = generate_artifacts(
-            ctx=ctx, reserved_words=chkpnt_reserved_words)
+            ctx=ctx, reserved_words=chkpnt_reserved_words
+        )
         task_id = ctx._metaflow_interface.create_task(parent_func.__name__)
         ctx._metaflow_interface.save_artifacts(
             artifacts_iter(),
@@ -108,20 +115,21 @@ def old_check_resource_allocation(num_gpus, each_participant_gpu_usage):
     # funtion raise an error.
     for gpu in np.ones(num_gpus, dtype=int):
         for i, (participant_name, participant_gpu_usage) in enumerate(
-                each_participant_gpu_usage.items()):
+            each_participant_gpu_usage.items()
+        ):
             if gpu == 0:
                 break
             if gpu < participant_gpu_usage:
                 remaining_gpu_memory.update({participant_name: gpu})
                 each_participant_gpu_usage = dict(
-                    itertools.islice(each_participant_gpu_usage.items(), i))
+                    itertools.islice(each_participant_gpu_usage.items(), i)
+                )
             else:
                 gpu -= participant_gpu_usage
     if len(remaining_gpu_memory) > 0:
         raise ResourcesAllocationError(
             f"Failed to allocate Participant {list(remaining_gpu_memory.keys())} "
-            +
-            "to specified GPU. Please try allocating lesser GPU resources to participants"
+            + "to specified GPU. Please try allocating lesser GPU resources to participants"
         )
 
 
@@ -132,8 +140,9 @@ def check_resource_allocation(num_gpus, each_participant_gpu_usage):
     for gpu in np.ones(num_gpus, dtype=int):
         # buffer to cycle though since need_assigned will change sizes as we assign participants
         current_dict = need_assigned.copy()
-        for i, (participant_name,
-                participant_gpu_usage) in enumerate(current_dict.items()):
+        for i, (participant_name, participant_gpu_usage) in enumerate(
+            current_dict.items()
+        ):
             if gpu == 0:
                 break
             if gpu < participant_gpu_usage:
@@ -148,6 +157,6 @@ def check_resource_allocation(num_gpus, each_participant_gpu_usage):
     # assigned
     if len(need_assigned) > 0:
         raise ResourcesAllocationError(
-            f"Failed to allocate Participant {list(need_assigned.keys())} " +
-            "to specified GPU. Please try allocating lesser GPU resources to participants"
+            f"Failed to allocate Participant {list(need_assigned.keys())} "
+            + "to specified GPU. Please try allocating lesser GPU resources to participants"
         )

--- a/openfl/experimental/utilities/runtime_utils.py
+++ b/openfl/experimental/utilities/runtime_utils.py
@@ -3,10 +3,12 @@
 
 """openfl.experimental.utilities package."""
 
-import itertools
 import inspect
-import numpy as np
+import itertools
 from types import MethodType
+
+import numpy as np
+
 from openfl.experimental.utilities import ResourcesAllocationError
 
 

--- a/openfl/experimental/utilities/stream_redirect.py
+++ b/openfl/experimental/utilities/stream_redirect.py
@@ -3,8 +3,8 @@
 
 """openfl.experimental.utilities.stream_redirect module."""
 
-import sys
 import io
+import sys
 from copy import deepcopy
 
 

--- a/openfl/experimental/utilities/stream_redirect.py
+++ b/openfl/experimental/utilities/stream_redirect.py
@@ -65,10 +65,12 @@ class RedirectStdStreamContext:
         """
         self.__old_stdout = sys.stdout
         self.__old_stderr = sys.stderr
-        sys.stdout = RedirectStdStream(self.stdstreambuffer._stdoutbuff,
-                                       sys.stdout)
-        sys.stderr = RedirectStdStream(self.stdstreambuffer._stderrbuff,
-                                       sys.stderr)
+        sys.stdout = RedirectStdStream(
+            self.stdstreambuffer._stdoutbuff, sys.stdout
+        )
+        sys.stderr = RedirectStdStream(
+            self.stdstreambuffer._stderrbuff, sys.stderr
+        )
 
         return self.stdstreambuffer
 

--- a/openfl/experimental/utilities/stream_redirect.py
+++ b/openfl/experimental/utilities/stream_redirect.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2020-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
 """openfl.experimental.utilities.stream_redirect module."""
 
 import io
@@ -56,6 +55,7 @@ class RedirectStdStreamContext:
     """
     Context Manager that enables redirection of stdout & stderr
     """
+
     def __init__(self):
         self.stdstreambuffer = RedirectStdStreamBuffer()
 
@@ -65,8 +65,10 @@ class RedirectStdStreamContext:
         """
         self.__old_stdout = sys.stdout
         self.__old_stderr = sys.stderr
-        sys.stdout = RedirectStdStream(self.stdstreambuffer._stdoutbuff, sys.stdout)
-        sys.stderr = RedirectStdStream(self.stdstreambuffer._stderrbuff, sys.stderr)
+        sys.stdout = RedirectStdStream(self.stdstreambuffer._stdoutbuff,
+                                       sys.stdout)
+        sys.stderr = RedirectStdStream(self.stdstreambuffer._stderrbuff,
+                                       sys.stderr)
 
         return self.stdstreambuffer
 

--- a/openfl/experimental/utilities/transitions.py
+++ b/openfl/experimental/utilities/transitions.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2020-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
 """Detect criteria for transitions in placement."""
 
 

--- a/openfl/experimental/utilities/ui.py
+++ b/openfl/experimental/utilities/ui.py
@@ -1,10 +1,11 @@
 # Copyright (C) 2020-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from openfl.experimental.utilities.metaflow_utils import DefaultCard, FlowGraph
-from pathlib import Path
 import os
 import webbrowser
+from pathlib import Path
+
+from openfl.experimental.utilities.metaflow_utils import DefaultCard, FlowGraph
 
 
 class InspectFlow:

--- a/openfl/experimental/utilities/ui.py
+++ b/openfl/experimental/utilities/ui.py
@@ -9,6 +9,7 @@ from openfl.experimental.utilities.metaflow_utils import DefaultCard, FlowGraph
 
 
 class InspectFlow:
+
     def __init__(
         self,
         flow_obj,

--- a/openfl/experimental/workspace_export/__init__.py
+++ b/openfl/experimental/workspace_export/__init__.py
@@ -1,6 +1,4 @@
 # Copyright (C) 2020-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from .export import WorkspaceExport
-
-__all__ = ["WorkspaceExport"]
+from openfl.experimental.workspace_export.export import WorkspaceExport

--- a/openfl/experimental/workspace_export/export.py
+++ b/openfl/experimental/workspace_export/export.py
@@ -2,19 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 """Workspace Builder module."""
 
-import re
-import yaml
 import ast
-import astor
-import inspect
 import importlib
-import nbformat
-
-from shutil import copytree
+import inspect
+import re
 from logging import getLogger
 from pathlib import Path
+from shutil import copytree
 
+import astor
+import nbformat
+import yaml
 from nbdev.export import nb_export
+
 from openfl.experimental.interface.cli.cli_helper import print_tree
 
 
@@ -200,8 +200,8 @@ class WorkspaceExport:
         """
         Imports generated python script with help of importlib
         """
-        import sys
         import importlib
+        import sys
 
         sys.path.append(str(self.script_path.parent))
         self.exported_script_module = importlib.import_module(self.script_name)

--- a/openfl/experimental/workspace_export/export.py
+++ b/openfl/experimental/workspace_export/export.py
@@ -30,29 +30,31 @@ class WorkspaceExport:
     Returns:
         None
     """
-    def __init__(self,
-                 notebook_path: str,
-                 output_workspace: str) -> None:
+
+    def __init__(self, notebook_path: str, output_workspace: str) -> None:
         self.logger = getLogger(__name__)
 
         self.notebook_path = Path(notebook_path).resolve()
         self.output_workspace_path = Path(output_workspace).resolve()
         self.output_workspace_path.parent.mkdir(parents=True, exist_ok=True)
 
-        self.template_workspace_path = Path(f"{__file__}").parent.parent.parent.parent.joinpath(
-            "openfl-workspace", "experimental", "template_workspace"
-        ).resolve(strict=True)
+        self.template_workspace_path = Path(
+            f"{__file__}").parent.parent.parent.parent.joinpath(
+                "openfl-workspace", "experimental",
+                "template_workspace").resolve(strict=True)
 
         # Copy template workspace to output directory
-        self.created_workspace_path = Path(copytree(
-            self.template_workspace_path, self.output_workspace_path))
-        self.logger.info(f"Copied template workspace to {self.created_workspace_path}")
+        self.created_workspace_path = Path(
+            copytree(self.template_workspace_path, self.output_workspace_path))
+        self.logger.info(
+            f"Copied template workspace to {self.created_workspace_path}")
 
         self.logger.info("Converting jupter notebook to python script...")
         export_filename = self.__get_exp_name()
-        self.script_path = Path(self.__convert_to_python(
-            self.notebook_path, self.created_workspace_path.joinpath("src"),
-            f"{export_filename}.py")).resolve()
+        self.script_path = Path(
+            self.__convert_to_python(
+                self.notebook_path, self.created_workspace_path.joinpath("src"),
+                f"{export_filename}.py")).resolve()
         print_tree(self.created_workspace_path, level=2)
 
         # Generated python script name without .py extension
@@ -72,11 +74,13 @@ class WorkspaceExport:
                 code = cell.source
                 match = re.search(r"#\s*\|\s*default_exp\s+(\w+)", code)
                 if match:
-                    self.logger.info(f"Retrieved {match.group(1)} from default_exp")
+                    self.logger.info(
+                        f"Retrieved {match.group(1)} from default_exp")
                     return match.group(1)
         return None
 
-    def __convert_to_python(self, notebook_path: Path, output_path: Path, export_filename):
+    def __convert_to_python(self, notebook_path: Path, output_path: Path,
+                            export_filename):
         nb_export(notebook_path, output_path)
 
         return Path(output_path).joinpath(export_filename).resolve()
@@ -131,8 +135,10 @@ class WorkspaceExport:
             if "__init__" in cls.__dict__:
                 init_signature = inspect.signature(cls.__init__)
                 # Extract the parameter names (excluding 'self', 'args', and 'kwargs')
-                arg_names = [param for param in init_signature.parameters if param not in (
-                    "self", "args", "kwargs")]
+                arg_names = [
+                    param for param in init_signature.parameters
+                    if param not in ("self", "args", "kwargs")
+                ]
                 return arg_names
             return []
         self.logger.error(f"{cls} is not a class")
@@ -148,7 +154,8 @@ class WorkspaceExport:
         # Going though all attributes in imported python script
         for attr in self.available_modules_in_exported_script:
             t = getattr(self.exported_script_module, attr)
-            if inspect.isclass(t) and t != parent_class and issubclass(t, parent_class):
+            if inspect.isclass(t) and t != parent_class and issubclass(
+                    t, parent_class):
                 return inspect.getsource(t), attr
 
         return None, None
@@ -157,15 +164,14 @@ class WorkspaceExport:
         """
         Provided name of the class returns expected arguments and it's values in form of dictionary
         """
-        instantiation_args = {
-            "args": {}, "kwargs": {}
-        }
+        instantiation_args = {"args": {}, "kwargs": {}}
 
         with open(self.script_path, "r") as s:
             tree = ast.parse(s.read())
 
             for node in ast.walk(tree):
-                if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                if isinstance(node, ast.Call) and isinstance(
+                        node.func, ast.Name):
                     if node.func.id == class_name:
                         # We found an instantiation of the class
                         for arg in node.args:
@@ -174,9 +180,11 @@ class WorkspaceExport:
                                 # Use the variable name as the argument value
                                 instantiation_args["args"][arg.id] = arg.id
                             elif isinstance(arg, ast.Constant):
-                                instantiation_args["args"][arg.s] = astor.to_source(arg)
+                                instantiation_args["args"][
+                                    arg.s] = astor.to_source(arg)
                             else:
-                                instantiation_args["args"][arg.arg] = astor.to_source(arg).strip()
+                                instantiation_args["args"][
+                                    arg.arg] = astor.to_source(arg).strip()
 
                         for kwarg in node.keywords:
                             # Iterate through keyword arguments
@@ -205,7 +213,8 @@ class WorkspaceExport:
 
         sys.path.append(str(self.script_path.parent))
         self.exported_script_module = importlib.import_module(self.script_name)
-        self.available_modules_in_exported_script = dir(self.exported_script_module)
+        self.available_modules_in_exported_script = dir(
+            self.exported_script_module)
 
     def __read_yaml(self, path):
         with open(path, "r") as y:
@@ -252,7 +261,9 @@ class WorkspaceExport:
                     line_nos.append(i)
                     # Avoid commented lines, libraries from *.txt file, or openfl.git
                     # installation
-                    if not line.startswith("#") and "-r" not in line and "openfl.git" not in line:
+                    if not line.startswith(
+                            "#"
+                    ) and "-r" not in line and "openfl.git" not in line:
                         requirements.append(f"{line.split(' ')[-1].strip()}\n")
 
         requirements_filepath = str(
@@ -274,25 +285,25 @@ class WorkspaceExport:
         Generates plan.yaml
         """
         flspec = getattr(
-            importlib.import_module("openfl.experimental.interface"), "FLSpec"
-        )
+            importlib.import_module("openfl.experimental.interface"), "FLSpec")
         # Get flow classname
-        _, self.flow_class_name = self.__get_class_name_and_sourcecode_from_parent_class(flspec)
+        _, self.flow_class_name = self.__get_class_name_and_sourcecode_from_parent_class(
+            flspec)
         # Get expected arguments of flow class
-        self.flow_class_expected_arguments = self.__get_class_arguments(self.flow_class_name)
+        self.flow_class_expected_arguments = self.__get_class_arguments(
+            self.flow_class_name)
         # Get provided arguments to flow class
         self.arguments_passed_to_initialize = self.__extract_class_initializing_args(
             self.flow_class_name)
 
-        plan = self.created_workspace_path.joinpath("plan", "plan.yaml").resolve()
+        plan = self.created_workspace_path.joinpath("plan",
+                                                    "plan.yaml").resolve()
         data = self.__read_yaml(plan)
         if data is None:
-            data["federated_flow"] = {
-                "settings": {},
-                "template": ""
-            }
+            data["federated_flow"] = {"settings": {}, "template": ""}
 
-        data["federated_flow"]["template"] = f"src.{self.script_name}.{self.flow_class_name}"
+        data["federated_flow"][
+            "template"] = f"src.{self.script_name}.{self.flow_class_name}"
 
         def update_dictionary(args: dict, data: dict, dtype: str = "args"):
             for idx, (k, v) in enumerate(args.items()):
@@ -304,9 +315,7 @@ class WorkspaceExport:
                 elif dtype == "kwargs":
                     if v is not None and type(v) not in (int, str, bool):
                         v = f"src.{self.script_name}.{k}"
-                data["federated_flow"]["settings"].update({
-                    k: v
-                })
+                data["federated_flow"]["settings"].update({k: v})
 
         # Find positional arguments of flow class and it's values
         pos_args = self.arguments_passed_to_initialize["args"]
@@ -328,26 +337,30 @@ class WorkspaceExport:
         # If flow classname is not yet found
         if not hasattr(self, "flow_class_name"):
             flspec = getattr(
-                importlib.import_module("openfl.experimental.interface"), "FLSpec"
-            )
+                importlib.import_module("openfl.experimental.interface"),
+                "FLSpec")
             _, self.flow_class_name = self.__get_class_name_and_sourcecode_from_parent_class(
                 flspec)
 
         # Import flow class
-        federated_flow_class = getattr(self.exported_script_module, self.flow_class_name)
+        federated_flow_class = getattr(self.exported_script_module,
+                                       self.flow_class_name)
         # Find federated_flow._runtime and federated_flow._runtime.collaborators
         for t in self.available_modules_in_exported_script:
             t = getattr(self.exported_script_module, t)
             if isinstance(t, federated_flow_class):
                 if not hasattr(t, "_runtime"):
-                    raise Exception("Unable to locate LocalRuntime instantiation")
+                    raise Exception(
+                        "Unable to locate LocalRuntime instantiation")
                 runtime = t._runtime
                 if not hasattr(runtime, "collaborators"):
-                    raise Exception("LocalRuntime instance does not have collaborators")
+                    raise Exception(
+                        "LocalRuntime instance does not have collaborators")
                 collaborators_names = runtime.collaborators
                 break
 
-        data_yaml = self.created_workspace_path.joinpath("plan", "data.yaml").resolve()
+        data_yaml = self.created_workspace_path.joinpath("plan",
+                                                         "data.yaml").resolve()
         data = self.__read_yaml(data_yaml)
         if data is None:
             data = {}
@@ -359,12 +372,13 @@ class WorkspaceExport:
             data["aggregator"] = {
                 "callable_func": {
                     "settings": {},
-                    "template": f"src.{self.script_name}.{private_attrs_callable.__name__}"
+                    "template":
+                        f"src.{self.script_name}.{private_attrs_callable.__name__}"
                 }
             }
             # Find arguments expected by Aggregator
-            arguments_passed_to_initialize = self.__extract_class_initializing_args("Aggregator")[
-                "kwargs"]
+            arguments_passed_to_initialize = self.__extract_class_initializing_args(
+                "Aggregator")["kwargs"]
             agg_kwargs = aggregator.kwargs
             for key, value in agg_kwargs.items():
                 if isinstance(value, (int, str, bool)):
@@ -375,8 +389,8 @@ class WorkspaceExport:
                     data["aggregator"]["callable_func"]["settings"][key] = value
 
         # Find arguments expected by Collaborator
-        arguments_passed_to_initialize = self.__extract_class_initializing_args("Collaborator")[
-            "kwargs"]
+        arguments_passed_to_initialize = self.__extract_class_initializing_args(
+            "Collaborator")["kwargs"]
         for collab_name in collaborators_names:
             if collab_name not in data:
                 data[collab_name] = {

--- a/openfl/experimental/workspace_export/export.py
+++ b/openfl/experimental/workspace_export/export.py
@@ -38,23 +38,31 @@ class WorkspaceExport:
         self.output_workspace_path = Path(output_workspace).resolve()
         self.output_workspace_path.parent.mkdir(parents=True, exist_ok=True)
 
-        self.template_workspace_path = Path(
-            f"{__file__}").parent.parent.parent.parent.joinpath(
-                "openfl-workspace", "experimental",
-                "template_workspace").resolve(strict=True)
+        self.template_workspace_path = (
+            Path(f"{__file__}")
+            .parent.parent.parent.parent.joinpath(
+                "openfl-workspace", "experimental", "template_workspace"
+            )
+            .resolve(strict=True)
+        )
 
         # Copy template workspace to output directory
         self.created_workspace_path = Path(
-            copytree(self.template_workspace_path, self.output_workspace_path))
+            copytree(self.template_workspace_path, self.output_workspace_path)
+        )
         self.logger.info(
-            f"Copied template workspace to {self.created_workspace_path}")
+            f"Copied template workspace to {self.created_workspace_path}"
+        )
 
         self.logger.info("Converting jupter notebook to python script...")
         export_filename = self.__get_exp_name()
         self.script_path = Path(
             self.__convert_to_python(
-                self.notebook_path, self.created_workspace_path.joinpath("src"),
-                f"{export_filename}.py")).resolve()
+                self.notebook_path,
+                self.created_workspace_path.joinpath("src"),
+                f"{export_filename}.py",
+            )
+        ).resolve()
         print_tree(self.created_workspace_path, level=2)
 
         # Generated python script name without .py extension
@@ -75,12 +83,14 @@ class WorkspaceExport:
                 match = re.search(r"#\s*\|\s*default_exp\s+(\w+)", code)
                 if match:
                     self.logger.info(
-                        f"Retrieved {match.group(1)} from default_exp")
+                        f"Retrieved {match.group(1)} from default_exp"
+                    )
                     return match.group(1)
         return None
 
-    def __convert_to_python(self, notebook_path: Path, output_path: Path,
-                            export_filename):
+    def __convert_to_python(
+        self, notebook_path: Path, output_path: Path, export_filename
+    ):
         nb_export(notebook_path, output_path)
 
         return Path(output_path).joinpath(export_filename).resolve()
@@ -123,8 +133,10 @@ class WorkspaceExport:
         # Find class from imported python script module
         for idx, attr in enumerate(self.available_modules_in_exported_script):
             if attr == class_name:
-                cls = getattr(self.exported_script_module,
-                              self.available_modules_in_exported_script[idx])
+                cls = getattr(
+                    self.exported_script_module,
+                    self.available_modules_in_exported_script[idx],
+                )
 
         # If class not found
         if "cls" not in locals():
@@ -136,7 +148,8 @@ class WorkspaceExport:
                 init_signature = inspect.signature(cls.__init__)
                 # Extract the parameter names (excluding 'self', 'args', and 'kwargs')
                 arg_names = [
-                    param for param in init_signature.parameters
+                    param
+                    for param in init_signature.parameters
                     if param not in ("self", "args", "kwargs")
                 ]
                 return arg_names
@@ -154,8 +167,11 @@ class WorkspaceExport:
         # Going though all attributes in imported python script
         for attr in self.available_modules_in_exported_script:
             t = getattr(self.exported_script_module, attr)
-            if inspect.isclass(t) and t != parent_class and issubclass(
-                    t, parent_class):
+            if (
+                inspect.isclass(t)
+                and t != parent_class
+                and issubclass(t, parent_class)
+            ):
                 return inspect.getsource(t), attr
 
         return None, None
@@ -171,7 +187,8 @@ class WorkspaceExport:
 
             for node in ast.walk(tree):
                 if isinstance(node, ast.Call) and isinstance(
-                        node.func, ast.Name):
+                    node.func, ast.Name
+                ):
                     if node.func.id == class_name:
                         # We found an instantiation of the class
                         for arg in node.args:
@@ -180,11 +197,13 @@ class WorkspaceExport:
                                 # Use the variable name as the argument value
                                 instantiation_args["args"][arg.id] = arg.id
                             elif isinstance(arg, ast.Constant):
-                                instantiation_args["args"][
-                                    arg.s] = astor.to_source(arg)
+                                instantiation_args["args"][arg.s] = (
+                                    astor.to_source(arg)
+                                )
                             else:
-                                instantiation_args["args"][
-                                    arg.arg] = astor.to_source(arg).strip()
+                                instantiation_args["args"][arg.arg] = (
+                                    astor.to_source(arg).strip()
+                                )
 
                         for kwarg in node.keywords:
                             # Iterate through keyword arguments
@@ -214,7 +233,8 @@ class WorkspaceExport:
         sys.path.append(str(self.script_path.parent))
         self.exported_script_module = importlib.import_module(self.script_name)
         self.available_modules_in_exported_script = dir(
-            self.exported_script_module)
+            self.exported_script_module
+        )
 
     def __read_yaml(self, path):
         with open(path, "r") as y:
@@ -261,13 +281,16 @@ class WorkspaceExport:
                     line_nos.append(i)
                     # Avoid commented lines, libraries from *.txt file, or openfl.git
                     # installation
-                    if not line.startswith(
-                            "#"
-                    ) and "-r" not in line and "openfl.git" not in line:
+                    if (
+                        not line.startswith("#")
+                        and "-r" not in line
+                        and "openfl.git" not in line
+                    ):
                         requirements.append(f"{line.split(' ')[-1].strip()}\n")
 
         requirements_filepath = str(
-            self.created_workspace_path.joinpath("requirements.txt").resolve())
+            self.created_workspace_path.joinpath("requirements.txt").resolve()
+        )
 
         # Write libraries found in requirements.txt
         with open(requirements_filepath, "a") as f:
@@ -285,25 +308,31 @@ class WorkspaceExport:
         Generates plan.yaml
         """
         flspec = getattr(
-            importlib.import_module("openfl.experimental.interface"), "FLSpec")
+            importlib.import_module("openfl.experimental.interface"), "FLSpec"
+        )
         # Get flow classname
-        _, self.flow_class_name = self.__get_class_name_and_sourcecode_from_parent_class(
-            flspec)
+        _, self.flow_class_name = (
+            self.__get_class_name_and_sourcecode_from_parent_class(flspec)
+        )
         # Get expected arguments of flow class
         self.flow_class_expected_arguments = self.__get_class_arguments(
-            self.flow_class_name)
+            self.flow_class_name
+        )
         # Get provided arguments to flow class
-        self.arguments_passed_to_initialize = self.__extract_class_initializing_args(
-            self.flow_class_name)
+        self.arguments_passed_to_initialize = (
+            self.__extract_class_initializing_args(self.flow_class_name)
+        )
 
-        plan = self.created_workspace_path.joinpath("plan",
-                                                    "plan.yaml").resolve()
+        plan = self.created_workspace_path.joinpath(
+            "plan", "plan.yaml"
+        ).resolve()
         data = self.__read_yaml(plan)
         if data is None:
             data["federated_flow"] = {"settings": {}, "template": ""}
 
         data["federated_flow"][
-            "template"] = f"src.{self.script_name}.{self.flow_class_name}"
+            "template"
+        ] = f"src.{self.script_name}.{self.flow_class_name}"
 
         def update_dictionary(args: dict, data: dict, dtype: str = "args"):
             for idx, (k, v) in enumerate(args.items()):
@@ -338,29 +367,35 @@ class WorkspaceExport:
         if not hasattr(self, "flow_class_name"):
             flspec = getattr(
                 importlib.import_module("openfl.experimental.interface"),
-                "FLSpec")
-            _, self.flow_class_name = self.__get_class_name_and_sourcecode_from_parent_class(
-                flspec)
+                "FLSpec",
+            )
+            _, self.flow_class_name = (
+                self.__get_class_name_and_sourcecode_from_parent_class(flspec)
+            )
 
         # Import flow class
-        federated_flow_class = getattr(self.exported_script_module,
-                                       self.flow_class_name)
+        federated_flow_class = getattr(
+            self.exported_script_module, self.flow_class_name
+        )
         # Find federated_flow._runtime and federated_flow._runtime.collaborators
         for t in self.available_modules_in_exported_script:
             t = getattr(self.exported_script_module, t)
             if isinstance(t, federated_flow_class):
                 if not hasattr(t, "_runtime"):
                     raise Exception(
-                        "Unable to locate LocalRuntime instantiation")
+                        "Unable to locate LocalRuntime instantiation"
+                    )
                 runtime = t._runtime
                 if not hasattr(runtime, "collaborators"):
                     raise Exception(
-                        "LocalRuntime instance does not have collaborators")
+                        "LocalRuntime instance does not have collaborators"
+                    )
                 collaborators_names = runtime.collaborators
                 break
 
-        data_yaml = self.created_workspace_path.joinpath("plan",
-                                                         "data.yaml").resolve()
+        data_yaml = self.created_workspace_path.joinpath(
+            "plan", "data.yaml"
+        ).resolve()
         data = self.__read_yaml(data_yaml)
         if data is None:
             data = {}
@@ -372,13 +407,13 @@ class WorkspaceExport:
             data["aggregator"] = {
                 "callable_func": {
                     "settings": {},
-                    "template":
-                        f"src.{self.script_name}.{private_attrs_callable.__name__}"
+                    "template": f"src.{self.script_name}.{private_attrs_callable.__name__}",
                 }
             }
             # Find arguments expected by Aggregator
-            arguments_passed_to_initialize = self.__extract_class_initializing_args(
-                "Aggregator")["kwargs"]
+            arguments_passed_to_initialize = (
+                self.__extract_class_initializing_args("Aggregator")["kwargs"]
+            )
             agg_kwargs = aggregator.kwargs
             for key, value in agg_kwargs.items():
                 if isinstance(value, (int, str, bool)):
@@ -390,14 +425,12 @@ class WorkspaceExport:
 
         # Find arguments expected by Collaborator
         arguments_passed_to_initialize = self.__extract_class_initializing_args(
-            "Collaborator")["kwargs"]
+            "Collaborator"
+        )["kwargs"]
         for collab_name in collaborators_names:
             if collab_name not in data:
                 data[collab_name] = {
-                    "callable_func": {
-                        "settings": {},
-                        "template": None
-                    }
+                    "callable_func": {"settings": {}, "template": None}
                 }
             # Find collaborator details
             kw_args = runtime.get_collaborator_kwargs(collab_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.black]
+line-length = 80
+
+[tool.isort]
+profile = "black"
+force_single_line = "False"
+line_length = 80

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,11 @@ ignore =
     W503
     # Allow "import torch.nn.functional as F"
     N812
+
+per-file-ignores =
+    # Unused imports in __init__.py are OK
+    **/__init__.py:F401
+    
 select = E,F,W,N,C4,C90,C801
 inline-quotes = '
 multiline-quotes = '

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,12 @@
 [flake8]
 
-# W503 Line break occurred before a binary operator. Update by W504 Line
-# break occurred after a binary operator
-# N812: lowercase imported as non lowercase. Allow "import torch.nn.functional as F"
-ignore = W503, N812
+ignore =
+    # Conflicts with black
+    E203
+    # Line break occurred before a binary operator. Update by W504 Line
+    W503
+    # Allow "import torch.nn.functional as F"
+    N812
 select = E,F,W,N,C4,C90,C801
 inline-quotes = '
 multiline-quotes = '

--- a/shell/format.sh
+++ b/shell/format.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+base_dir=$(dirname $(dirname $0))
+
+# TODO: @karansh1 Apply across all modules
+isort --sp "${base_dir}/pyproject.toml" openfl/experimental
+
+black --config "${base_dir}/pyproject.toml" openfl/experimental
+
+flake8 --config "${base_dir}/setup.cfg" openfl/experimental

--- a/shell/lint.sh
+++ b/shell/lint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+base_dir=$(dirname $(dirname $0))
+
+# TODO: @karansh1 Apply across all modules
+isort --sp "${base_dir}/pyproject.toml" --check openfl/experimental
+
+black --config "${base_dir}/pyproject.toml" --check openfl/experimental
+
+flake8 --config "${base_dir}/setup.cfg" openfl/experimental


### PR DESCRIPTION
Note: This PR only impacts `openfl.experimental` namespace, and should be a non-breaking change. 

Changes:
* Sorted imports using `isort`
* Formatted files using `black`
* Linted using `flake8`

Configuration for `isort` and `black` is included in `pyproject.toml`. `flake8` continues to use `setup.cfg`


For future development:
* Lint using `./shell/lint.sh`
* Format using `./shell/format.sh`
* Use absolute imports as discussed [here](https://github.com/securefederatedai/openfl/pull/980#discussion_r1628970037).