### PR TITLE
Allow `feature_shape` to be passed to `fx plan initialize`

### DIFF
--- a/openfl/interface/cli.py
+++ b/openfl/interface/cli.py
@@ -254,7 +254,7 @@ def entry():
         cli.add_command(command_group.__getattribute__(module))
 
     try:
-        cli()
+        cli(max_content_width=120)
     except Exception as e:
         error_handler(e)
 

--- a/openfl/interface/plan.py
+++ b/openfl/interface/plan.py
@@ -65,8 +65,6 @@ def initialize(context, plan_config, cols_config, data_config,
             echo(f'{p} is out of the openfl workspace scope.')
             sys.exit(1)
 
-    logger.info("input shape = {input_shape}")
-
     plan_config = Path(plan_config).absolute()
     cols_config = Path(cols_config).absolute()
     data_config = Path(data_config).absolute()

--- a/openfl/interface/plan.py
+++ b/openfl/interface/plan.py
@@ -57,8 +57,6 @@ def initialize(context, plan_config, cols_config, data_config,
     from openfl.utilities.utils import getfqdn_env
     from openfl.utilities.mocks import MockDataLoader
 
-    #logger.info(f'Feature_shape = {feature_shape}')
-
     for p in [plan_config, cols_config, data_config]:
         if is_directory_traversal(p):
             echo(f'{p} is out of the openfl workspace scope.')
@@ -86,7 +84,6 @@ def initialize(context, plan_config, cols_config, data_config,
         # If feature shape is not provided, data is assumed to be present
         collaborator_cname = list(plan.cols_data_paths)[0]
         data_loader = plan.get_data_loader(collaborator_cname)
-        echo(f'Real data loader feature shape: {data_loader.get_feature_shape()}')
     task_runner = plan.get_task_runner(data_loader)
     tensor_pipe = plan.get_tensor_pipe()
 

--- a/openfl/utilities/click_types.py
+++ b/openfl/utilities/click_types.py
@@ -1,6 +1,6 @@
-# Copyright (C) 2020-2023 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-"""Click types module."""
+"""Custom input types definition for Click"""
 
 import click
 import ast
@@ -31,15 +31,16 @@ class IpAddressParamType(click.ParamType):
             self.fail(f'{value} is not a valid ip adress name', param, ctx)
         return value
 
-class ListOption(click.Option):
 
+class InputSpec(click.Option):
+    """List or dictionary that corresponds to the input shape for a model"""
     def type_cast_value(self, ctx, value):
         try:
             if value is None:
                 return None
             else:
                 return ast.literal_eval(value)
-        except:
+        except Exception:
             raise click.BadParameter(value)
 
 

--- a/openfl/utilities/click_types.py
+++ b/openfl/utilities/click_types.py
@@ -3,6 +3,7 @@
 """Click types module."""
 
 import click
+import ast
 
 from openfl.utilities import utils
 
@@ -29,6 +30,17 @@ class IpAddressParamType(click.ParamType):
         if not utils.is_api_adress(value):
             self.fail(f'{value} is not a valid ip adress name', param, ctx)
         return value
+
+class ListOption(click.Option):
+
+    def type_cast_value(self, ctx, value):
+        try:
+            if value is None:
+                return None
+            else:
+                return ast.literal_eval(value)
+        except:
+            raise click.BadParameter(value)
 
 
 FQDN = FqdnParamType()

--- a/openfl/utilities/mocks.py
+++ b/openfl/utilities/mocks.py
@@ -1,0 +1,12 @@
+# Copyright (C) 2020-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Mock objects to eliminate extraneous dependencies"""
+
+
+class MockDataLoader:
+    """Placeholder dataloader for when data is not available"""
+    def __init__(self, feature_shape):
+        self.feature_shape = feature_shape
+
+    def get_feature_shape(self):
+        return self.feature_shape


### PR DESCRIPTION
This PR:
- Fixes the `feature_shape` argument that can be passed to `fx plan initialize`. By passing this argument (which allows for list types arguments, such as `[1,28,28]`), loading the data loader for the model owner / aggregator can be avoided. This is important because the aggregator may not have access to local data to generate the initial model.