### PR TITLE
Update torch from 1.13.1 to 2.3.1 (and dependent packages) in existing tutorials and workspaces

### DIFF
--- a/openfl-tutorials/experimental/Privacy_Meter/requirements_privacy_meter.txt
+++ b/openfl-tutorials/experimental/Privacy_Meter/requirements_privacy_meter.txt
@@ -1,9 +1,8 @@
-torch==1.13.1
-torchvision==0.14.1
+torch==2.3.1
+torchvision==0.18.1
 matplotlib
 pillow
-opacus==1.3.0
-numpy==1.23.5
+opacus==1.5.2
 cloudpickle
 scikit-learn
 git+https://github.com/privacytrustlab/ml_privacy_meter.git@ac181a885815f85b3809317c247f422e6596cb4a

--- a/openfl-tutorials/experimental/Vision_Transformer/requirements_vision_transformer.txt
+++ b/openfl-tutorials/experimental/Vision_Transformer/requirements_vision_transformer.txt
@@ -1,4 +1,4 @@
-torch==2.0.1
-torchvision==0.15.2
-medmnist==2.2.2
+torch==2.3.1
+torchvision==0.18.1
+medmnist==3.0.1
 transformers==4.38.0

--- a/openfl-tutorials/interactive_api/PyTorch_DogsCats_ViT/workspace/requirements.txt
+++ b/openfl-tutorials/interactive_api/PyTorch_DogsCats_ViT/workspace/requirements.txt
@@ -1,6 +1,6 @@
-torch==1.13.1
+torch==2.3.1
 linformer==0.2.1
-torchvision==0.14.1
+torchvision==0.18.1
 vit-pytorch==0.40.2
 setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability
 wheel>=0.38.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/openfl-tutorials/interactive_api/PyTorch_Lightning_MNIST_GAN/envoy/sd_requirements.txt
+++ b/openfl-tutorials/interactive_api/PyTorch_Lightning_MNIST_GAN/envoy/sd_requirements.txt
@@ -1,7 +1,7 @@
 numpy
 pillow
 pynvml==11.4.1
-torch==1.13.1
-torchvision==0.14.1
+torch==2.3.1
+torchvision==0.18.1
 setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability
 wheel>=0.38.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/openfl-tutorials/interactive_api/PyTorch_Lightning_MNIST_GAN/workspace/PyTorch_Lightning_GAN.ipynb
+++ b/openfl-tutorials/interactive_api/PyTorch_Lightning_MNIST_GAN/workspace/PyTorch_Lightning_GAN.ipynb
@@ -15,7 +15,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install \"pytorch-lightning>=1.3\" \"torch==1.13.1\" \"torchvision==0.14.1\" \"torchmetrics>=0.3\" \"scikit-image\" \"matplotlib\""
+    "!pip install \"pytorch-lightning>=1.3\" \"torch==2.3.1\" \"torchvision==0.18.1\" \"torchmetrics>=0.3\" \"scikit-image\" \"matplotlib\""
    ]
   },
   {

--- a/openfl-tutorials/interactive_api/PyTorch_Market_Re-ID/workspace/requirements.txt
+++ b/openfl-tutorials/interactive_api/PyTorch_Market_Re-ID/workspace/requirements.txt
@@ -1,2 +1,2 @@
-torch==1.13.1
-torchvision==0.14.1
+torch==2.3.1
+torchvision==0.18.1

--- a/openfl-tutorials/interactive_api/PyTorch_TinyImageNet/workspace/requirements.txt
+++ b/openfl-tutorials/interactive_api/PyTorch_TinyImageNet/workspace/requirements.txt
@@ -1,4 +1,4 @@
-torch==1.13.1
-torchvision==0.14.1
+torch==2.3.1
+torchvision==0.18.1
 setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability
 wheel>=0.38.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/openfl-tutorials/interactive_api/PyTorch_TinyImageNet_XPU/workspace/requirements.txt
+++ b/openfl-tutorials/interactive_api/PyTorch_TinyImageNet_XPU/workspace/requirements.txt
@@ -1,4 +1,4 @@
-torch==1.13.1
-torchvision==0.14.1
+torch==2.3.1
+torchvision==0.18.1
 setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability
 wheel>=0.38.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/openfl-workspace/experimental/101_torch_cnn_mnist/requirements.txt
+++ b/openfl-workspace/experimental/101_torch_cnn_mnist/requirements.txt
@@ -1,4 +1,4 @@
-torch==1.13.1
-torchvision==0.14.1
+torch==2.3.1
+torchvision==0.18.1
 tensorboard
 wheel>=0.38.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/openfl-workspace/experimental/102_aggregator_validation/requirements.txt
+++ b/openfl-workspace/experimental/102_aggregator_validation/requirements.txt
@@ -1,4 +1,4 @@
-torch==1.13.1
-torchvision==0.14.1
+torch==2.3.1
+torchvision==0.18.1
 tensorboard
 wheel>=0.38.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/openfl-workspace/experimental/301_torch_cnn_mnist_watermarking/requirements.txt
+++ b/openfl-workspace/experimental/301_torch_cnn_mnist_watermarking/requirements.txt
@@ -1,5 +1,5 @@
-torch==1.13.1
-torchvision==0.14.1
+torch==2.3.1
+torchvision==0.18.1
 tensorboard
 wheel>=0.38.0 # not directly required, pinned by Snyk to avoid a vulnerability
 matplotlib

--- a/openfl-workspace/experimental/501_pytorch_tinyimagenet_transfer_learning/requirements.txt
+++ b/openfl-workspace/experimental/501_pytorch_tinyimagenet_transfer_learning/requirements.txt
@@ -1,4 +1,4 @@
-torch==1.13.1
-torchvision==0.14.1
+torch==2.3.1
+torchvision==0.18.1
 tensorboard
 wheel>=0.38.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/tests/github/experimental/workspace/testcase_internalloop/requirements.txt
+++ b/tests/github/experimental/workspace/testcase_internalloop/requirements.txt
@@ -1,4 +1,4 @@
-torch==1.13.1
-torchvision==0.14.1
+torch==2.3.1
+torchvision==0.18.1
 tensorboard
 wheel>=0.38.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/tests/github/experimental/workspace/testcase_private_attributes_initialization_without_callable/requirements.txt
+++ b/tests/github/experimental/workspace/testcase_private_attributes_initialization_without_callable/requirements.txt
@@ -1,4 +1,4 @@
-torch==1.13.1
-torchvision==0.14.1
+torch==2.3.1
+torchvision==0.18.1
 tensorboard
 wheel>=0.38.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/tests/github/experimental/workspace/testcase_reference_with_include_exclude/requirements.txt
+++ b/tests/github/experimental/workspace/testcase_reference_with_include_exclude/requirements.txt
@@ -1,4 +1,4 @@
-torch==1.13.1
-torchvision==0.14.1
+torch==2.3.1
+torchvision==0.18.1
 tensorboard
 wheel>=0.38.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/tests/github/experimental/workspace/testcase_validate_particpant_names/requirements.txt
+++ b/tests/github/experimental/workspace/testcase_validate_particpant_names/requirements.txt
@@ -1,4 +1,4 @@
-torch==1.13.1
-torchvision==0.14.1
+torch==2.3.1
+torchvision==0.18.1
 tensorboard
 wheel>=0.38.0 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
Any existing tutorials and workspaces that are running on `torch=1.13.1` will trigger a dependabot bump to address vulnerabilities sooner or later.

This PR preemptively bumps those tutorials and workspaces. 

Furthermore, because `torch>2.3` does not support `numpy 2.x` (default `numpy` installed by `openfl`), this PR bumps directly to `torch==2.3.1` as well as any dependent packages (i.e. `torchvision`)