### PR TITLE
Set timeouts for all CI workflows

### DIFF
--- a/.github/workflows/double_ws_export.yml
+++ b/.github/workflows/double_ws_export.yml
@@ -19,6 +19,7 @@ jobs:
   build:
     if: github.event.pull_request.draft == false
     runs-on: 'ubuntu-latest'
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/experimental_workflow_tests.yml
+++ b/.github/workflows/experimental_workflow_tests.yml
@@ -14,6 +14,7 @@ jobs:
   build:
     if: (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'workflow_interface'))
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/gandlf.yml
+++ b/.github/workflows/gandlf.yml
@@ -19,6 +19,7 @@ jobs:
   build:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -15,6 +15,7 @@ jobs:
   build:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/pki.yml
+++ b/.github/workflows/pki.yml
@@ -19,6 +19,7 @@ jobs:
   test_insecure_client:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/pytest_coverage.yml
+++ b/.github/workflows/pytest_coverage.yml
@@ -20,6 +20,7 @@ jobs:
   build:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/straggler-handling.yml
+++ b/.github/workflows/straggler-handling.yml
@@ -22,6 +22,7 @@ jobs:
       matrix:
        os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/task_runner_e2e.yml
+++ b/.github/workflows/task_runner_e2e.yml
@@ -33,7 +33,7 @@ jobs:
   test_with_tls:
     name: tr_tls
     runs-on: ubuntu-22.04
-    timeout-minutes: 120 # 2 hours
+    timeout-minutes: 15
     strategy:
       matrix:
         # There are open issues for some of the models, so excluding them for now:
@@ -100,7 +100,7 @@ jobs:
   test_with_non_tls:
     name: tr_non_tls
     runs-on: ubuntu-22.04
-    timeout-minutes: 120 # 2 hours
+    timeout-minutes: 15
     strategy:
       matrix:
         # Testing non TLS scenario only for torch_cnn_mnist model and python 3.10
@@ -167,7 +167,7 @@ jobs:
   test_with_no_client_auth:
     name: tr_no_client_auth
     runs-on: ubuntu-22.04
-    timeout-minutes: 120 # 2 hours
+    timeout-minutes: 15
     strategy:
       matrix:
         # Testing non TLS scenario only for torch_cnn_mnist model and python 3.10

--- a/.github/workflows/taskrunner.yml
+++ b/.github/workflows/taskrunner.yml
@@ -23,6 +23,8 @@ jobs:
        os: ['ubuntu-latest', 'windows-latest']
        python-version: ['3.8','3.9','3.10','3.11']
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 

--- a/.github/workflows/taskrunner_eden_pipeline.yml
+++ b/.github/workflows/taskrunner_eden_pipeline.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
        os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -14,6 +14,8 @@ jobs:
       actions: read #  only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     name: Build
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -15,6 +15,8 @@ jobs:
   pytest-coverage: # from pytest_coverage.yml
     needs: lint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.8
@@ -35,6 +37,8 @@ jobs:
   cli:
     needs: [lint, pytest-coverage]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.8

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,6 +14,7 @@ env:
 jobs:
   pytest-coverage: # from pytest_coverage.yml
     runs-on: windows-latest
+    timeout-minutes: 15
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.8
@@ -34,6 +35,7 @@ jobs:
   cli: # from taskrunner.yml
     needs: [pytest-coverage]
     runs-on: windows-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.8

--- a/.github/workflows/workflow_interface_101_mnist.yml
+++ b/.github/workflows/workflow_interface_101_mnist.yml
@@ -18,6 +18,7 @@ jobs:
   run_notebook:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     steps:
     - name: Checkout OpenFL repository
       uses: actions/checkout@v4.1.1


### PR DESCRIPTION
Yesterday had issues with certain runs being stuck indefinitely, delaying CI in other PRs, likely due to busy runners. Decided to add timeouts for workflows wherever missing.

15 minutes is double the [average time taken per action](https://github.com/securefederatedai/openfl/actions/metrics/performance), which is good insurance cover for anomalous, yet successful runs.