### PR TITLE
Set FQDN as env variable for pytest coverage

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -26,6 +26,9 @@ jobs:
   pytest-coverage: # from pytest_coverage.yml
     needs: lint
     runs-on: ubuntu-latest
+    env:
+      # A workaround for long FQDN names provided by GitHub actions.
+      FQDN: "localhost"
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.8

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+env:
+  # A workaround for long FQDN names provided by GitHub actions.
+  FQDN: "localhost"
+
 jobs:
   lint: # from lint.yml
     runs-on: ubuntu-latest
@@ -26,9 +30,6 @@ jobs:
   pytest-coverage: # from pytest_coverage.yml
     needs: lint
     runs-on: ubuntu-latest
-    env:
-      # A workaround for long FQDN names provided by GitHub actions.
-      FQDN: "localhost"
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.8

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,12 +7,13 @@ on:
 permissions:
   contents: read
 
+env:
+  # A workaround for long FQDN names provided by GitHub actions.
+  FQDN: "localhost"
+
 jobs:
   pytest-coverage: # from pytest_coverage.yml
     runs-on: windows-latest
-    env:
-      # A workaround for long FQDN names provided by GitHub actions.
-      FQDN: "localhost"
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.8

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,6 +10,9 @@ permissions:
 jobs:
   pytest-coverage: # from pytest_coverage.yml
     runs-on: windows-latest
+    env:
+      # A workaround for long FQDN names provided by GitHub actions.
+      FQDN: "localhost"
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.8


### PR DESCRIPTION
**Problem**  - Pytest coverage is failing as part of Ubuntu and Windows nightly jobs. https://github.com/securefederatedai/openfl/actions/runs/11788591035/attempts/1

**Reason** - FQDN is missing in the environment section of above workflow yaml files.

After adding FQDN as localhost, it is working fine - https://github.com/payalcha/openfl/actions/runs/11792791416
