### PR TITLE
fix(deps): bumping requests version to 2.32.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -160,7 +160,7 @@ setup(
         'pandas',
         'protobuf>=4.22,<5.0.0dev',
         'pyzmq<=26.1.1',
-        'requests',
+        'requests>=2.32.2',
         'rich',
         'scikit-learn',
         'tensorboard',

--- a/setup.py
+++ b/setup.py
@@ -160,7 +160,7 @@ setup(
         'pandas',
         'protobuf>=4.22,<5.0.0dev',
         'pyzmq<=26.1.1',
-        'requests>=2.32.2',
+        'requests>=2.32.0',
         'rich',
         'scikit-learn',
         'tensorboard',


### PR DESCRIPTION
Update the minimum required version for the [`requests`](https://pypi.org/project/requests/) module to fix vulnerabilities [CVE-2024-35195](https://avd.aquasec.com/nvd/2024/cve-2024-35195/) and [CVE-2023-32681](https://avd.aquasec.com/nvd/2023/cve-2023-32681/). 

Also resolves 
- https://github.com/securefederatedai/openfl/security/code-scanning/724
- https://github.com/securefederatedai/openfl/security/code-scanning/723