### PR TITLE
[FeTS][GaNDLF] skip loading `train.csv` during inference mode

### DIFF
--- a/openfl/federated/data/loader_gandlf.py
+++ b/openfl/federated/data/loader_gandlf.py
@@ -25,7 +25,10 @@ class GaNDLFDataLoaderWrapper(DataLoader):
             data_path (str): The path to the directory containing the data.
             feature_shape (tuple): The shape of an example feature array.
         """
-        self.train_csv = data_path + "/train.csv"
+        if 'inference' in data_path:
+            self.train_csv = None
+        else:
+            self.train_csv = data_path + "/train.csv"
         self.val_csv = data_path + "/valid.csv"
         self.train_dataloader = None
         self.val_dataloader = None

--- a/openfl/federated/data/loader_gandlf.py
+++ b/openfl/federated/data/loader_gandlf.py
@@ -25,7 +25,7 @@ class GaNDLFDataLoaderWrapper(DataLoader):
             data_path (str): The path to the directory containing the data.
             feature_shape (tuple): The shape of an example feature array.
         """
-        if 'inference' in data_path:
+        if "inference" in data_path:
             self.train_csv = None
         else:
             self.train_csv = data_path + "/train.csv"

--- a/openfl/federated/task/runner_gandlf.py
+++ b/openfl/federated/task/runner_gandlf.py
@@ -66,10 +66,7 @@ class GaNDLFTaskRunner(TaskRunner):
 
         # allow pass-through of a gandlf config as a file or a dict
 
-        if 'inference' in self.data_loader.train_csv:
-            train_csv = None
-        else:
-            train_csv = self.data_loader.train_csv
+        train_csv = self.data_loader.train_csv
         val_csv = self.data_loader.val_csv
 
         if isinstance(gandlf_config, str) and os.path.exists(gandlf_config):

--- a/openfl/federated/task/runner_gandlf.py
+++ b/openfl/federated/task/runner_gandlf.py
@@ -66,7 +66,10 @@ class GaNDLFTaskRunner(TaskRunner):
 
         # allow pass-through of a gandlf config as a file or a dict
 
-        train_csv = self.data_loader.train_csv
+        if 'inference' in self.data_loader.train_csv:
+            train_csv = None
+        else:
+            train_csv = self.data_loader.train_csv
         val_csv = self.data_loader.val_csv
 
         if isinstance(gandlf_config, str) and os.path.exists(gandlf_config):


### PR DESCRIPTION
This PR is in support of updating [FeTS AI Challenge code base](https://github.com/FeTS-AI/Challenge/pull/201).

Specifically, this PR introduces a conditional check to handle inference mode in the data loader by adjusting the assignment of `self.train_csv`. If `data_path` contains a reference to `inference`, then `self.train_csv` will not be assigned a path. Otherwise, `self.train_csv` will load in `train.csv` from the specified `data_path`

This is important since training data is not present during inference/testing, so there needed to be a way to bypass this assignment