### PR TITLE
fix(deps): requests minimum version set to 2.32.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
         'dynaconf',
         'tqdm',
         'numpy',
-        'requests',
+        'requests>=2.32.0',
         'cloudpickle',
         'cryptography',
         'pandas',


### PR DESCRIPTION
Update the minimum required version for the [requests](https://pypi.org/project/requests/) module to fix vulnerabilities [CVE-2024-35195](https://avd.aquasec.com/nvd/2024/cve-2024-35195/) and [CVE-2023-32681](https://avd.aquasec.com/nvd/2023/cve-2023-32681/).

Fixes:
- https://github.com/securefederatedai/openfl/security/code-scanning/881
- https://github.com/securefederatedai/openfl/security/code-scanning/882

Also refer: 
- https://github.com/securefederatedai/openfl/pull/1048