### PR TITLE
Change MD5 hashing to SHA256 for Interactive API examples

### DIFF
--- a/openfl-tutorials/interactive_api/MXNet_landmarks/envoy/landmark_shard_descriptor.py
+++ b/openfl-tutorials/interactive_api/MXNet_landmarks/envoy/landmark_shard_descriptor.py
@@ -5,7 +5,7 @@
 
 import json
 import shutil
-from hashlib import md5
+from hashlib import sha256
 from logging import getLogger
 from pathlib import Path
 from random import shuffle
@@ -114,7 +114,7 @@ class LandmarkShardDescriptor(ShardDescriptor):
 
         self.process_data('training.csv')
         (self.data_folder / 'training.csv').unlink()
-        self.save_all_md5()
+        self.save_all_sha256()
 
     def get_dataset(self, dataset_type='train') -> LandmarkShardDataset:
         """Return a shard dataset by type."""
@@ -124,33 +124,33 @@ class LandmarkShardDescriptor(ShardDescriptor):
             worldsize=self.worldsize
         )
 
-    def calc_all_md5(self) -> Dict[str, str]:
+    def calc_all_sha256(self) -> Dict[str, str]:
         """Calculate hash of all dataset."""
-        md5_dict = {}
+        sha256_dict = {}
         for root in self.data_folder.glob('*.npy'):
-            md5_calc = md5(usedforsecurity=False)
+            sha256_calc = sha256(usedforsecurity=False)
             rel_file = root.relative_to(self.data_folder)
 
             with open(self.data_folder / rel_file, 'rb') as f:
                 for chunk in iter(lambda: f.read(4096), b''):
-                    md5_calc.update(chunk)
-                md5_dict[str(rel_file)] = md5_calc.hexdigest()
-        return md5_dict
+                    sha256_calc.update(chunk)
+                sha256_dict[str(rel_file)] = sha256_calc.hexdigest()
+        return sha256_dict
 
-    def save_all_md5(self) -> None:
+    def save_all_sha256(self) -> None:
         """Save dataset hash."""
-        all_md5 = self.calc_all_md5()
+        all_sha256 = self.calc_all_sha256()
         with open(self.data_folder / 'dataset.json', 'w', encoding='utf-8') as f:
-            json.dump(all_md5, f)
+            json.dump(all_sha256, f)
 
     def is_dataset_complete(self) -> bool:
         """Check dataset integrity."""
-        dataset_md5_path = self.data_folder / 'dataset.json'
-        if dataset_md5_path.exists():
-            with open(dataset_md5_path, 'r', encoding='utf-8') as f:
-                old_md5 = json.load(f)
-            new_md5 = self.calc_all_md5()
-            return new_md5 == old_md5
+        dataset_sha256_path = self.data_folder / 'dataset.json'
+        if dataset_sha256_path.exists():
+            with open(dataset_sha256_path, 'r', encoding='utf-8') as f:
+                old_sha256 = json.load(f)
+            new_sha256 = self.calc_all_sha256()
+            return new_sha256 == old_sha256
         return False
 
     @property

--- a/openfl-tutorials/interactive_api/PyTorch_DogsCats_ViT/envoy/dogs_cats_shard_descriptor.py
+++ b/openfl-tutorials/interactive_api/PyTorch_DogsCats_ViT/envoy/dogs_cats_shard_descriptor.py
@@ -6,7 +6,7 @@
 import json
 import os
 import shutil
-from hashlib import md5
+from hashlib import sha256
 from logging import getLogger
 from pathlib import Path
 from random import shuffle
@@ -120,7 +120,7 @@ class DogsCatsShardDescriptor(ShardDescriptor):
 
             os.remove(self.data_folder / 'train.zip')
 
-            self.save_all_md5()
+            self.save_all_sha256()
 
     def get_dataset(self, dataset_type='train'):
         """Return a shard dataset by type."""
@@ -132,39 +132,39 @@ class DogsCatsShardDescriptor(ShardDescriptor):
             enforce_image_hw=self.enforce_image_hw
         )
 
-    def calc_all_md5(self):
+    def calc_all_sha256(self):
         """Calculate hash of all dataset."""
-        md5_dict = {}
+        sha256_dict = {}
         for root, _, files in os.walk(self.data_folder):
             for file in files:
                 if file == 'dataset.json':
                     continue
-                md5_calc = md5(usedforsecurity=False)
+                sha256_calc = sha256(usedforsecurity=False)
                 rel_dir = os.path.relpath(root, self.data_folder)
                 rel_file = os.path.join(rel_dir, file)
 
                 with open(self.data_folder / rel_file, 'rb') as f:
                     for chunk in iter(lambda: f.read(4096), b''):
-                        md5_calc.update(chunk)
-                    md5_dict[rel_file] = md5_calc.hexdigest()
-        return md5_dict
+                        sha256_calc.update(chunk)
+                    sha256_dict[rel_file] = sha256_calc.hexdigest()
+        return sha256_dict
 
-    def save_all_md5(self):
+    def save_all_sha256(self):
         """Save dataset hash."""
-        all_md5 = self.calc_all_md5()
+        all_sha256 = self.calc_all_sha256()
         with open(os.path.join(self.data_folder, 'dataset.json'), 'w', encoding='utf-8') as f:
-            json.dump(all_md5, f)
+            json.dump(all_sha256, f)
 
     def is_dataset_complete(self):
         """Check dataset integrity."""
-        new_md5 = self.calc_all_md5()
+        new_sha256 = self.calc_all_sha256()
         try:
             with open(os.path.join(self.data_folder, 'dataset.json'), 'r', encoding='utf-8') as f:
-                old_md5 = json.load(f)
+                old_sha256 = json.load(f)
         except FileNotFoundError:
             return False
 
-        return new_md5 == old_md5
+        return new_sha256 == old_sha256
 
     @property
     def sample_shape(self):


### PR DESCRIPTION
## Context
- MD5 hashing may allow an attacker to produce collisions on the hash or execute length extension attacks. ([CWE-328](http://cwe.mitre.org/data/definitions/328.html))
- SHA-2 family hash functions are strong, well-vetted cryptographic hash functions that are currently not known to suffer these weaknesses.
- This PR fixes a weakness identified by Coverity. 

## Affected examples
Changed [hashlib.md5](https://docs.python.org/3/library/hashlib.html#hashlib.md5) to [hashlib.sha256](https://docs.python.org/3/library/hashlib.html#hashlib.sha256).
- [MXNet Facial Keypoints Detection tutorial](https://github.com/securefederatedai/openfl/tree/develop/openfl-tutorials/interactive_api/MXNet_landmarks)
- [Dogs vs. Cats tutorial based on vit_pytorch library](https://github.com/securefederatedai/openfl/tree/develop/openfl-tutorials/interactive_api/PyTorch_DogsCats_ViT)