### PR TITLE
Fix for tensor shape error in Federated_Pytorch_MNIST_Tutorial.ipynb

### DIFF
--- a/openfl-tutorials/Federated_Pytorch_MNIST_Tutorial.ipynb
+++ b/openfl-tutorials/Federated_Pytorch_MNIST_Tutorial.ipynb
@@ -65,9 +65,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def one_hot(labels, classes):\n",
-    "    return np.eye(classes)[labels]\n",
-    "\n",
     "transform = transforms.Compose(\n",
     "    [transforms.ToTensor(),\n",
     "     transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])\n",
@@ -75,15 +72,14 @@
     "trainset = torchvision.datasets.MNIST(root='./data', train=True,\n",
     "                                        download=True, transform=transform)\n",
     "\n",
-    "train_images,train_labels = trainset.train_data, np.array(trainset.train_labels)\n",
+    "train_images,train_labels = trainset.data, np.array(trainset.targets)\n",
     "train_images = torch.from_numpy(np.expand_dims(train_images, axis=1)).float()\n",
     "\n",
     "validset = torchvision.datasets.MNIST(root='./data', train=False,\n",
     "                                       download=True, transform=transform)\n",
     "\n",
-    "valid_images,valid_labels = validset.test_data, np.array(validset.test_labels)\n",
-    "valid_images = torch.from_numpy(np.expand_dims(valid_images, axis=1)).float()\n",
-    "valid_labels = one_hot(valid_labels,10)"
+    "valid_images,valid_labels = validset.data, np.array(validset.targets)\n",
+    "valid_images = torch.from_numpy(np.expand_dims(valid_images, axis=1)).float()"
    ]
   },
   {


### PR DESCRIPTION
Fixing error: "RuntimeError: The size of tensor a (32) must match the size of tensor b (10) at non-singleton dimension 1" in openfl-tutorials/Federated_Pytorch_MNIST_Tutorial.ipynb by changing the shape of validation label data.


Before:
<img width="1676" alt="Screenshot 2024-10-22 at 3 05 42 PM" src="https://github.com/user-attachments/assets/8cfc9e33-eeff-49f3-a2f1-491d9bba7749">


After:
<img width="1693" alt="Screenshot 2024-10-22 at 2 36 13 PM" src="https://github.com/user-attachments/assets/71ad4678-28a6-4885-a850-c72583d18713">

<img width="1139" alt="Screenshot 2024-10-22 at 3 21 57 PM" src="https://github.com/user-attachments/assets/0b242bc1-f0ff-4d6a-a05b-45c15b5a46ba">
