### PR TITLE
Rename scan.yml to hadolint.yml

### DIFF
--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Security Scans
+name: Hadolint Security Scan
 
 on:
   pull_request:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -64,7 +64,14 @@ jobs:
 
       - name: Run Trivy code vulnerability scanner (SPDX-JSON Output)
         run: |
-          trivy --quiet fs --format spdx-json --output trivy-code-spdx-results.json --ignore-unfixed --vuln-type os,library --severity CRITICAL,HIGH,MEDIUM,LOW .
+          trivy --quiet fs \
+          --format spdx-json \
+          --output trivy-code-spdx-results.json \
+          --ignore-unfixed \
+          --vuln-type os,library \
+          --severity CRITICAL,HIGH,MEDIUM,LOW \
+          --db-repository ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db \
+          .
   
       - name: Upload Code Vulnerability Scan Results
         uses: actions/upload-artifact@v3

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -33,11 +33,18 @@ jobs:
 
       - name: Install Trivy
         run: |
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.55.0
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin
   
       - name: Run Trivy code vulnerability scanner (JSON Output)
         run: |
-          trivy --quiet fs --format json --output trivy-code-results.json --ignore-unfixed --vuln-type os,library --severity CRITICAL,HIGH,MEDIUM,LOW .
+          trivy --quiet fs \
+          --format json \
+          --output trivy-code-results.json \
+          --ignore-unfixed \
+          --vuln-type os,library \
+          --severity CRITICAL,HIGH,MEDIUM,LOW \
+          --db-repository 'ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db' \
+          .
 
       - name: Upload Code Vulnerability Scan Results
         uses: actions/upload-artifact@v3
@@ -70,7 +77,7 @@ jobs:
           --ignore-unfixed \
           --vuln-type os,library \
           --severity CRITICAL,HIGH,MEDIUM,LOW \
-          --db-repository ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db \
+          --db-repository 'ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db' \
           .
   
       - name: Upload Code Vulnerability Scan Results


### PR DESCRIPTION
1. This workflow is only running hadolint so changing the name
2. Fix trivy db issue ;
    2024-10-30T22:42:00Z	FATAL	Fatal error	init error: DB error: failed to download vulnerability DB: database download error: oci download error: failed to fetch the layer: GET https://ghcr.io/v2/aquasecurity/trivy-db/blobs/sha256:31d6cee5dd31c64acd18eb95f837c6b4870d06cece1725e3f1c02c250413ee3f: TOOMANYREQUESTS: retry-after: 645.846µs, allowed: 44000/minute