### PR TITLE
Update Federated_Pytorch_MNIST_Tutorial.ipynb (Delete one-hot encoding)

### DIFF
--- a/openfl-tutorials/Federated_Pytorch_MNIST_Tutorial.ipynb
+++ b/openfl-tutorials/Federated_Pytorch_MNIST_Tutorial.ipynb
@@ -83,7 +83,6 @@
     "\n",
     "valid_images,valid_labels = validset.test_data, np.array(validset.test_labels)\n",
     "valid_images = torch.from_numpy(np.expand_dims(valid_images, axis=1)).float()\n",
-    "valid_labels = one_hot(valid_labels,10)"
    ]
   },
   {


### PR DESCRIPTION
While running the openfl-tutorials/Federated_Pytorch_MNIST_Tutorial.ipynb file, an error occurred: '''
File /opt/anaconda3/envs/openfl/lib/python3.10/site-packages/openfl/federated/task/runner_pt.py:486, in PyTorchTaskRunner.validate_(self, validation_dataloader)
    484         # get the index of the max log-probability
    485         pred = output.argmax(dim=1)
--> 486         val_score += pred.eq(target).sum().cpu().numpy()
    488 accuracy = val_score / total_samples
    489 return Metric(name="accuracy", value=np.array(accuracy))

RuntimeError: The size of tensor a (32) must match the size of tensor b (10) at non-singleton dimension 1 . '''

I modified it according to the commit contents, and the code worked well after that.

Signed-off-by: tonywjs<tonywjs@kangwon.ac.kr>