### PR TITLE
fix coverity hash issue in metaflow_utils file

### DIFF
--- a/openfl/experimental/utilities/metaflow_utils.py
+++ b/openfl/experimental/utilities/metaflow_utils.py
@@ -345,6 +345,7 @@ class TaskDataStore(TaskDataStore):
 
         def pickle_iter():
             for name, obj in artifacts_iter:
+                #removed extra variable
                 do_v4 = force_v4 if isinstance(force_v4, bool) else force_v4.get(name, False)
                 if do_v4:
                     encode_type = "gzip+pickle-v4"

--- a/openfl/experimental/utilities/metaflow_utils.py
+++ b/openfl/experimental/utilities/metaflow_utils.py
@@ -345,7 +345,6 @@ class TaskDataStore(TaskDataStore):
 
         def pickle_iter():
             for name, obj in artifacts_iter:
-                #removed extra variable
                 do_v4 = force_v4 if isinstance(force_v4, bool) else force_v4.get(name, False)
                 if do_v4:
                     encode_type = "gzip+pickle-v4"

--- a/openfl/experimental/utilities/metaflow_utils.py
+++ b/openfl/experimental/utilities/metaflow_utils.py
@@ -66,9 +66,9 @@ class SystemMutex:
 
     def __enter__(self):
         lock_id = hashlib.new(
-            "md5", self.name.encode("utf8"), usedforsecurity=False
+            "sha256", self.name.encode("utf8"), usedforsecurity=False
         ).hexdigest()  # nosec
-        # MD5sum used for concurrency purposes, not security
+        # Using SHA-256 to address security warning
         self.fp = open(f"/tmp/.lock-{lock_id}.lck", "wb")
         fcntl.flock(self.fp.fileno(), fcntl.LOCK_EX)
 
@@ -345,11 +345,7 @@ class TaskDataStore(TaskDataStore):
 
         def pickle_iter():
             for name, obj in artifacts_iter:
-                do_v4 = (
-                    force_v4 and force_v4
-                    if isinstance(force_v4, bool)
-                    else force_v4.get(name, False)
-                )
+                do_v4 = force_v4 if isinstance(force_v4, bool) else force_v4.get(name, False)
                 if do_v4:
                     encode_type = "gzip+pickle-v4"
                     if encode_type not in self._encodings:


### PR DESCRIPTION
Fixing errors: 
1. 656300 [Risky cryptographic hashing function](https://coverity.devtools.intel.com/prod4/doc/en/cov_checker_ref.html#static_checker_RISKY_CRYPTO) 
2. 656287 [Same on both sides](https://coverity.devtools.intel.com/prod4/doc/en/cov_checker_ref.html#static_checker_CONSTANT_EXPRESSION_RESULT)


Coverity Error
![Screenshot 2024-10-25 at 11 20 48 AM](https://github.com/user-attachments/assets/e98f1d6e-7f1e-46bf-9e72-cd5701fd35ea)

![Screenshot 2024-10-25 at 11 21 23 AM](https://github.com/user-attachments/assets/b1013bd4-ee41-4e3d-9e64-a686515cb8a2)


Changed from md5 to sha256 hashing and removed repetitive variable 