### PR TITLE
Fixed ImportError issue in Experimental aggregator based workflow

### DIFF
--- a/openfl/experimental/component/aggregator/__init__.py
+++ b/openfl/experimental/component/aggregator/__init__.py
@@ -3,4 +3,4 @@
 """openfl.experimental.component.aggregator package."""
 
 # FIXME: Too much recursion.
-from openfl.experimental.component.aggregator import Aggregator
+from openfl.experimental.component.aggregator.aggregator import Aggregator


### PR DESCRIPTION
Updated openfl/experimental/component/aggregator/__init__.py

Ran the following tutorials and test cases:

- Experimental workspace 101_torch_cnn_mnist, 301_torch_cnn_mnist_watermarking
- Experimental workspace testcase:
         - testcase_datastore_cli
         - testcase_private_attributes
         - testcase_reference
         - testcase_internalloop

No Issues observed

This PR fixes #989 