### PR TITLE
 Validating Log File Path for cli function

### DIFF
--- a/openfl/interface/cli.py
+++ b/openfl/interface/cli.py
@@ -185,7 +185,11 @@ def cli(context, log_level, no_warnings):
     # Validate log_file with tighter restrictions
     if log_file:
         log_file = os.path.normpath(log_file)
-        if not re.match(r"^logs/[\w\-.]+$", log_file) or ".." in log_file or log_file.startswith("/"):
+        if (
+            not re.match(r"^logs/[\w\-.]+$", log_file)
+            or ".." in log_file
+            or log_file.startswith("/")
+        ):
             raise ValueError("Invalid log file path")
         # Ensure the log file is in the 'logs' directory
         allowed_directory = Path("logs").resolve()

--- a/openfl/interface/cli.py
+++ b/openfl/interface/cli.py
@@ -187,7 +187,7 @@ def cli(context, log_level, no_warnings):
         log_file = os.path.normpath(log_file)
         if not re.match(r"^logs/[\w\-.]+$", log_file) or ".." in log_file or log_file.startswith("/"):
             raise ValueError("Invalid log file path")
-        
+
         # Ensure the log file is in the 'logs' directory
         allowed_directory = Path("logs").resolve()
         full_path = (allowed_directory / log_file).resolve()

--- a/openfl/interface/cli.py
+++ b/openfl/interface/cli.py
@@ -182,9 +182,17 @@ def cli(context, log_level, no_warnings):
         # This will be overridden later with user selected debugging level
         disable_warnings()
     log_file = os.getenv("LOG_FILE")
-    # Validate log_file using allow list approach
-    if log_file and not re.match(r"^[\w\-.]+$", log_file):
-        raise ValueError("Invalid log file path")
+    # Validate log_file with tighter restrictions
+    if log_file:
+        log_file = os.path.normpath(log_file)
+        if not re.match(r"^logs/[\w\-.]+$", log_file) or ".." in log_file or log_file.startswith("/"):
+            raise ValueError("Invalid log file path")
+        
+        # Ensure the log file is in the 'logs' directory
+        allowed_directory = Path("logs").resolve()
+        full_path = (allowed_directory / log_file).resolve()
+        if not str(full_path).startswith(str(allowed_directory)):
+            raise ValueError("Log file path is not allowed")
     setup_logging(log_level, log_file)
     sys.stdout.reconfigure(encoding="utf-8")
 


### PR DESCRIPTION
Fixing 656290 [Filesystem path, filename, or URI manipulation](https://coverity.devtools.intel.com/prod4/doc/en/cov_checker_ref.html#static_checker_PATH_MANIPULATION)

![Screenshot 2024-11-04 at 2 01 35 PM](https://github.com/user-attachments/assets/47478cba-def2-4459-997b-f7f1362e80bd)



**Changes**:

- **Path Normalization**: Added os.path.normpath(log_file) to normalize the log file path.
- **Regular Expression Validation**: Updated the regular expression to ensure the log file is within the logs directory and contains only allowed characters.
- **Additional Security Checks**:
     1. Ensured the log file path does not contain .. or start with /.
     2. Used pathlib to handle paths more securely.
     3. Verified that the resolved log file path is within the allowed directory.
