### PR TITLE
Fix path manipulation coverity vulnerability issue

### DIFF
--- a/openfl/interface/cli.py
+++ b/openfl/interface/cli.py
@@ -4,6 +4,7 @@
 """CLI module."""
 import logging
 import os
+import re
 import sys
 import time
 import warnings
@@ -181,6 +182,9 @@ def cli(context, log_level, no_warnings):
         # This will be overridden later with user selected debugging level
         disable_warnings()
     log_file = os.getenv("LOG_FILE")
+    # Validate log_file using allow list approach
+    if log_file and not re.match(r'^[\w\-.]+$', log_file):
+        raise ValueError("Invalid log file path")
     setup_logging(log_level, log_file)
     sys.stdout.reconfigure(encoding="utf-8")
 

--- a/openfl/interface/cli.py
+++ b/openfl/interface/cli.py
@@ -183,7 +183,7 @@ def cli(context, log_level, no_warnings):
         disable_warnings()
     log_file = os.getenv("LOG_FILE")
     # Validate log_file using allow list approach
-    if log_file and not re.match(r'^[\w\-.]+$', log_file):
+    if log_file and not re.match(r"^[\w\-.]+$", log_file):
         raise ValueError("Invalid log file path")
     setup_logging(log_level, log_file)
     sys.stdout.reconfigure(encoding="utf-8")

--- a/openfl/utilities/optimizers/numpy/yogi_optimizer.py
+++ b/openfl/utilities/optimizers/numpy/yogi_optimizer.py
@@ -79,7 +79,8 @@ class NumPyYogi(NumPyAdam):
         """
         sign = np.sign(grad**2 - self.grads_second_moment[grad_name])
         self.grads_second_moment[grad_name] = (
-            self.beta_2 * self.grads_second_moment[grad_name] + (1.0 - self.beta_2) * sign * grad**2
+            self.beta_2 * self.grads_second_moment[grad_name]
+            + (1.0 - self.beta_2) * sign * grad**2
         )
 
     def step(self, gradients: Dict[str, np.ndarray]) -> None:

--- a/openfl/utilities/optimizers/numpy/yogi_optimizer.py
+++ b/openfl/utilities/optimizers/numpy/yogi_optimizer.py
@@ -79,8 +79,7 @@ class NumPyYogi(NumPyAdam):
         """
         sign = np.sign(grad**2 - self.grads_second_moment[grad_name])
         self.grads_second_moment[grad_name] = (
-            self.beta_2 * self.grads_second_moment[grad_name]
-            + (1.0 - self.beta_2) * sign * grad**2
+            self.beta_2 * self.grads_second_moment[grad_name] + (1.0 - self.beta_2) * sign * grad**2
         )
 
     def step(self, gradients: Dict[str, np.ndarray]) -> None:


### PR DESCRIPTION
Fixing error: 656290 [Filesystem path, filename, or URI manipulation](https://coverity.devtools.intel.com/prod4/doc/en/cov_checker_ref.html#static_checker_PATH_MANIPULATION)

Coverity error

![Screenshot 2024-10-24 at 11 01 46 AM](https://github.com/user-attachments/assets/7cc848e9-7fb0-4b0c-8c0b-071167f1e1a4)

 The log_file is validated using a regular expression that only allows word characters, hyphens, and dots. This prevents directory traversal and other unsafe characters.
