### PR TITLE
Bump `tensorboardX` to allow new `protobuf`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -164,7 +164,7 @@ setup(
         'rich',
         'scikit-learn',
         'tensorboard',
-        'tensorboardX<=2.6',
+        'tensorboardX>=2.6',
         'tqdm',
     ],
     setup_requires=['grpcio-tools>=1.56.2,<1.66.0'],


### PR DESCRIPTION
### Description
This PR (permanently?) addresses protobuf version issues. OpenFL inadvertently capped `protobuf` to 3.x as a result of `tensorboardX==2.6`.

`protobuf` 3.20.x is >4y old at this point. So the plan is to get rid of this limitation.
It was observed that protos in OpenFL-Security (internal) builds case were always built with the recent `protobuf` by respecting what setup actually asked for (i.e >3.20.x version), while `tensorboardX<=2.6` forced `protobuf` to be 3.x. 
 
In summary, `tensorboardX<=2.6` currently dictates `protobuf==3.x` to be used. They have long [lifted](https://pypi.org/project/tensorboardX/) this requirement of protobuf version with a minor version bump from 2.6 to 2.6.2.
 
Using `tensorboardX>=2.6` allows usage of any recent `protobuf` version, making it flexible for any TPT package. Aside, `tensorboardX` should be deprecated in favor of PyTorch's native `tensorboard` support. This will be addressed in a future PR.