### PR TITLE
Fixes #1047 - Fix documentation link in the contributing.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to OpenFL
 
 We welcome contributions from the community. There are several ways to contribute:
-* Improvements in [documentation](https://openfl.readthedocs.io/en/latest/install.html).
+* Improvements in [documentation](https://openfl.readthedocs.io/en/latest/).
 * Contributing to OpenFL's code-base: via bug-fixes or feature additions.
 * Answering questions on our [discussions page](https://github.com/securefederatedai/openfl/discussions).
 * Participating in our [roadmap](https://github.com/securefederatedai/openfl/blob/develop/ROADMAP.md) discussions.

--- a/docs/contributing_guidelines/contributing.md
+++ b/docs/contributing_guidelines/contributing.md
@@ -5,7 +5,7 @@ We welcome contributions from the community. We believe that anyone can bring so
 
 We accept various contributions from documentation improvement and bug fixing to major features proposals and [roadmap](https://github.com/intel/openfl/blob/develop/ROADMAP.md) suggestions.
 
-Documentation improvement: review our [documentation](https://openfl.readthedocs.io/en/latest/install.html) and let us know if something is not clear or not relevant. 
+Documentation improvement: review our [documentation](https://openfl.readthedocs.io/en/latest) and let us know if something is not clear or not relevant. 
 Propose your own formulations or even write new section explaining something that you know how works, but do not see in the documentation. 
 Propose it through GitHub [issues](https://github.com/intel/openfl/issues/new/choose) or [Discussions](https://github.com/intel/openfl/discussions).
 


### PR DESCRIPTION
 set to default page of documentation, removed the trailing base page