### PR TITLE
Fix docstrings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,6 +43,9 @@ extensions = [
     'sphinx.ext.autosummary',
     'recommonmark'
 ]
+autodoc_default_options = {
+    'imported-members': True,
+}
 autosummary_generate = True  # Turn on sphinx.ext.autosummary
 
 source_suffix = ['.rst', '.md']


### PR DESCRIPTION
added 
autodoc_default_options = {
    'imported-members': True,
}
to docs/conf.py

This allows the docstrings to be rendered correctly with the RTD build process, this setting was previously only in the makefile for local builds.