### PR TITLE
Logging fix - No of rounds saved vs started

### DIFF
--- a/.github/workflows/pytest_coverage.yml
+++ b/.github/workflows/pytest_coverage.yml
@@ -1,4 +1,4 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# This workflow will run code coverage
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: Pytest and code coverage 
@@ -6,6 +6,7 @@ name: Pytest and code coverage
 on:
   pull_request:
     branches: [ develop ]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/openfl/component/aggregator/aggregator.py
+++ b/openfl/component/aggregator/aggregator.py
@@ -968,15 +968,16 @@ class Aggregator:
 
         # Once all of the task results have been processed
         self._end_of_round_check_done[self.round_number] = True
+
+        # Save the latest model
+        self.logger.info("Saving round %s model...", self.round_number)
+        self._save_model(self.round_number, self.last_state_path)
+
         self.round_number += 1
         # resetting stragglers for task for a new round
         self.stragglers = []
         # resetting collaborators_done for next round
         self.collaborators_done = []
-
-        # Save the latest model
-        self.logger.info("Saving round %s model...", self.round_number)
-        self._save_model(self.round_number, self.last_state_path)
 
         # TODO This needs to be fixed!
         if self._time_to_quit():


### PR DESCRIPTION
In addition, enabling manual trigger of pytest coverage workflow.

**Before** - Round number `r+1` is shown as "Saved" and "Started" both.
<img width="475" alt="round_no_issue" src="https://github.com/user-attachments/assets/00491520-6347-478b-9b87-fc4149a19135">

**After** - Existing round number `r` is "Saved" and `r+1` is "Started", which is expected.
<img width="475" alt="round_no_fixed" src="https://github.com/user-attachments/assets/d72d5665-cd74-4f3b-8201-02c3bfa00a09">
