### PR TITLE
uploading hadolint JSON report

### DIFF
--- a/.github/workflows/scans.yml
+++ b/.github/workflows/scans.yml
@@ -27,4 +27,9 @@ jobs:
         pip install .
     - name: Hadolint Dockerfile Scan
       run: |
-        docker run -v ${PWD}/openfl-docker:/openfl-docker --rm -i hadolint/hadolint hadolint -t error /openfl-docker/Dockerfile.base
+        docker run -v ${PWD}/openfl-docker:/openfl-docker --rm -i hadolint/hadolint hadolint -t error -f csv /openfl-docker/Dockerfile.base > hadolint_output.csv
+    - name: Upload Hadolint CSV Report
+      uses: actions/upload-artifact@v3
+      with:
+        name: hadolint-report
+        path: hadolint_output.csv

--- a/.github/workflows/scans.yml
+++ b/.github/workflows/scans.yml
@@ -27,9 +27,10 @@ jobs:
         pip install .
     - name: Hadolint Dockerfile Scan
       run: |
-        docker run -v ${PWD}/openfl-docker:/openfl-docker --rm -i hadolint/hadolint hadolint -t error -f csv /openfl-docker/Dockerfile.base > hadolint_output.csv
+        docker run -v ${PWD}/openfl-docker:/openfl-docker --rm -i hadolint/hadolint hadolint -t error /openfl-docker/Dockerfile.base
+        docker run -v ${PWD}/openfl-docker:/openfl-docker --rm -i hadolint/hadolint hadolint -t error -f json /openfl-docker/Dockerfile.base > hadolint_output.json
     - name: Upload Hadolint CSV Report
       uses: actions/upload-artifact@v3
       with:
         name: hadolint-report
-        path: hadolint_output.csv
+        path: hadolint_output.json

--- a/.github/workflows/scans.yml
+++ b/.github/workflows/scans.yml
@@ -29,7 +29,7 @@ jobs:
       run: |
         docker run -v ${PWD}/openfl-docker:/openfl-docker --rm -i hadolint/hadolint hadolint -t error /openfl-docker/Dockerfile.base
         docker run -v ${PWD}/openfl-docker:/openfl-docker --rm -i hadolint/hadolint hadolint -t error -f json /openfl-docker/Dockerfile.base > hadolint_output.json
-    - name: Upload Hadolint CSV Report
+    - name: Upload Hadolint JSON Report
       uses: actions/upload-artifact@v3
       with:
         name: hadolint-report


### PR DESCRIPTION
Hadolint Dockerfile Scan:

- Scans openfl-docker/Dockerfile.base for issues.
- Filters results to include only those categorized as errors using the -t error flag.
- Outputs results in JSON format with the -f json flag.
- The scan results are saved as an artifact, which can be downloaded and reviewed after the workflow completes.

Results 
https://github.com/securefederatedai/openfl/actions/runs/11046970602 

[hadolint-report.zip](https://github.com/user-attachments/files/17144912/hadolint-report.zip)

