### PR TITLE
adding trivy scan for code and uploading results to artifacts

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -37,7 +37,7 @@ jobs:
   
       - name: Run Trivy code vulnerability scanner (JSON Output)
         run: |
-          trivy --quiet fs --format json --output trivy-code-results.json --ignore-unfixed --vuln-type os,library --severity CRITICAL,HIGH,MEDIUM,LOW .
+          trivy --quiet fs --format spdx-json --output trivy-code-results.json --ignore-unfixed --vuln-type os,library --severity CRITICAL,HIGH,MEDIUM,LOW .
 
       - name: Upload Code Vulnerability Scan Results
         uses: actions/upload-artifact@v3
@@ -49,7 +49,7 @@ jobs:
         uses: aquasecurity/trivy-action@0.24.0
         with:
           image-ref: 'docker.io/securefederatedai/openfl:${{ github.sha }}'
-          format: 'json'
+          format: 'spdx-json'
           output: 'trivy-docker-results.json'
           exit-code: '1'
           ignore-unfixed: true

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -32,15 +32,8 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 
       - name: Run Trivy code vulnerability scanner (JSON Output)
-        uses: aquasecurity/trivy-action@0.24.0
-        with:
-          image-ref: ''
-          format: 'json'
-          output: 'trivy-code-results.json'
-          exit-code: '1'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH,MEDIUM,LOW'
+        run: |
+          trivy --quiet fs --format json --output trivy-code-results.json --ignore-unfixed --vuln-type os,library --severity CRITICAL,HIGH,MEDIUM,LOW .
 
       - name: Upload Code Vulnerability Scan Results
         uses: actions/upload-artifact@v3

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -26,15 +26,15 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
 
-      - name: Install Trivy
-        run: |
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.55.0
-
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: 'trivy-results.sarif'
 
+      - name: Install Trivy
+        run: |
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.55.0
+  
       - name: Run Trivy code vulnerability scanner (JSON Output)
         run: |
           trivy --quiet fs --format json --output trivy-code-results.json --ignore-unfixed --vuln-type os,library --severity CRITICAL,HIGH,MEDIUM,LOW .

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -37,7 +37,7 @@ jobs:
   
       - name: Run Trivy code vulnerability scanner (JSON Output)
         run: |
-          trivy --quiet fs --format spdx-json --output trivy-code-results.json --ignore-unfixed --vuln-type os,library --severity CRITICAL,HIGH,MEDIUM,LOW .
+          trivy --quiet fs --format json --output trivy-code-results.json --ignore-unfixed --vuln-type os,library --severity CRITICAL,HIGH,MEDIUM,LOW .
 
       - name: Upload Code Vulnerability Scan Results
         uses: actions/upload-artifact@v3
@@ -45,11 +45,11 @@ jobs:
           name: trivy-code-report-json
           path: trivy-code-results.json
       
-      - name: Run Trivy vulnerability scanner for Docker image
+      - name: Run Trivy vulnerability scanner for Docker image (JSON Output)
         uses: aquasecurity/trivy-action@0.24.0
         with:
           image-ref: 'docker.io/securefederatedai/openfl:${{ github.sha }}'
-          format: 'spdx-json'
+          format: 'json'
           output: 'trivy-docker-results.json'
           exit-code: '1'
           ignore-unfixed: true
@@ -61,3 +61,30 @@ jobs:
         with:
           name: trivy-docker-report-json
           path: trivy-docker-results.json
+
+      - name: Run Trivy code vulnerability scanner (SPDX-JSON Output)
+        run: |
+          trivy --quiet fs --format spdx-json --output trivy-code-spdx-results.json --ignore-unfixed --vuln-type os,library --severity CRITICAL,HIGH,MEDIUM,LOW .
+  
+      - name: Upload Code Vulnerability Scan Results
+        uses: actions/upload-artifact@v3
+        with:
+          name: trivy-code-spdx-report-json
+          path: trivy-code-spdx-results.json
+        
+      - name: Run Trivy vulnerability scanner for Docker image (SPDX-JSON Output)
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          image-ref: 'docker.io/securefederatedai/openfl:${{ github.sha }}'
+          format: 'spdx-json'
+          output: 'trivy-docker-spdx-results.json'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH,MEDIUM,LOW'
+    
+      - name: Upload Docker Vulnerability Scan
+        uses: actions/upload-artifact@v3
+        with:
+          name: trivy-docker-spdx-report-json
+          path: trivy-docker-spdx-results.json

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -49,8 +49,8 @@ jobs:
         uses: aquasecurity/trivy-action@0.24.0
         with:
           image-ref: 'docker.io/securefederatedai/openfl:${{ github.sha }}'
-          format: 'csv'
-          output: 'trivy-docker-results.csv'
+          format: 'json'
+          output: 'trivy-docker-results.json'
           exit-code: '1'
           ignore-unfixed: true
           vuln-type: 'os,library'
@@ -59,5 +59,5 @@ jobs:
       - name: Upload Docker Vulnerability Scan
         uses: actions/upload-artifact@v3
         with:
-          name: trivy-docker-report-csv
-          path: trivy-docker-results.csv
+          name: trivy-docker-report-json
+          path: trivy-docker-results.json

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -26,6 +26,10 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
 
+      - name: Install Trivy
+        run: |
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.55.0
+
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
         with:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -30,17 +30,37 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: 'trivy-results.sarif'
+
+      - name: Run Trivy code vulnerability scanner (JSON Output)
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          image-ref: ''
+          format: 'json'
+          output: 'trivy-code-results.json'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH,MEDIUM,LOW'
+
+      - name: Upload Code Vulnerability Scan Results
+        uses: actions/upload-artifact@v3
+        with:
+          name: trivy-code-report-json
+          path: trivy-code-results.json
       
-      - name: Run Trivy vulnerability scanner
+      - name: Run Trivy vulnerability scanner for Docker image
         uses: aquasecurity/trivy-action@0.24.0
         with:
           image-ref: 'docker.io/securefederatedai/openfl:${{ github.sha }}'
-          format: 'table'
+          format: 'csv'
+          output: 'trivy-docker-results.csv'
           exit-code: '1'
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH,MEDIUM,LOW'
   
-      - name: Log completion message
-        run: |
-          echo "Trivy scan completed. Review the output above for vulnerabilities."
+      - name: Upload Docker Vulnerability Scan
+        uses: actions/upload-artifact@v3
+        with:
+          name: trivy-docker-report-csv
+          path: trivy-docker-results.csv


### PR DESCRIPTION
Adding code vulnerability and docker vulnerability scans from trivy

**Code Vulnerability Scan:**

1. Install Trivy using curl command
2. Runs the Trivy scan for code vulnerabilities. This example uses json output. You can adjust the format and output filename as needed.
3. Uploads the code vulnerability scan results as a separate artifact.

**Docker Vulnerability Scan:**

1. Runs the Trivy scan for the Docker image vulnerabilities. This example outputs the results in csv format.
2. Uploads the Docker vulnerability scan results as a separate artifact.

Outputs results in Json and SP format and results are saved as an artifact, which can be downloaded and reviewed after the workflow completes.

Results
https://github.com/securefederatedai/openfl/actions/runs/11047772730 

Outputs results in JSON and spdx-json formats.
The scan results are saved as an artifact, which can be downloaded and reviewed after the workflow completes.

[trivy-code-report-json.zip](https://github.com/user-attachments/files/17144892/trivy-code-report-json.zip)
[trivy-docker-report-json.zip](https://github.com/user-attachments/files/17144897/trivy-docker-report-json.zip)
