### PR TITLE
Pin dependency to NumPy 1.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -156,7 +156,7 @@ setup(
         'grpcio>=1.56.2',
         'ipykernel',
         'jupyterlab',
-        'numpy',
+        'numpy<2',
         'pandas',
         'protobuf>=3.20.3',
         'pyzmq<=26.0.3',


### PR DESCRIPTION
This PR:

- Pins `setup.py` `install_requires` to `numpy>2`

**Background:** NumPy recently had a major release (v2.0.0) that has some potential downstream issues with packages compiled for NumPy 1.x

> A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.0.0 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled with NumPy 2.0.
Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.
>
>If you are a user of the module, the easiest solution will be to
downgrade to 'numpy<2' or try to upgrade the affected module.
We expect that some modules will need time to support NumPy 2.

[source](https://numpy.org/doc/stable/user/troubleshooting-importerror.html#downstream-importerror-or-attributeerror)

**Issue**: This impacts _at least_ PyTorch versions earlier than v2.3 (i.e. PyTorch Task Runner)
```
>>> torch.__version__
'2.2.2+cpu'
>>> x = torch.rand(1)
>>> x.numpy()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: Numpy is not available
```

**Proposed resolution**: Pin install requirement to `numpy<2`
_**Rationale**_: With `python v3.9+` installing OpenFL will automatically install NumPy 2.0.0. By pinning to NumPy 1.x, this will allow OpenFL to continue to support earlier versions of PyTorch as well as avoid any potential issues caused in other packages. 

_Another potential resolution would be to update all PyTorch examples and workspaces to `2.3.0+`, but older torch versions might not work, and we might not catch other potential downstream issues._
