### PR TITLE
Restore `openfl-tutorials` as installable package

### DIFF
--- a/.github/workflows/experimental_workflow_tests.yml
+++ b/.github/workflows/experimental_workflow_tests.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.8
+    - name: Set up Python 3
       uses: actions/setup-python@v3
       with:
-        python-version: "3.8"
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/experimental_workflow_tests.yml
+++ b/.github/workflows/experimental_workflow_tests.yml
@@ -10,10 +10,6 @@ on:
 permissions:
   contents: read
 
-env:
-  # A workaround for long FQDN names provided by GitHub actions.
-  FQDN: "localhost"
-
 jobs:
   build:
     if: (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'workflow_interface'))

--- a/.github/workflows/experimental_workflow_tests.yml
+++ b/.github/workflows/experimental_workflow_tests.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+env:
+  # A workaround for long FQDN names provided by GitHub actions.
+  FQDN: "localhost"
+
 jobs:
   build:
     if: (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'workflow_interface'))

--- a/openfl-tutorials/experimental/workflow/workflow_interface_requirements.txt
+++ b/openfl-tutorials/experimental/workflow/workflow_interface_requirements.txt
@@ -5,6 +5,7 @@ dill==0.3.6
 matplotlib>=2.0.0
 metaflow==2.7.15
 nbdev==2.3.12
+nbformat
 ray==2.9.2
 torch
 torchvision

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,15 @@ setup(
     long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type='text/markdown',
     url='https://github.com/securefederatedai/openfl',
-    packages=find_packages(include=("openfl", "openfl.*", "openfl-docker", "openfl-workspace")),
+    packages=find_packages(
+        include=(
+            "openfl",
+            "openfl.*",
+            "openfl-docker",
+            "openfl-workspace",
+            "openfl-tutorials",
+        )
+    ),
     include_package_data=True,
     setup_requires=['grpcio-tools>=1.56.2,<1.66.0'],  # ensure it is in-sync with `install_requires`
     install_requires=[


### PR DESCRIPTION
`openfl-tutorials` were excluded as packages since #1187. This caused an issue installing requirements for experimental API activation.

Edit: I still think tutorials need not be included as "installable package" and needs to be revisited.