### PR TITLE
Version cap `grpcio<1.66.0`

### DIFF
--- a/.github/workflows/task_runner_e2e.yml
+++ b/.github/workflows/task_runner_e2e.yml
@@ -6,8 +6,8 @@
 name: Task Runner E2E
 
 on:
-  schedule:
-    - cron: "0 0 * * *" # Run every day at midnight
+  pull_request:
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
     inputs:
       num_rounds:

--- a/.github/workflows/task_runner_e2e.yml
+++ b/.github/workflows/task_runner_e2e.yml
@@ -6,8 +6,8 @@
 name: Task Runner E2E
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  schedule:
+    - cron: "0 0 * * *" # Run every day at midnight
   workflow_dispatch:
     inputs:
       num_rounds:

--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,7 @@ setup(
         'docker',
         'dynaconf==3.2.6',
         'flatten_json',
-        'grpcio>=1.56.2',
+        'grpcio>=1.56.2,<1.66.0',
         'ipykernel',
         'jupyterlab',
         'numpy',


### PR DESCRIPTION
May fix #1163.

Previous failures were random, albeit coincident with a new grpc release (1.68) happening around the same time failures started to appear. This is a useful change regardless.