### PR TITLE
Mark `create(...)` as externally callable.

### DIFF
--- a/openfl/interface/collaborator.py
+++ b/openfl/interface/collaborator.py
@@ -115,6 +115,10 @@ def start_(plan, collaborator_name, data_config, secure):
 )
 @option("-s", "--silent", help="Do not prompt", is_flag=True)
 def create_(collaborator_name, data_path, silent):
+    create(collaborator_name, data_path, silent)
+
+
+def create(collaborator_name, data_path, silent):
     """Creates a user for an experiment.
 
     Args:
@@ -122,7 +126,6 @@ def create_(collaborator_name, data_path, silent):
         data_path (str): The data path to be associated with the collaborator.
         silent (bool): Do not prompt.
     """
-
     if data_path and is_directory_traversal(data_path):
         echo("Data path is out of the openfl workspace scope.")
         sys.exit(1)


### PR DESCRIPTION
This PR reverts a change in `interface/collaborator.py` introduced by https://github.com/securefederatedai/openfl/pull/1003/commits/4abfb0a12c183ec123f9775613fa56b36eb69b24#

The change is to mark `create(...)` as externally callable.

More context: #834 and #1061.