### PR TITLE
adding docker-bench-security

### DIFF
--- a/.github/workflows/docker-bench-security.yml
+++ b/.github/workflows/docker-bench-security.yml
@@ -35,9 +35,11 @@ jobs:
             -v /var/lib:/var/lib:ro \
             -v /var/run/docker.sock:/var/run/docker.sock:ro \
             --label docker_bench_security \
-            docker/docker-bench-security > results/docker-bench-report.txt
+            docker/docker-bench-security -l results/docker-bench-security.log -o json
       - name: Upload Results
         uses: actions/upload-artifact@v3
         with:
           name: docker-bench-results
-          path: results/docker-bench-results.txt
+          path: |
+            results/docker-bench-security.log
+            results/docker-bench-security.log.json

--- a/.github/workflows/docker-bench-security.yml
+++ b/.github/workflows/docker-bench-security.yml
@@ -6,39 +6,151 @@ on:
 
 permissions:
   contents: read
-  
+
 jobs:
-  docker-bench-security:
+  build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v3
-        with:
-          python-version: "3.8"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install .
-      - name: Run Docker Bench for Security
-        run: |
-          mkdir -p results
-          docker run --rm --net host --pid host --userns host --cap-add audit_control \
-            -e DOCKER_CONTENT_TRUST=0 \
-            -v /etc:/etc:ro \
-            -v /lib/systemd/system:/lib/systemd/system:ro \
-            -v /usr/bin/containerd:/usr/bin/containerd:ro \
-            -v /usr/bin/runc:/usr/bin/runc:ro \
-            -v /usr/lib/systemd:/usr/lib/systemd:ro \
-            -v /var/lib:/var/lib:ro \
-            -v /var/run/docker.sock:/var/run/docker.sock:ro \
-            -v "$(pwd)/results:/results" \
-            --label docker_bench_security \
-            docker/docker-bench-security
-      - name: Upload Results
-        uses: actions/upload-artifact@v3
-        with:
-          name: docker-bench-results
-          path: logs/docker-bench-security.log
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.8"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .
+    - name: Clean Docker System
+      run: |
+        docker system prune -f
+    - name: Build base image
+      run: |
+        docker build -t openfl -f openfl-docker/Dockerfile.base .
+    - name: Create workspace image
+      run: |
+        fx workspace create --prefix example_workspace --template keras_cnn_mnist
+        cd example_workspace
+        fx plan initialize -a localhost
+        fx workspace dockerize --base_image openfl
+    - name: Create certificate authority for workspace
+      run: |
+        cd example_workspace
+        fx workspace certify
+    - name: Create signed cert for collaborator
+      run: |
+        cd example_workspace
+        fx collaborator create -d 1 -n charlie --silent
+        fx collaborator generate-cert-request -n charlie --silent
+        fx collaborator certify --request-pkg col_charlie_to_agg_cert_request.zip --silent       
+        # Pack the collaborator's private key, signed cert, and data.yaml into a tarball
+        tarfiles="plan/data.yaml agg_to_col_charlie_signed_cert.zip"
+        for entry in cert/client/*; do
+            if [[ "$entry" == *.key ]]; then
+                tarfiles="$tarfiles $entry"
+            fi
+        done
+
+        tar -cf cert_col_charlie.tar $tarfiles
+
+        # Clean up
+        rm -f $tarfiles
+        rm -f col_charlie_to_agg_cert_request.zip
+
+    - name: Create signed cert for aggregator
+      run: |
+        cd example_workspace
+        fx aggregator generate-cert-request --fqdn localhost
+        fx aggregator certify --fqdn localhost --silent
+
+        # Pack all files that aggregator needs to start training
+        tar -cf cert_agg.tar plan cert save
+
+        # Remove the directories after archiving
+        rm -rf plan cert save
+
+    - name: Load workspace image
+      run: |
+        cd example_workspace
+        docker load -i example_workspace_image.tar
+
+    - name: Run aggregator and collaborator
+      run: |
+        cd example_workspace
+
+        set -x
+        docker run --rm \
+          --network host \
+          --mount type=bind,source=./cert_agg.tar,target=/certs.tar \
+          -e CONTAINER_TYPE=aggregator \
+          example_workspace /home/openfl/openfl-docker/start_actor_in_container.sh &
+        
+        # TODO: Run with two collaborators instead.
+        docker run --rm \
+          --network host \
+          --mount type=bind,source=./cert_col_charlie.tar,target=/certs.tar \
+          -e CONTAINER_TYPE=collaborator \
+          -e COL=charlie \
+          example_workspace /home/openfl/openfl-docker/start_actor_in_container.sh
+    
+    - name: Run Docker Bench for Security
+      run: |
+        docker run --rm --net host --pid host --userns host --cap-add audit_control \
+          -e DOCKER_CONTENT_TRUST=0 \
+          -v /etc:/etc:ro \
+          -v /lib/systemd/system:/lib/systemd/system:ro \
+          -v /usr/bin/containerd:/usr/bin/containerd:ro \
+          -v /usr/bin/runc:/usr/bin/runc:ro \
+          -v /usr/lib/systemd:/usr/lib/systemd:ro \
+          -v /var/lib:/var/lib:ro \
+          -v /var/run/docker.sock:/var/run/docker.sock:ro \
+          -v "$(pwd)/results:/results" \
+          --label docker_bench_security \
+          docker/docker-bench-security
+
+
+# name: Docker Bench for Security
+
+# on:
+#   pull_request:
+#     branches: [ develop ]
+
+# permissions:
+#   contents: read
+  
+# jobs:
+#   docker-bench-security:
+#     runs-on: ubuntu-latest
+
+#     steps:
+#       - name: Checkout code
+#         uses: actions/checkout@v3
+#       - name: Set up Python 3.8
+#         uses: actions/setup-python@v3
+#         with:
+#           python-version: "3.8"
+#       - name: Install dependencies
+#         run: |
+#           python -m pip install --upgrade pip
+#           pip install .
+#       - name: Run Docker Bench for Security
+#         run: |
+#           mkdir -p results
+#           docker run --rm --net host --pid host --userns host --cap-add audit_control \
+#             -e DOCKER_CONTENT_TRUST=0 \
+#             -v /etc:/etc:ro \
+#             -v /lib/systemd/system:/lib/systemd/system:ro \
+#             -v /usr/bin/containerd:/usr/bin/containerd:ro \
+#             -v /usr/bin/runc:/usr/bin/runc:ro \
+#             -v /usr/lib/systemd:/usr/lib/systemd:ro \
+#             -v /var/lib:/var/lib:ro \
+#             -v /var/run/docker.sock:/var/run/docker.sock:ro \
+#             -v "$(pwd)/results:/results" \
+#             --label docker_bench_security \
+#             docker/docker-bench-security
+#       - name: Upload Results
+#         uses: actions/upload-artifact@v3
+#         with:
+#           name: docker-bench-results
+#           path: logs/docker-bench-security.log

--- a/.github/workflows/docker-bench-security.yml
+++ b/.github/workflows/docker-bench-security.yml
@@ -25,24 +25,17 @@ jobs:
       - name: Run Docker Bench for Security
         run: |
           mkdir -p results
-          # docker run --net host --pid host --cap-add audit_control --cap-add sys_admin --cap-add syslog \
-          #   -e DOCKER_CONTENT_TRUST=$DOCKER_CONTENT_TRUST \
-          #   -v /etc:/etc:ro \
-          #   -v /lib/systemd/system:/lib/systemd/system:ro \
-          #   -v /usr/bin/containerd:/usr/bin/containerd:ro \
-          #   -v /usr/bin/runc:/usr/bin/runc:ro \
-          #   -v /usr/lib/systemd:/usr/lib/systemd:ro \
-          #   -v /var/lib:/var/lib:ro \
-          #   -v /var/run/docker.sock:/var/run/docker.sock:ro \
-          #   --label docker_bench_security \
-          #   docker-bench-security > results/docker-bench-results.txt
-          docker run --net host --pid host --cap-add audit_control --cap-add sys_admin --cap-add syslog \
-             --security-opt apparmor=unconfined \
-             -v /var/run/docker.sock:/var/run/docker.sock \
-             -v /etc:/etc \
-             -v /usr/bin/docker:/usr/bin/docker \
-             --label docker-bench-security \
-             docker/docker-bench-security > docker-bench-report.txt
+          docker run --rm --net host --pid host --userns host --cap-add audit_control \
+            -e DOCKER_CONTENT_TRUST=0 \
+            -v /etc:/etc:ro \
+            -v /lib/systemd/system:/lib/systemd/system:ro \
+            -v /usr/bin/containerd:/usr/bin/containerd:ro \
+            -v /usr/bin/runc:/usr/bin/runc:ro \
+            -v /usr/lib/systemd:/usr/lib/systemd:ro \
+            -v /var/lib:/var/lib:ro \
+            -v /var/run/docker.sock:/var/run/docker.sock:ro \
+            --label docker_bench_security \
+            docker/docker-bench-security > docker-bench-report.txt
       - name: Upload Results
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/docker-bench-security.yml
+++ b/.github/workflows/docker-bench-security.yml
@@ -35,11 +35,10 @@ jobs:
             -v /var/lib:/var/lib:ro \
             -v /var/run/docker.sock:/var/run/docker.sock:ro \
             --label docker_bench_security \
-            docker/docker-bench-security -l results/docker-bench-security.log -o json
+            docker/docker-bench-security -l results/docker-bench-security.log
       - name: Upload Results
         uses: actions/upload-artifact@v3
         with:
           name: docker-bench-results
           path: |
             results/docker-bench-security.log
-            results/docker-bench-security.log.json

--- a/.github/workflows/docker-bench-security.yml
+++ b/.github/workflows/docker-bench-security.yml
@@ -26,75 +26,8 @@ jobs:
       run: |
         docker image prune -a -f
         docker system prune -a -f
-    - name: Build base image
-      run: |
-        docker build -t openfl -f openfl-docker/Dockerfile.base .
-    - name: Create workspace image
-      run: |
-        fx workspace create --prefix example_workspace --template keras_cnn_mnist
-        cd example_workspace
-        fx plan initialize -a localhost
-        fx workspace dockerize --base_image openfl
-    - name: Create certificate authority for workspace
-      run: |
-        cd example_workspace
-        fx workspace certify
-    - name: Create signed cert for collaborator
-      run: |
-        cd example_workspace
-        fx collaborator create -d 1 -n charlie --silent
-        fx collaborator generate-cert-request -n charlie --silent
-        fx collaborator certify --request-pkg col_charlie_to_agg_cert_request.zip --silent       
-        # Pack the collaborator's private key, signed cert, and data.yaml into a tarball
-        tarfiles="plan/data.yaml agg_to_col_charlie_signed_cert.zip"
-        for entry in cert/client/*; do
-            if [[ "$entry" == *.key ]]; then
-                tarfiles="$tarfiles $entry"
-            fi
-        done
-
-        tar -cf cert_col_charlie.tar $tarfiles
-
-        # Clean up
-        rm -f $tarfiles
-        rm -f col_charlie_to_agg_cert_request.zip
-
-    - name: Create signed cert for aggregator
-      run: |
-        cd example_workspace
-        fx aggregator generate-cert-request --fqdn localhost
-        fx aggregator certify --fqdn localhost --silent
-
-        # Pack all files that aggregator needs to start training
-        tar -cf cert_agg.tar plan cert save
-
-        # Remove the directories after archiving
-        rm -rf plan cert save
-
-    - name: Load workspace image
-      run: |
-        cd example_workspace
-        docker load -i example_workspace_image.tar
-
-    - name: Run aggregator and collaborator
-      run: |
-        cd example_workspace
-
-        set -x
-        docker run --rm \
-          --network host \
-          --mount type=bind,source=./cert_agg.tar,target=/certs.tar \
-          -e CONTAINER_TYPE=aggregator \
-          example_workspace /home/openfl/openfl-docker/start_actor_in_container.sh &
-        
-        # TODO: Run with two collaborators instead.
-        docker run --rm \
-          --network host \
-          --mount type=bind,source=./cert_col_charlie.tar,target=/certs.tar \
-          -e CONTAINER_TYPE=collaborator \
-          -e COL=charlie \
-          example_workspace /home/openfl/openfl-docker/start_actor_in_container.sh
-            
+    - name: Create results directory
+      run: mkdir -p results
     - name: Run Docker Bench for Security
       run: |
         docker run --rm --net host --pid host --userns host --cap-add audit_control \
@@ -108,50 +41,10 @@ jobs:
           -v /var/run/docker.sock:/var/run/docker.sock:ro \
           -v "$(pwd)/results:/results" \
           --label docker_bench_security \
-          docker/docker-bench-security
+          docker/docker-bench-security | tee results/security_bench_report.txt
 
-
-# name: Docker Bench for Security
-
-# on:
-#   pull_request:
-#     branches: [ develop ]
-
-# permissions:
-#   contents: read
-  
-# jobs:
-#   docker-bench-security:
-#     runs-on: ubuntu-latest
-
-#     steps:
-#       - name: Checkout code
-#         uses: actions/checkout@v3
-#       - name: Set up Python 3.8
-#         uses: actions/setup-python@v3
-#         with:
-#           python-version: "3.8"
-#       - name: Install dependencies
-#         run: |
-#           python -m pip install --upgrade pip
-#           pip install .
-#       - name: Run Docker Bench for Security
-#         run: |
-#           mkdir -p results
-#           docker run --rm --net host --pid host --userns host --cap-add audit_control \
-#             -e DOCKER_CONTENT_TRUST=0 \
-#             -v /etc:/etc:ro \
-#             -v /lib/systemd/system:/lib/systemd/system:ro \
-#             -v /usr/bin/containerd:/usr/bin/containerd:ro \
-#             -v /usr/bin/runc:/usr/bin/runc:ro \
-#             -v /usr/lib/systemd:/usr/lib/systemd:ro \
-#             -v /var/lib:/var/lib:ro \
-#             -v /var/run/docker.sock:/var/run/docker.sock:ro \
-#             -v "$(pwd)/results:/results" \
-#             --label docker_bench_security \
-#             docker/docker-bench-security
-#       - name: Upload Results
-#         uses: actions/upload-artifact@v3
-#         with:
-#           name: docker-bench-results
-#           path: logs/docker-bench-security.log
+    - name: Upload Security Bench Report
+      uses: actions/upload-artifact@v3
+      with:
+        name: security-bench-report
+        path: results/security_bench_report.txt

--- a/.github/workflows/docker-bench-security.yml
+++ b/.github/workflows/docker-bench-security.yml
@@ -93,36 +93,6 @@ jobs:
           -e CONTAINER_TYPE=collaborator \
           -e COL=charlie \
           example_workspace /home/openfl/openfl-docker/start_actor_in_container.sh
-    
-    - name: Wait for containers to initialize
-      run: |
-        sleep 10  # Initial sleep to give the containers some time to start
-        echo "Checking if aggregator and collaborator containers are running..."
-        # Check for the running containers in a loop
-        for i in {1..10}; do  # Retry up to 10 times
-          if docker ps | grep -q "aggregator"; then
-            echo "Aggregator container is running."
-            break
-          fi
-          if [ $i -eq 10 ]; then
-            echo "Aggregator container did not start in time!"
-            exit 1
-          fi
-          sleep 5  # Wait before checking again
-        done
-      
-        for i in {1..10}; do
-          if docker ps | grep -q "collaborator"; then
-            echo "Collaborator container is running."
-            break
-          fi
-          if [ $i -eq 10 ]; then
-            echo "Collaborator container did not start in time!"
-            exit 1
-          fi
-          sleep 5  # Wait before checking again
-        done
-      
             
     - name: Run Docker Bench for Security
       run: |

--- a/.github/workflows/docker-bench-security.yml
+++ b/.github/workflows/docker-bench-security.yml
@@ -25,12 +25,16 @@ jobs:
       - name: Run Docker Bench for Security
         run: |
           mkdir -p results
-          docker run --rm --privileged --pid host \
-            --volume /var/run/docker.sock:/var/run/docker.sock \
-            --volume /usr:/usr \
-            --volume /etc:/etc \
-            --volume /lib/modules:/lib/modules:ro \
-            docker/docker-bench-security > results/docker-bench-results.txt
+          docker run --rm --net host --pid host --userns host --cap-add audit_control \
+            -e DOCKER_CONTENT_TRUST=$DOCKER_CONTENT_TRUST \
+            -v /etc:/etc:ro \
+            -v /usr/bin/containerd:/usr/bin/containerd:ro \
+            -v /usr/bin/runc:/usr/bin/runc:ro \
+            -v /usr/lib/systemd:/usr/lib/systemd:ro \
+            -v /var/lib:/var/lib:ro \
+            -v /var/run/docker.sock:/var/run/docker.sock:ro \
+            --label docker_bench_security \
+            docker-bench-security > results/docker-bench-results.txt
       - name: Upload Results
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/docker-bench-security.yml
+++ b/.github/workflows/docker-bench-security.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Run Docker Bench for Security
         run: |
           mkdir -p results
-          docker run --rm --net host --pid host --userns host --cap-add audit_control \
+          docker run --net host --pid host --cap-add audit_control --cap-add sys_admin --cap-add syslog \
             -e DOCKER_CONTENT_TRUST=$DOCKER_CONTENT_TRUST \
             -v /etc:/etc:ro \
             -v /lib/systemd/system:/lib/systemd/system:ro \

--- a/.github/workflows/docker-bench-security.yml
+++ b/.github/workflows/docker-bench-security.yml
@@ -34,7 +34,7 @@ jobs:
             -v /usr/lib/systemd:/usr/lib/systemd:ro \
             -v /var/lib:/var/lib:ro \
             -v /var/run/docker.sock:/var/run/docker.sock:ro \
-             -v $(pwd)/results:/results \
+            -v "$(pwd)/results:/results" \
             --label docker_bench_security \
             docker/docker-bench-security -l results/docker-bench-security.log
       - name: Upload Results

--- a/.github/workflows/docker-bench-security.yml
+++ b/.github/workflows/docker-bench-security.yml
@@ -34,6 +34,7 @@ jobs:
             -v /usr/lib/systemd:/usr/lib/systemd:ro \
             -v /var/lib:/var/lib:ro \
             -v /var/run/docker.sock:/var/run/docker.sock:ro \
+             -v $(pwd)/results:/results \
             --label docker_bench_security \
             docker/docker-bench-security -l results/docker-bench-security.log
       - name: Upload Results

--- a/.github/workflows/docker-bench-security.yml
+++ b/.github/workflows/docker-bench-security.yml
@@ -24,8 +24,8 @@ jobs:
         pip install .
     - name: Clean Docker System
       run: |
-        docker image prune -a
-        docker system prune -a
+        docker image prune -a -f
+        docker system prune -a -f
     - name: Build base image
       run: |
         docker build -t openfl -f openfl-docker/Dockerfile.base .

--- a/.github/workflows/docker-bench-security.yml
+++ b/.github/workflows/docker-bench-security.yml
@@ -94,6 +94,36 @@ jobs:
           -e COL=charlie \
           example_workspace /home/openfl/openfl-docker/start_actor_in_container.sh
     
+    - name: Wait for containers to initialize
+      run: |
+        sleep 10  # Initial sleep to give the containers some time to start
+        echo "Checking if aggregator and collaborator containers are running..."
+        # Check for the running containers in a loop
+        for i in {1..10}; do  # Retry up to 10 times
+          if docker ps | grep -q "aggregator"; then
+            echo "Aggregator container is running."
+            break
+          fi
+          if [ $i -eq 10 ]; then
+            echo "Aggregator container did not start in time!"
+            exit 1
+          fi
+          sleep 5  # Wait before checking again
+        done
+      
+        for i in {1..10}; do
+          if docker ps | grep -q "collaborator"; then
+            echo "Collaborator container is running."
+            break
+          fi
+          if [ $i -eq 10 ]; then
+            echo "Collaborator container did not start in time!"
+            exit 1
+          fi
+          sleep 5  # Wait before checking again
+        done
+      
+            
     - name: Run Docker Bench for Security
       run: |
         docker run --rm --net host --pid host --userns host --cap-add audit_control \

--- a/.github/workflows/docker-bench-security.yml
+++ b/.github/workflows/docker-bench-security.yml
@@ -24,7 +24,8 @@ jobs:
         pip install .
     - name: Clean Docker System
       run: |
-        docker system prune -f
+        docker image prune -a
+        docker system prune -a
     - name: Build base image
       run: |
         docker build -t openfl -f openfl-docker/Dockerfile.base .

--- a/.github/workflows/docker-bench-security.yml
+++ b/.github/workflows/docker-bench-security.yml
@@ -1,0 +1,38 @@
+name: Docker Bench for Security
+
+on:
+  pull_request:
+    branches: [ develop ]
+
+permissions:
+  contents: read
+  
+jobs:
+  docker-bench-security:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.8"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+      - name: Run Docker Bench for Security
+        run: |
+          mkdir -p results
+          docker run --rm --privileged --pid host \
+            --volume /var/run/docker.sock:/var/run/docker.sock \
+            --volume /usr:/usr \
+            --volume /etc:/etc \
+            --volume /lib/modules:/lib/modules:ro \
+            docker/docker-bench-security > results/docker-bench-results.txt
+      - name: Upload Results
+        uses: actions/upload-artifact@v3
+        with:
+          name: docker-bench-results
+          path: results/docker-bench-results.txt

--- a/.github/workflows/docker-bench-security.yml
+++ b/.github/workflows/docker-bench-security.yml
@@ -35,7 +35,7 @@ jobs:
             -v /var/lib:/var/lib:ro \
             -v /var/run/docker.sock:/var/run/docker.sock:ro \
             --label docker_bench_security \
-            docker/docker-bench-security > docker-bench-report.txt
+            docker/docker-bench-security > results/docker-bench-report.txt
       - name: Upload Results
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/docker-bench-security.yml
+++ b/.github/workflows/docker-bench-security.yml
@@ -36,10 +36,9 @@ jobs:
             -v /var/run/docker.sock:/var/run/docker.sock:ro \
             -v "$(pwd)/results:/results" \
             --label docker_bench_security \
-            docker/docker-bench-security -l results/docker-bench-security.log
+            docker/docker-bench-security
       - name: Upload Results
         uses: actions/upload-artifact@v3
         with:
           name: docker-bench-results
-          path: |
-            results/docker-bench-security.log
+          path: logs/docker-bench-security.log

--- a/.github/workflows/docker-bench-security.yml
+++ b/.github/workflows/docker-bench-security.yml
@@ -28,6 +28,7 @@ jobs:
           docker run --rm --net host --pid host --userns host --cap-add audit_control \
             -e DOCKER_CONTENT_TRUST=$DOCKER_CONTENT_TRUST \
             -v /etc:/etc:ro \
+            -v /lib/systemd/system:/lib/systemd/system:ro \
             -v /usr/bin/containerd:/usr/bin/containerd:ro \
             -v /usr/bin/runc:/usr/bin/runc:ro \
             -v /usr/lib/systemd:/usr/lib/systemd:ro \

--- a/.github/workflows/docker-bench-security.yml
+++ b/.github/workflows/docker-bench-security.yml
@@ -25,17 +25,24 @@ jobs:
       - name: Run Docker Bench for Security
         run: |
           mkdir -p results
+          # docker run --net host --pid host --cap-add audit_control --cap-add sys_admin --cap-add syslog \
+          #   -e DOCKER_CONTENT_TRUST=$DOCKER_CONTENT_TRUST \
+          #   -v /etc:/etc:ro \
+          #   -v /lib/systemd/system:/lib/systemd/system:ro \
+          #   -v /usr/bin/containerd:/usr/bin/containerd:ro \
+          #   -v /usr/bin/runc:/usr/bin/runc:ro \
+          #   -v /usr/lib/systemd:/usr/lib/systemd:ro \
+          #   -v /var/lib:/var/lib:ro \
+          #   -v /var/run/docker.sock:/var/run/docker.sock:ro \
+          #   --label docker_bench_security \
+          #   docker-bench-security > results/docker-bench-results.txt
           docker run --net host --pid host --cap-add audit_control --cap-add sys_admin --cap-add syslog \
-            -e DOCKER_CONTENT_TRUST=$DOCKER_CONTENT_TRUST \
-            -v /etc:/etc:ro \
-            -v /lib/systemd/system:/lib/systemd/system:ro \
-            -v /usr/bin/containerd:/usr/bin/containerd:ro \
-            -v /usr/bin/runc:/usr/bin/runc:ro \
-            -v /usr/lib/systemd:/usr/lib/systemd:ro \
-            -v /var/lib:/var/lib:ro \
-            -v /var/run/docker.sock:/var/run/docker.sock:ro \
-            --label docker_bench_security \
-            docker-bench-security > results/docker-bench-results.txt
+             --security-opt apparmor=unconfined \
+             -v /var/run/docker.sock:/var/run/docker.sock \
+             -v /etc:/etc \
+             -v /usr/bin/docker:/usr/bin/docker \
+             --label docker-bench-security \
+             docker/docker-bench-security > docker-bench-report.txt
       - name: Upload Results
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Adding Docker Bench for Security is a crucial tool for assessing the security of Docker containers and their configurations.

**Key Reasons for adding Docker Bench for Security:**

1. Security Compliance
2. Vulnerability Identification
3. Risk Assessment
4. Best Practices Implementation
5. Automated Security Checks
