### PR TITLE
Fix for TF (2.13) cnn histology workspace 'Adam' object has no attribute 'weights' issue

### DIFF
--- a/openfl-workspace/tf_cnn_histology/src/tf_cnn.py
+++ b/openfl-workspace/tf_cnn_histology/src/tf_cnn.py
@@ -88,7 +88,7 @@ class TensorFlowCNN(KerasTaskRunner):
 
         model = tf.keras.models.Model(inputs=[inputs], outputs=[predict])
 
-        self.optimizer = tf.keras.optimizers.Adam()
+        self.optimizer = tf.keras.optimizers.legacy.Adam()
 
         model.compile(
             loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),


### PR DESCRIPTION
for more details please refer https://github.com/securefederatedai/openfl/issues/1127.