### PR TITLE
Bake in default for federate evaluation and leverage the same in sample workspace

### DIFF
--- a/docs/about/features_index/fed_eval.rst
+++ b/docs/about/features_index/fed_eval.rst
@@ -32,11 +32,17 @@ This script can be directly executed as follows:
 
     $ python test_hello_federation.py --template torch_cnn_mnist_fed_eval
     
-In order to adapt this template for federated evaluation, the following modifications were made to ``plan.yaml``:
+In order to adapt this template for federated evaluation, the following defaults were added for assigner, aggregator and tasks and same referenced in the ``plan.yaml``:
 
 .. literalinclude:: ../../../openfl-workspace/torch_cnn_mnist_fed_eval/plan/plan.yaml
 
-Key Changes for Federated Evaluation:
+.. literalinclude:: ../../../openfl-workspace/workspace/plan/defaults/federated-evaluation/aggregator.yaml
+
+.. literalinclude:: ../../../openfl-workspace/workspace/plan/defaults/federated-evaluation/assigner.yaml
+
+.. literalinclude:: ../../../openfl-workspace/workspace/plan/defaults/federated-evaluation/tasks_torch.yaml
+
+Key Changes for Federated Evaluation by baking in defaults for:
 
 1. **aggregator.settings.rounds_to_train**: Set to 1
 2. **assigner**: Assign to aggregated_model_validation instead of default assignments
@@ -48,4 +54,4 @@ This sample script will create a federation based on the `torch_cnn_mnist_fed_ev
 
 ---
 
-Congratulations, you have successfully performed federated evaluation across two decentralized collaborator nodes.
+Congratulations, you have successfully performed federated evaluation across two decentralized collaborator nodes with minor default reference changes to plan

--- a/openfl-workspace/torch_cnn_mnist_fed_eval/plan/plan.yaml
+++ b/openfl-workspace/torch_cnn_mnist_fed_eval/plan/plan.yaml
@@ -2,15 +2,12 @@
 # Licensed subject to the terms of the separately executed evaluation license agreement between Intel Corporation and you.
 
 aggregator :
-  defaults : plan/defaults/aggregator.yaml
+  defaults : plan/defaults/federated-evaluation/aggregator.yaml
   template : openfl.component.Aggregator
   settings :
     init_state_path     : save/torch_cnn_mnist_init.pbuf
     best_state_path     : save/torch_cnn_mnist_best.pbuf
     last_state_path     : save/torch_cnn_mnist_last.pbuf
-    ######### SET ROUNDS TO 1 #############
-    rounds_to_train     : 1
-    #######################################
     log_metric_callback :
       template : src.mnist_utils.write_metric
 
@@ -37,25 +34,10 @@ network :
   defaults : plan/defaults/network.yaml
 
 assigner :
-  ######### SET ASSIGNER TO ONLY INCLUDE AGGREGATED MODEL VALIDATION #############
-  template : openfl.component.RandomGroupedAssigner
-  settings :
-    task_groups  :
-      - name       : validate
-        percentage : 1.0
-        tasks      :
-          - aggregated_model_validation
-  ################################################################################
+  defaults : plan/defaults/federated-evaluation/assigner.yaml
   
 tasks :
-  ######### SET AGGREGATED MODEL VALIDATION AS ONLY TASK #############
-  aggregated_model_validation:
-    function : validate
-    kwargs   :
-      apply   : global
-      metrics :
-        - acc
-  ####################################################################
+  defaults : plan/defaults/federated-evaluation/tasks_torch.yaml
 
 compression_pipeline :
   defaults : plan/defaults/compression_pipeline.yaml

--- a/openfl-workspace/workspace/plan/defaults/federated-evaluation/aggregator.yaml
+++ b/openfl-workspace/workspace/plan/defaults/federated-evaluation/aggregator.yaml
@@ -1,0 +1,7 @@
+template : openfl.component.Aggregator
+settings :
+    db_store_rounds : 2
+    write_logs      : true
+    ######### Default rounds to 1 for evaluation #############
+    rounds_to_train     : 1
+    ##########################################################

--- a/openfl-workspace/workspace/plan/defaults/federated-evaluation/assigner.yaml
+++ b/openfl-workspace/workspace/plan/defaults/federated-evaluation/assigner.yaml
@@ -1,0 +1,7 @@
+template : openfl.component.RandomGroupedAssigner
+settings :
+  task_groups  :
+    - name       : validate
+      percentage : 1.0
+      tasks      :
+        - aggregated_model_validation

--- a/openfl-workspace/workspace/plan/defaults/federated-evaluation/tasks_torch.yaml
+++ b/openfl-workspace/workspace/plan/defaults/federated-evaluation/tasks_torch.yaml
@@ -1,0 +1,7 @@
+aggregated_model_validation:
+  function : validate_task
+  kwargs   :
+    apply   : global
+    metrics :
+      - acc
+  


### PR DESCRIPTION
- federated evaluation with defaults baked in aggregator, tasks and assigner
- updated torch_cnn_mnist_fed_eval sample workspace to use new defaults
Signed-off-by: Shailesh Pant <shailesh.pant@intel.com>

Steps followed to validate the changes
- Ran the following commands inside home folder ~/src/clean/openfl where clean checkout of fork branch is pulled
```
#!/bin/sh
cd ~/src/clean/openfl
## Create a fedeval sample workspace using torch_cnn_mnist_fed_eval template
fx workspace create --prefix ./fed_eval --template torch_cnn_mnist_fed_eval
cd fed_eval
fx workspace certify
fx aggregator generate-cert-request
fx aggregator certify --silent
fx plan initialize
## Create two collaborators

fx collaborator create -n collaborator1 -d 1
fx collaborator generate-cert-request -n collaborator1
fx collaborator certify -n collaborator1 --silent
fx collaborator create -n collaborator2 -d 2
fx collaborator generate-cert-request -n collaborator2
fx collaborator certify -n collaborator2 --silent

## start the fedeval federation
fx aggregator start > fx_aggregator.log 2>&1 &
fx collaborator start -n collaborator1 > collab1.log 2>&1 &
fx collaborator start -n collaborator2 > collab2.log 2>&1 &
tail -f fx_aggregator.log collab1.log collab2.log
```

Plan yaml prepared using these defaults

```
 aggregator:                                                                                                                      plan.py:197
                      settings:
                        best_state_path: save/torch_cnn_mnist_best.pbuf
                        db_store_rounds: 2
                        init_state_path: save/torch_cnn_mnist_init.pbuf
                        last_state_path: save/torch_cnn_mnist_last.pbuf
                        log_metric_callback:
                          template: src.mnist_utils.write_metric
                        rounds_to_train: 1
                        write_logs: true
                      template: openfl.component.Aggregator
                    assigner:
                      settings:
                        task_groups:
                        - name: validate
                          percentage: 1.0
                          tasks:
                          - aggregated_model_validation
                      template: openfl.component.RandomGroupedAssigner
                    collaborator:
                      settings:
                        db_store_rounds: 1
                        delta_updates: false
                        opt_treatment: RESET
                      template: openfl.component.Collaborator
                    compression_pipeline:
                      settings: {}
                      template: openfl.pipelines.NoCompressionPipeline
                    data_loader:
                      settings:
                        batch_size: 256
                        collaborator_count: 2
                        data_group_name: mnist
                      template: src.ptmnist_inmemory.PyTorchMNISTInMemory
                    network:
                      settings:
                        agg_addr: <###masked>
                        agg_port: 50923
                        cert_folder: cert
                        client_reconnect_interval: 5
                        hash_salt: auto
                        require_client_auth: true
                        use_tls: true
                      template: openfl.federation.Network
                    task_runner:
                      settings: {}
                      template: src.pt_cnn.PyTorchCNN
                    tasks:
                      aggregated_model_validation:
                        function: validate_task
                        kwargs:
                          apply: global
                          metrics:
                          - acc
                      settings: {}
```
Output

```
==> collab2.log <==
[11:50:12] METRIC   Round 0, collaborator collaborator2 is sending metric for task aggregated_model_validation: accuracy    0.094419                utils.py:112

==> fx_aggregator.log <==
[11:50:12] INFO     Collaborator collaborator1 is sending task results for aggregated_model_validation, round 0                                aggregator.py:624
           METRIC   {'round': 0, 'metric_origin': 'collaborator1', 'task_name': 'aggregated_model_validation', 'metric_name': 'accuracy',           utils.py:112
                    'metric_value': 0.08940000087022781}
           INFO     Round: 0, Collaborators that have completed all tasks: ['collaborator1']                                                  aggregator.py:1041
           INFO     Collaborator collaborator2 is sending task results for aggregated_model_validation, round 0                                aggregator.py:624
           METRIC   {'round': 0, 'metric_origin': 'collaborator2', 'task_name': 'aggregated_model_validation', 'metric_name': 'accuracy',           utils.py:112
                    'metric_value': 0.09441888332366943}

==> collab1.log <==
           INFO     Waiting for tasks...                                                                                                     collaborator.py:221

==> fx_aggregator.log <==
           INFO     Round: 0, Collaborators that have completed all tasks: ['collaborator1', 'collaborator2']                                 aggregator.py:1041
           METRIC   {'metric_origin': 'aggregator', 'task_name': 'aggregated_model_validation', 'metric_name': 'accuracy', 'metric_value':          utils.py:112
                    0.09190919112772902, 'round': 0}
           METRIC   Round 0: saved the best model with score 0.091909                                                                               utils.py:112
           INFO     Saving round 0 model...                                                                                                    aggregator.py:986
           INFO     Experiment Completed. Cleaning up...                                                                                       aggregator.py:999

==> collab2.log <==
           INFO     Waiting for tasks...                                                                                                     collaborator.py:221

==> fx_aggregator.log <==
           INFO     Sending signal to collaborator collaborator2 to shutdown...                                                                aggregator.py:351

==> collab2.log <==
           INFO     End of Federation reached. Exiting...                                                                                    collaborator.py:186

 ✔️ OK

==> collab1.log <==
[11:50:22] INFO     Waiting for tasks...                                                                                                     collaborator.py:221

==> fx_aggregator.log <==
[11:50:22] INFO     Sending signal to collaborator collaborator1 to shutdown...                                                                aggregator.py:351

==> collab1.log <==
           INFO     End of Federation reached. Exiting...                                                                                    collaborator.py:186

 ✔️ OK

==> fx_aggregator.log <==

 ✔️ OK
 ```
 
 