### PR TITLE
End to end testing: Fixture moved to a separate file

### DIFF
--- a/.github/workflows/task_runner_docker_e2e.yml
+++ b/.github/workflows/task_runner_docker_e2e.yml
@@ -28,81 +28,81 @@ env:
   NUM_COLLABORATORS: ${{ inputs.num_collaborators || '2' }}
 
 jobs:
-  # test_with_tls_docker:
-  #   name: tr_tls_docker
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 15
-  #   strategy:
-  #     matrix:
-  #       # There are open issues for some of the models, so excluding them for now:
-  #       # model_name: [ "torch_cnn_mnist", "keras_cnn_mnist", "torch_cnn_histology" ]
-  #       model_name: ["keras_cnn_mnist"]
-  #       python_version: ["3.9"]
-  #     fail-fast: false # do not immediately fail if one of the combinations fail
+  test_with_tls_docker:
+    name: tr_tls_docker
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        # There are open issues for some of the models, so excluding them for now:
+        # model_name: [ "torch_cnn_mnist", "keras_cnn_mnist", "torch_cnn_histology" ]
+        model_name: ["keras_cnn_mnist"]
+        python_version: ["3.9"]
+      fail-fast: false # do not immediately fail if one of the combinations fail
 
-  #   env:
-  #     MODEL_NAME: ${{ matrix.model_name }}
-  #     PYTHON_VERSION: ${{ matrix.python_version }}
+    env:
+      MODEL_NAME: ${{ matrix.model_name }}
+      PYTHON_VERSION: ${{ matrix.python_version }}
 
-  #   steps:
-  #     - name: Checkout OpenFL repository
-  #       id: checkout_openfl
-  #       uses: actions/checkout@v4.1.1
-  #       with:
-  #         fetch-depth: 2 # needed for detecting changes
-  #         submodules: "true"
-  #         token: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout OpenFL repository
+        id: checkout_openfl
+        uses: actions/checkout@v4.1.1
+        with:
+          fetch-depth: 2 # needed for detecting changes
+          submodules: "true"
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-  #     - name: Set up Python
-  #       id: setup_python
-  #       uses: actions/setup-python@v3
-  #       with:
-  #         python-version: ${{ env.PYTHON_VERSION }}
+      - name: Set up Python
+        id: setup_python
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
 
-  #     - name: Install dependencies
-  #       id: install_dependencies
-  #       run: |
-  #         python -m pip install --upgrade pip
-  #         pip install .
-  #         pip install -r test-requirements.txt
+      - name: Install dependencies
+        id: install_dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          pip install -r test-requirements.txt
 
-  #     - name: Create OpenFL image
-  #       id: create_openfl_image
-  #       run: |
-  #         echo "Creating openfl image. This may take a few minutes..."
-  #         cd openfl-docker
-  #         docker build . -t openfl -f Dockerfile.base \
-  #           --build-arg OPENFL_REVISION=https://github.com/securefederatedai/openfl.git@develop
+      - name: Create OpenFL image
+        id: create_openfl_image
+        run: |
+          echo "Creating openfl image. This may take a few minutes..."
+          cd openfl-docker
+          docker build . -t openfl -f Dockerfile.base \
+            --build-arg OPENFL_REVISION=https://github.com/${{ github.repository }}.git@${{ github.ref_name }}
 
-  #     - name: Run Task Runner E2E tests with TLS
-  #       id: run_tests
-  #       run: |
-  #         python -m pytest -s tests/end_to_end/test_suites/docker_tests.py \
-  #         -m docker --model_name ${{ env.MODEL_NAME }} \
-  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
-  #         echo "Task runner end to end test run completed"
+      - name: Run Task Runner E2E tests with TLS
+        id: run_tests
+        run: |
+          python -m pytest -s tests/end_to_end/test_suites/docker_tests.py \
+          -m docker --model_name ${{ env.MODEL_NAME }} \
+          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
+          echo "Task runner end to end test run completed"
 
-  #     - name: Print test summary
-  #       id: print_test_summary
-  #       if: ${{ always() }}
-  #       run: |
-  #         export PYTHONPATH="$PYTHONPATH:."
-  #         python tests/end_to_end/utils/summary_helper.py
-  #         echo "Test summary printed"
+      - name: Print test summary
+        id: print_test_summary
+        if: ${{ always() }}
+        run: |
+          export PYTHONPATH="$PYTHONPATH:."
+          python tests/end_to_end/utils/summary_helper.py
+          echo "Test summary printed"
 
-  #     - name: Create Tar (exclude cert and data folders)
-  #       id: tar_files
-  #       if: ${{ always() }}
-  #       run: |
-  #         tar -cvf result.tar --exclude="cert" --exclude="data" --exclude="__pycache__" $HOME/results
+      - name: Create Tar (exclude cert and data folders)
+        id: tar_files
+        if: ${{ always() }}
+        run: |
+          tar -cvf result.tar --exclude="cert" --exclude="data" --exclude="__pycache__" $HOME/results
 
-  #     - name: Upload Artifacts
-  #       id: upload_artifacts
-  #       uses: actions/upload-artifact@v4
-  #       if: ${{ always() }}
-  #       with:
-  #         name: tr_tls_docker_${{ env.MODEL_NAME }}_python${{ env.PYTHON_VERSION }}_${{ github.run_id }}
-  #         path: result.tar
+      - name: Upload Artifacts
+        id: upload_artifacts
+        uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: tr_tls_docker_${{ env.MODEL_NAME }}_python${{ env.PYTHON_VERSION }}_${{ github.run_id }}
+          path: result.tar
 
   test_with_non_tls_docker:
     name: tr_non_tls_docker
@@ -128,10 +128,6 @@ jobs:
           fetch-depth: 2 # needed for detecting changes
           submodules: "true"
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Print GitHub variables
-        run: |
-          echo "${{ toJson(github) }}"
 
       - name: Set up Python
         id: setup_python
@@ -184,77 +180,78 @@ jobs:
           name: tr_non_tls_docker_${{ env.MODEL_NAME }}_python${{ env.PYTHON_VERSION }}_${{ github.run_id }}
           path: result.tar
 
-  # test_with_no_client_auth_docker:
-  #   name: tr_no_client_auth_docker
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 15
-  #   strategy:
-  #     matrix:
-  #       # Testing non TLS scenario only for keras_cnn_mnist model and python 3.10
-  #       # If required, this can be extended to other models and python versions
-  #       model_name: ["keras_cnn_mnist"]
-  #       python_version: ["3.11"]
-  #     fail-fast: false # do not immediately fail if one of the combinations fail
+  test_with_no_client_auth_docker:
+    name: tr_no_client_auth_docker
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        # Testing non TLS scenario only for keras_cnn_mnist model and python 3.10
+        # If required, this can be extended to other models and python versions
+        model_name: ["keras_cnn_mnist"]
+        python_version: ["3.11"]
+      fail-fast: false # do not immediately fail if one of the combinations fail
 
-  #   env:
-  #     MODEL_NAME: ${{ matrix.model_name }}
-  #     PYTHON_VERSION: ${{ matrix.python_version }}
+    env:
+      MODEL_NAME: ${{ matrix.model_name }}
+      PYTHON_VERSION: ${{ matrix.python_version }}
 
-  #   steps:
-  #     - name: Checkout OpenFL repository
-  #       id: checkout_openfl
-  #       uses: actions/checkout@v4.1.1
-  #       with:
-  #         fetch-depth: 2 # needed for detecting changes
-  #         submodules: "true"
-  #         token: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout OpenFL repository
+        id: checkout_openfl
+        uses: actions/checkout@v4.1.1
+        with:
+          fetch-depth: 2 # needed for detecting changes
+          submodules: "true"
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-  #     - name: Set up Python
-  #       id: setup_python
-  #       uses: actions/setup-python@v3
-  #       with:
-  #         python-version: ${{ env.PYTHON_VERSION }}
+      - name: Set up Python
+        id: setup_python
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
 
-  #     - name: Install dependencies
-  #       id: install_dependencies
-  #       run: |
-  #         python -m pip install --upgrade pip
-  #         pip install .
-  #         pip install -r test-requirements.txt
+      - name: Install dependencies
+        id: install_dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          pip install -r test-requirements.txt
 
-  #     - name: Create OpenFL image
-  #       id: create_openfl_image
-  #       run: |
-  #         echo "Creating openfl image. This may take a few minutes..."
-  #         cd openfl-docker
-  #         docker build . -t openfl -f Dockerfile.base
+      - name: Create OpenFL image
+        id: create_openfl_image
+        run: |
+          echo "Creating openfl image. This may take a few minutes..."
+          cd openfl-docker
+          docker build . -t openfl -f Dockerfile.base \
+            --build-arg OPENFL_REVISION=https://github.com/${{ github.repository }}.git@${{ github.ref_name }}
 
-  #     - name: Run Task Runner E2E tests without TLS
-  #       id: run_tests
-  #       run: |
-  #         python -m pytest -s tests/end_to_end/test_suites/docker_tests.py \
-  #         -m docker --model_name ${{ env.MODEL_NAME }} \
-  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_client_auth
-  #         echo "Task runner end to end test run completed"
+      - name: Run Task Runner E2E tests without Client Auth
+        id: run_tests
+        run: |
+          python -m pytest -s tests/end_to_end/test_suites/docker_tests.py \
+          -m docker --model_name ${{ env.MODEL_NAME }} \
+          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_client_auth
+          echo "Task runner end to end test run completed"
 
-  #     - name: Print test summary
-  #       id: print_test_summary
-  #       if: ${{ always() }}
-  #       run: |
-  #         export PYTHONPATH="$PYTHONPATH:."
-  #         python tests/end_to_end/utils/summary_helper.py
-  #         echo "Test summary printed"
+      - name: Print test summary
+        id: print_test_summary
+        if: ${{ always() }}
+        run: |
+          export PYTHONPATH="$PYTHONPATH:."
+          python tests/end_to_end/utils/summary_helper.py
+          echo "Test summary printed"
 
-  #     - name: Create Tar (exclude cert and data folders)
-  #       id: tar_files
-  #       if: ${{ always() }}
-  #       run: |
-  #         tar -cvf result.tar --exclude="cert" --exclude="data" --exclude="__pycache__" $HOME/results
+      - name: Create Tar (exclude cert and data folders)
+        id: tar_files
+        if: ${{ always() }}
+        run: |
+          tar -cvf result.tar --exclude="cert" --exclude="data" --exclude="__pycache__" $HOME/results
 
-  #     - name: Upload Artifacts
-  #       id: upload_artifacts
-  #       uses: actions/upload-artifact@v4
-  #       if: ${{ always() }}
-  #       with:
-  #         name: tr_no_client_auth_docker_${{ env.MODEL_NAME }}_python${{ env.PYTHON_VERSION }}_${{ github.run_id }}
-  #         path: result.tar
+      - name: Upload Artifacts
+        id: upload_artifacts
+        uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: tr_no_client_auth_docker_${{ env.MODEL_NAME }}_python${{ env.PYTHON_VERSION }}_${{ github.run_id }}
+          path: result.tar

--- a/.github/workflows/task_runner_docker_e2e.yml
+++ b/.github/workflows/task_runner_docker_e2e.yml
@@ -30,8 +30,7 @@ env:
 jobs:
   test_with_tls_docker:
     name: tr_tls_docker
-    runs-on:
-      labels: ubuntu-20.04-16core
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     strategy:
       matrix:
@@ -106,8 +105,7 @@ jobs:
 
   test_with_non_tls_docker:
     name: tr_non_tls_docker
-    runs-on:
-      labels: ubuntu-20.04-16core
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     strategy:
       matrix:
@@ -182,8 +180,7 @@ jobs:
 
   test_with_no_client_auth_docker:
     name: tr_no_client_auth_docker
-    runs-on:
-      labels: ubuntu-20.04-16core
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     strategy:
       matrix:

--- a/.github/workflows/task_runner_docker_e2e.yml
+++ b/.github/workflows/task_runner_docker_e2e.yml
@@ -30,7 +30,9 @@ env:
 jobs:
   test_with_tls_docker:
     name: tr_tls_docker
-    runs-on: ubuntu-22.04
+    runs-on:
+      group: ubuntu-runners
+      labels: ubuntu-20.04-16core
     timeout-minutes: 15
     strategy:
       matrix:
@@ -66,6 +68,13 @@ jobs:
           pip install .
           pip install -r test-requirements.txt
 
+      - name: Create OpenFL image
+        id: create_openfl_image
+        run: |
+          echo "Creating openfl image. This may take a few minutes..."
+          cd openfl-docker
+          docker build . -t openfl -f Dockerfile.base
+
       - name: Run Task Runner E2E tests with TLS
         id: run_tests
         run: |
@@ -98,7 +107,9 @@ jobs:
 
   test_with_non_tls_docker:
     name: tr_non_tls_docker
-    runs-on: ubuntu-22.04
+    runs-on:
+      group: ubuntu-runners
+      labels: ubuntu-20.04-16core
     timeout-minutes: 15
     strategy:
       matrix:
@@ -134,6 +145,13 @@ jobs:
           pip install .
           pip install -r test-requirements.txt
 
+      - name: Create OpenFL image
+        id: create_openfl_image
+        run: |
+          echo "Creating openfl image. This may take a few minutes..."
+          cd openfl-docker
+          docker build . -t openfl -f Dockerfile.base
+
       - name: Run Task Runner E2E tests without TLS
         id: run_tests
         run: |
@@ -166,7 +184,9 @@ jobs:
 
   test_with_no_client_auth_docker:
     name: tr_no_client_auth_docker
-    runs-on: ubuntu-22.04
+    runs-on:
+      group: ubuntu-runners
+      labels: ubuntu-20.04-16core
     timeout-minutes: 15
     strategy:
       matrix:
@@ -201,6 +221,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install .
           pip install -r test-requirements.txt
+
+      - name: Create OpenFL image
+        id: create_openfl_image
+        run: |
+          echo "Creating openfl image. This may take a few minutes..."
+          cd openfl-docker
+          docker build . -t openfl -f Dockerfile.base
 
       - name: Run Task Runner E2E tests without TLS
         id: run_tests

--- a/.github/workflows/task_runner_docker_e2e.yml
+++ b/.github/workflows/task_runner_docker_e2e.yml
@@ -133,55 +133,56 @@ jobs:
         run: |
           echo "${{ toJson(github) }}"
 
-      # - name: Set up Python
-      #   id: setup_python
-      #   uses: actions/setup-python@v3
-      #   with:
-      #     python-version: ${{ env.PYTHON_VERSION }}
+      - name: Set up Python
+        id: setup_python
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
 
-      # - name: Install dependencies
-      #   id: install_dependencies
-      #   run: |
-      #     python -m pip install --upgrade pip
-      #     pip install .
-      #     pip install -r test-requirements.txt
+      - name: Install dependencies
+        id: install_dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          pip install -r test-requirements.txt
 
-      # - name: Create OpenFL image
-      #   id: create_openfl_image
-      #   run: |
-      #     echo "Creating openfl image. This may take a few minutes..."
-      #     cd openfl-docker
-      #     docker build . -t openfl -f Dockerfile.base
+      - name: Create OpenFL image
+        id: create_openfl_image
+        run: |
+          echo "Creating openfl image. This may take a few minutes..."
+          cd openfl-docker
+          docker build . -t openfl -f Dockerfile.base \
+            --build-arg OPENFL_REVISION=https://github.com/${{ github.repository }}.git@{{ github.ref_name }}
 
-      # - name: Run Task Runner E2E tests without TLS
-      #   id: run_tests
-      #   run: |
-      #     python -m pytest -s tests/end_to_end/test_suites/docker_tests.py \
-      #     -m docker --model_name ${{ env.MODEL_NAME }} \
-      #     --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_tls
-      #     echo "Task runner end to end test run completed"
+      - name: Run Task Runner E2E tests without TLS
+        id: run_tests
+        run: |
+          python -m pytest -s tests/end_to_end/test_suites/docker_tests.py \
+          -m docker --model_name ${{ env.MODEL_NAME }} \
+          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_tls
+          echo "Task runner end to end test run completed"
 
-      # - name: Print test summary
-      #   id: print_test_summary
-      #   if: ${{ always() }}
-      #   run: |
-      #     export PYTHONPATH="$PYTHONPATH:."
-      #     python tests/end_to_end/utils/summary_helper.py
-      #     echo "Test summary printed"
+      - name: Print test summary
+        id: print_test_summary
+        if: ${{ always() }}
+        run: |
+          export PYTHONPATH="$PYTHONPATH:."
+          python tests/end_to_end/utils/summary_helper.py
+          echo "Test summary printed"
 
-      # - name: Create Tar (exclude cert and data folders)
-      #   id: tar_files
-      #   if: ${{ always() }}
-      #   run: |
-      #     tar -cvf result.tar --exclude="cert" --exclude="data" --exclude="__pycache__" $HOME/results
+      - name: Create Tar (exclude cert and data folders)
+        id: tar_files
+        if: ${{ always() }}
+        run: |
+          tar -cvf result.tar --exclude="cert" --exclude="data" --exclude="__pycache__" $HOME/results
 
-      # - name: Upload Artifacts
-      #   id: upload_artifacts
-      #   uses: actions/upload-artifact@v4
-      #   if: ${{ always() }}
-      #   with:
-      #     name: tr_non_tls_docker_${{ env.MODEL_NAME }}_python${{ env.PYTHON_VERSION }}_${{ github.run_id }}
-      #     path: result.tar
+      - name: Upload Artifacts
+        id: upload_artifacts
+        uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: tr_non_tls_docker_${{ env.MODEL_NAME }}_python${{ env.PYTHON_VERSION }}_${{ github.run_id }}
+          path: result.tar
 
   # test_with_no_client_auth_docker:
   #   name: tr_no_client_auth_docker

--- a/.github/workflows/task_runner_docker_e2e.yml
+++ b/.github/workflows/task_runner_docker_e2e.yml
@@ -28,80 +28,81 @@ env:
   NUM_COLLABORATORS: ${{ inputs.num_collaborators || '2' }}
 
 jobs:
-  test_with_tls_docker:
-    name: tr_tls_docker
-    runs-on: ubuntu-22.04
-    timeout-minutes: 15
-    strategy:
-      matrix:
-        # There are open issues for some of the models, so excluding them for now:
-        # model_name: [ "torch_cnn_mnist", "keras_cnn_mnist", "torch_cnn_histology" ]
-        model_name: ["keras_cnn_mnist"]
-        python_version: ["3.9"]
-      fail-fast: false # do not immediately fail if one of the combinations fail
+  # test_with_tls_docker:
+  #   name: tr_tls_docker
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: 15
+  #   strategy:
+  #     matrix:
+  #       # There are open issues for some of the models, so excluding them for now:
+  #       # model_name: [ "torch_cnn_mnist", "keras_cnn_mnist", "torch_cnn_histology" ]
+  #       model_name: ["keras_cnn_mnist"]
+  #       python_version: ["3.9"]
+  #     fail-fast: false # do not immediately fail if one of the combinations fail
 
-    env:
-      MODEL_NAME: ${{ matrix.model_name }}
-      PYTHON_VERSION: ${{ matrix.python_version }}
+  #   env:
+  #     MODEL_NAME: ${{ matrix.model_name }}
+  #     PYTHON_VERSION: ${{ matrix.python_version }}
 
-    steps:
-      - name: Checkout OpenFL repository
-        id: checkout_openfl
-        uses: actions/checkout@v4.1.1
-        with:
-          fetch-depth: 2 # needed for detecting changes
-          submodules: "true"
-          token: ${{ secrets.GITHUB_TOKEN }}
+  #   steps:
+  #     - name: Checkout OpenFL repository
+  #       id: checkout_openfl
+  #       uses: actions/checkout@v4.1.1
+  #       with:
+  #         fetch-depth: 2 # needed for detecting changes
+  #         submodules: "true"
+  #         token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Python
-        id: setup_python
-        uses: actions/setup-python@v3
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
+  #     - name: Set up Python
+  #       id: setup_python
+  #       uses: actions/setup-python@v3
+  #       with:
+  #         python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install dependencies
-        id: install_dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install .
-          pip install -r test-requirements.txt
+  #     - name: Install dependencies
+  #       id: install_dependencies
+  #       run: |
+  #         python -m pip install --upgrade pip
+  #         pip install .
+  #         pip install -r test-requirements.txt
 
-      - name: Create OpenFL image
-        id: create_openfl_image
-        run: |
-          echo "Creating openfl image. This may take a few minutes..."
-          cd openfl-docker
-          docker build . -t openfl -f Dockerfile.base
+  #     - name: Create OpenFL image
+  #       id: create_openfl_image
+  #       run: |
+  #         echo "Creating openfl image. This may take a few minutes..."
+  #         cd openfl-docker
+  #         docker build . -t openfl -f Dockerfile.base \
+  #           --build-arg OPENFL_REVISION=https://github.com/securefederatedai/openfl.git@develop
 
-      - name: Run Task Runner E2E tests with TLS
-        id: run_tests
-        run: |
-          python -m pytest -s tests/end_to_end/test_suites/docker_tests.py \
-          -m docker --model_name ${{ env.MODEL_NAME }} \
-          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
-          echo "Task runner end to end test run completed"
+  #     - name: Run Task Runner E2E tests with TLS
+  #       id: run_tests
+  #       run: |
+  #         python -m pytest -s tests/end_to_end/test_suites/docker_tests.py \
+  #         -m docker --model_name ${{ env.MODEL_NAME }} \
+  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
+  #         echo "Task runner end to end test run completed"
 
-      - name: Print test summary
-        id: print_test_summary
-        if: ${{ always() }}
-        run: |
-          export PYTHONPATH="$PYTHONPATH:."
-          python tests/end_to_end/utils/summary_helper.py
-          echo "Test summary printed"
+  #     - name: Print test summary
+  #       id: print_test_summary
+  #       if: ${{ always() }}
+  #       run: |
+  #         export PYTHONPATH="$PYTHONPATH:."
+  #         python tests/end_to_end/utils/summary_helper.py
+  #         echo "Test summary printed"
 
-      - name: Create Tar (exclude cert and data folders)
-        id: tar_files
-        if: ${{ always() }}
-        run: |
-          tar -cvf result.tar --exclude="cert" --exclude="data" --exclude="__pycache__" $HOME/results
+  #     - name: Create Tar (exclude cert and data folders)
+  #       id: tar_files
+  #       if: ${{ always() }}
+  #       run: |
+  #         tar -cvf result.tar --exclude="cert" --exclude="data" --exclude="__pycache__" $HOME/results
 
-      - name: Upload Artifacts
-        id: upload_artifacts
-        uses: actions/upload-artifact@v4
-        if: ${{ always() }}
-        with:
-          name: tr_tls_docker_${{ env.MODEL_NAME }}_python${{ env.PYTHON_VERSION }}_${{ github.run_id }}
-          path: result.tar
+  #     - name: Upload Artifacts
+  #       id: upload_artifacts
+  #       uses: actions/upload-artifact@v4
+  #       if: ${{ always() }}
+  #       with:
+  #         name: tr_tls_docker_${{ env.MODEL_NAME }}_python${{ env.PYTHON_VERSION }}_${{ github.run_id }}
+  #         path: result.tar
 
   test_with_non_tls_docker:
     name: tr_non_tls_docker
@@ -128,127 +129,131 @@ jobs:
           submodules: "true"
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Python
-        id: setup_python
-        uses: actions/setup-python@v3
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install dependencies
-        id: install_dependencies
+      - name: Print GitHub variables
         run: |
-          python -m pip install --upgrade pip
-          pip install .
-          pip install -r test-requirements.txt
+          echo "${{ toJson(github) }}"
 
-      - name: Create OpenFL image
-        id: create_openfl_image
-        run: |
-          echo "Creating openfl image. This may take a few minutes..."
-          cd openfl-docker
-          docker build . -t openfl -f Dockerfile.base
+      # - name: Set up Python
+      #   id: setup_python
+      #   uses: actions/setup-python@v3
+      #   with:
+      #     python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Run Task Runner E2E tests without TLS
-        id: run_tests
-        run: |
-          python -m pytest -s tests/end_to_end/test_suites/docker_tests.py \
-          -m docker --model_name ${{ env.MODEL_NAME }} \
-          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_tls
-          echo "Task runner end to end test run completed"
+      # - name: Install dependencies
+      #   id: install_dependencies
+      #   run: |
+      #     python -m pip install --upgrade pip
+      #     pip install .
+      #     pip install -r test-requirements.txt
 
-      - name: Print test summary
-        id: print_test_summary
-        if: ${{ always() }}
-        run: |
-          export PYTHONPATH="$PYTHONPATH:."
-          python tests/end_to_end/utils/summary_helper.py
-          echo "Test summary printed"
+      # - name: Create OpenFL image
+      #   id: create_openfl_image
+      #   run: |
+      #     echo "Creating openfl image. This may take a few minutes..."
+      #     cd openfl-docker
+      #     docker build . -t openfl -f Dockerfile.base
 
-      - name: Create Tar (exclude cert and data folders)
-        id: tar_files
-        if: ${{ always() }}
-        run: |
-          tar -cvf result.tar --exclude="cert" --exclude="data" --exclude="__pycache__" $HOME/results
+      # - name: Run Task Runner E2E tests without TLS
+      #   id: run_tests
+      #   run: |
+      #     python -m pytest -s tests/end_to_end/test_suites/docker_tests.py \
+      #     -m docker --model_name ${{ env.MODEL_NAME }} \
+      #     --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_tls
+      #     echo "Task runner end to end test run completed"
 
-      - name: Upload Artifacts
-        id: upload_artifacts
-        uses: actions/upload-artifact@v4
-        if: ${{ always() }}
-        with:
-          name: tr_non_tls_docker_${{ env.MODEL_NAME }}_python${{ env.PYTHON_VERSION }}_${{ github.run_id }}
-          path: result.tar
+      # - name: Print test summary
+      #   id: print_test_summary
+      #   if: ${{ always() }}
+      #   run: |
+      #     export PYTHONPATH="$PYTHONPATH:."
+      #     python tests/end_to_end/utils/summary_helper.py
+      #     echo "Test summary printed"
 
-  test_with_no_client_auth_docker:
-    name: tr_no_client_auth_docker
-    runs-on: ubuntu-22.04
-    timeout-minutes: 15
-    strategy:
-      matrix:
-        # Testing non TLS scenario only for keras_cnn_mnist model and python 3.10
-        # If required, this can be extended to other models and python versions
-        model_name: ["keras_cnn_mnist"]
-        python_version: ["3.11"]
-      fail-fast: false # do not immediately fail if one of the combinations fail
+      # - name: Create Tar (exclude cert and data folders)
+      #   id: tar_files
+      #   if: ${{ always() }}
+      #   run: |
+      #     tar -cvf result.tar --exclude="cert" --exclude="data" --exclude="__pycache__" $HOME/results
 
-    env:
-      MODEL_NAME: ${{ matrix.model_name }}
-      PYTHON_VERSION: ${{ matrix.python_version }}
+      # - name: Upload Artifacts
+      #   id: upload_artifacts
+      #   uses: actions/upload-artifact@v4
+      #   if: ${{ always() }}
+      #   with:
+      #     name: tr_non_tls_docker_${{ env.MODEL_NAME }}_python${{ env.PYTHON_VERSION }}_${{ github.run_id }}
+      #     path: result.tar
 
-    steps:
-      - name: Checkout OpenFL repository
-        id: checkout_openfl
-        uses: actions/checkout@v4.1.1
-        with:
-          fetch-depth: 2 # needed for detecting changes
-          submodules: "true"
-          token: ${{ secrets.GITHUB_TOKEN }}
+  # test_with_no_client_auth_docker:
+  #   name: tr_no_client_auth_docker
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: 15
+  #   strategy:
+  #     matrix:
+  #       # Testing non TLS scenario only for keras_cnn_mnist model and python 3.10
+  #       # If required, this can be extended to other models and python versions
+  #       model_name: ["keras_cnn_mnist"]
+  #       python_version: ["3.11"]
+  #     fail-fast: false # do not immediately fail if one of the combinations fail
 
-      - name: Set up Python
-        id: setup_python
-        uses: actions/setup-python@v3
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
+  #   env:
+  #     MODEL_NAME: ${{ matrix.model_name }}
+  #     PYTHON_VERSION: ${{ matrix.python_version }}
 
-      - name: Install dependencies
-        id: install_dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install .
-          pip install -r test-requirements.txt
+  #   steps:
+  #     - name: Checkout OpenFL repository
+  #       id: checkout_openfl
+  #       uses: actions/checkout@v4.1.1
+  #       with:
+  #         fetch-depth: 2 # needed for detecting changes
+  #         submodules: "true"
+  #         token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create OpenFL image
-        id: create_openfl_image
-        run: |
-          echo "Creating openfl image. This may take a few minutes..."
-          cd openfl-docker
-          docker build . -t openfl -f Dockerfile.base
+  #     - name: Set up Python
+  #       id: setup_python
+  #       uses: actions/setup-python@v3
+  #       with:
+  #         python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Run Task Runner E2E tests without TLS
-        id: run_tests
-        run: |
-          python -m pytest -s tests/end_to_end/test_suites/docker_tests.py \
-          -m docker --model_name ${{ env.MODEL_NAME }} \
-          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_client_auth
-          echo "Task runner end to end test run completed"
+  #     - name: Install dependencies
+  #       id: install_dependencies
+  #       run: |
+  #         python -m pip install --upgrade pip
+  #         pip install .
+  #         pip install -r test-requirements.txt
 
-      - name: Print test summary
-        id: print_test_summary
-        if: ${{ always() }}
-        run: |
-          export PYTHONPATH="$PYTHONPATH:."
-          python tests/end_to_end/utils/summary_helper.py
-          echo "Test summary printed"
+  #     - name: Create OpenFL image
+  #       id: create_openfl_image
+  #       run: |
+  #         echo "Creating openfl image. This may take a few minutes..."
+  #         cd openfl-docker
+  #         docker build . -t openfl -f Dockerfile.base
 
-      - name: Create Tar (exclude cert and data folders)
-        id: tar_files
-        if: ${{ always() }}
-        run: |
-          tar -cvf result.tar --exclude="cert" --exclude="data" --exclude="__pycache__" $HOME/results
+  #     - name: Run Task Runner E2E tests without TLS
+  #       id: run_tests
+  #       run: |
+  #         python -m pytest -s tests/end_to_end/test_suites/docker_tests.py \
+  #         -m docker --model_name ${{ env.MODEL_NAME }} \
+  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_client_auth
+  #         echo "Task runner end to end test run completed"
 
-      - name: Upload Artifacts
-        id: upload_artifacts
-        uses: actions/upload-artifact@v4
-        if: ${{ always() }}
-        with:
-          name: tr_no_client_auth_docker_${{ env.MODEL_NAME }}_python${{ env.PYTHON_VERSION }}_${{ github.run_id }}
-          path: result.tar
+  #     - name: Print test summary
+  #       id: print_test_summary
+  #       if: ${{ always() }}
+  #       run: |
+  #         export PYTHONPATH="$PYTHONPATH:."
+  #         python tests/end_to_end/utils/summary_helper.py
+  #         echo "Test summary printed"
+
+  #     - name: Create Tar (exclude cert and data folders)
+  #       id: tar_files
+  #       if: ${{ always() }}
+  #       run: |
+  #         tar -cvf result.tar --exclude="cert" --exclude="data" --exclude="__pycache__" $HOME/results
+
+  #     - name: Upload Artifacts
+  #       id: upload_artifacts
+  #       uses: actions/upload-artifact@v4
+  #       if: ${{ always() }}
+  #       with:
+  #         name: tr_no_client_auth_docker_${{ env.MODEL_NAME }}_python${{ env.PYTHON_VERSION }}_${{ github.run_id }}
+  #         path: result.tar

--- a/.github/workflows/task_runner_docker_e2e.yml
+++ b/.github/workflows/task_runner_docker_e2e.yml
@@ -31,7 +31,6 @@ jobs:
   test_with_tls_docker:
     name: tr_tls_docker
     runs-on:
-      group: ubuntu-runners
       labels: ubuntu-20.04-16core
     timeout-minutes: 15
     strategy:
@@ -108,7 +107,6 @@ jobs:
   test_with_non_tls_docker:
     name: tr_non_tls_docker
     runs-on:
-      group: ubuntu-runners
       labels: ubuntu-20.04-16core
     timeout-minutes: 15
     strategy:
@@ -185,7 +183,6 @@ jobs:
   test_with_no_client_auth_docker:
     name: tr_no_client_auth_docker
     runs-on:
-      group: ubuntu-runners
       labels: ubuntu-20.04-16core
     timeout-minutes: 15
     strategy:

--- a/.github/workflows/task_runner_docker_e2e.yml
+++ b/.github/workflows/task_runner_docker_e2e.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Create OpenFL image
         id: create_openfl_image
         run: |
-          echo "Creating openfl image. This may take a few minutes..."
+          echo "Creating openfl image with current repo and branch. This may take a few minutes..."
           cd openfl-docker
           docker build . -t openfl -f Dockerfile.base \
             --build-arg OPENFL_REVISION=https://github.com/${{ github.repository }}.git@${{ github.ref_name }}
@@ -145,7 +145,7 @@ jobs:
       - name: Create OpenFL image
         id: create_openfl_image
         run: |
-          echo "Creating openfl image. This may take a few minutes..."
+          echo "Creating openfl image with current repo and branch. This may take a few minutes..."
           cd openfl-docker
           docker build . -t openfl -f Dockerfile.base \
             --build-arg OPENFL_REVISION=https://github.com/${{ github.repository }}.git@${{ github.ref_name }}
@@ -221,7 +221,7 @@ jobs:
       - name: Create OpenFL image
         id: create_openfl_image
         run: |
-          echo "Creating openfl image. This may take a few minutes..."
+          echo "Creating openfl image with current repo and branch. This may take a few minutes..."
           cd openfl-docker
           docker build . -t openfl -f Dockerfile.base \
             --build-arg OPENFL_REVISION=https://github.com/${{ github.repository }}.git@${{ github.ref_name }}

--- a/.github/workflows/task_runner_docker_e2e.yml
+++ b/.github/workflows/task_runner_docker_e2e.yml
@@ -152,7 +152,7 @@ jobs:
           echo "Creating openfl image. This may take a few minutes..."
           cd openfl-docker
           docker build . -t openfl -f Dockerfile.base \
-            --build-arg OPENFL_REVISION=https://github.com/${{ github.repository }}.git@{{ github.ref_name }}
+            --build-arg OPENFL_REVISION=https://github.com/${{ github.repository }}.git@${{ github.ref_name }}
 
       - name: Run Task Runner E2E tests without TLS
         id: run_tests

--- a/.github/workflows/task_runner_e2e.yml
+++ b/.github/workflows/task_runner_e2e.yml
@@ -30,209 +30,209 @@ env:
   NUM_COLLABORATORS: ${{ inputs.num_collaborators || '2' }}
 
 jobs:
-  # test_with_tls:
-  #   name: tr_tls
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 15
-  #   strategy:
-  #     matrix:
-  #       # There are open issues for some of the models, so excluding them for now:
-  #       # model_name: [ "torch_cnn_mnist", "keras_cnn_mnist", "torch_cnn_histology" ]
-  #       model_name: ["torch_cnn_mnist", "keras_cnn_mnist"]
-  #       python_version: ["3.9", "3.10", "3.11"]
-  #     fail-fast: false # do not immediately fail if one of the combinations fail
+  test_with_tls:
+    name: tr_tls
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        # There are open issues for some of the models, so excluding them for now:
+        # model_name: [ "torch_cnn_mnist", "keras_cnn_mnist", "torch_cnn_histology" ]
+        model_name: ["torch_cnn_mnist", "keras_cnn_mnist"]
+        python_version: ["3.9", "3.10", "3.11"]
+      fail-fast: false # do not immediately fail if one of the combinations fail
 
-  #   env:
-  #     MODEL_NAME: ${{ matrix.model_name }}
-  #     PYTHON_VERSION: ${{ matrix.python_version }}
+    env:
+      MODEL_NAME: ${{ matrix.model_name }}
+      PYTHON_VERSION: ${{ matrix.python_version }}
 
-  #   steps:
-  #     - name: Checkout OpenFL repository
-  #       id: checkout_openfl
-  #       uses: actions/checkout@v4.1.1
-  #       with:
-  #         fetch-depth: 2 # needed for detecting changes
-  #         submodules: "true"
-  #         token: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout OpenFL repository
+        id: checkout_openfl
+        uses: actions/checkout@v4.1.1
+        with:
+          fetch-depth: 2 # needed for detecting changes
+          submodules: "true"
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-  #     - name: Set up Python
-  #       id: setup_python
-  #       uses: actions/setup-python@v3
-  #       with:
-  #         python-version: ${{ env.PYTHON_VERSION }}
+      - name: Set up Python
+        id: setup_python
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
 
-  #     - name: Install dependencies
-  #       id: install_dependencies
-  #       run: |
-  #         python -m pip install --upgrade pip
-  #         pip install .
-  #         pip install -r test-requirements.txt
+      - name: Install dependencies
+        id: install_dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          pip install -r test-requirements.txt
 
-  #     - name: Run Task Runner E2E tests with TLS
-  #       id: run_tests
-  #       run: |
-  #         python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
-  #         -m ${{ env.MODEL_NAME }} --model_name ${{ env.MODEL_NAME }} \
-  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
-  #         echo "Task runner end to end test run completed"
+      - name: Run Task Runner E2E tests with TLS
+        id: run_tests
+        run: |
+          python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+          -m ${{ env.MODEL_NAME }} --model_name ${{ env.MODEL_NAME }} \
+          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
+          echo "Task runner end to end test run completed"
 
-  #     - name: Print test summary
-  #       id: print_test_summary
-  #       if: ${{ always() }}
-  #       run: |
-  #         export PYTHONPATH="$PYTHONPATH:."
-  #         python tests/end_to_end/utils/summary_helper.py
-  #         echo "Test summary printed"
+      - name: Print test summary
+        id: print_test_summary
+        if: ${{ always() }}
+        run: |
+          export PYTHONPATH="$PYTHONPATH:."
+          python tests/end_to_end/utils/summary_helper.py
+          echo "Test summary printed"
 
-  #     - name: Create Tar (exclude cert and data folders)
-  #       id: tar_files
-  #       if: ${{ always() }}
-  #       run: |
-  #         tar -cvf result.tar --exclude="cert" --exclude="data" --exclude="__pycache__" $HOME/results
+      - name: Create Tar (exclude cert and data folders)
+        id: tar_files
+        if: ${{ always() }}
+        run: |
+          tar -cvf result.tar --exclude="cert" --exclude="data" --exclude="__pycache__" $HOME/results
 
-  #     - name: Upload Artifacts
-  #       id: upload_artifacts
-  #       uses: actions/upload-artifact@v4
-  #       if: ${{ always() }}
-  #       with:
-  #         name: tr_tls_${{ env.MODEL_NAME }}_python${{ env.PYTHON_VERSION }}_${{ github.run_id }}
-  #         path: result.tar
+      - name: Upload Artifacts
+        id: upload_artifacts
+        uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: tr_tls_${{ env.MODEL_NAME }}_python${{ env.PYTHON_VERSION }}_${{ github.run_id }}
+          path: result.tar
 
-  # test_with_non_tls:
-  #   name: tr_non_tls
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 15
-  #   strategy:
-  #     matrix:
-  #       # Testing non TLS scenario only for torch_cnn_mnist model and python 3.10
-  #       # If required, this can be extended to other models and python versions
-  #       model_name: ["torch_cnn_mnist"]
-  #       python_version: ["3.10"]
-  #     fail-fast: false # do not immediately fail if one of the combinations fail
+  test_with_non_tls:
+    name: tr_non_tls
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        # Testing non TLS scenario only for torch_cnn_mnist model and python 3.10
+        # If required, this can be extended to other models and python versions
+        model_name: ["torch_cnn_mnist"]
+        python_version: ["3.10"]
+      fail-fast: false # do not immediately fail if one of the combinations fail
 
-  #   env:
-  #     MODEL_NAME: ${{ matrix.model_name }}
-  #     PYTHON_VERSION: ${{ matrix.python_version }}
+    env:
+      MODEL_NAME: ${{ matrix.model_name }}
+      PYTHON_VERSION: ${{ matrix.python_version }}
 
-  #   steps:
-  #     - name: Checkout OpenFL repository
-  #       id: checkout_openfl
-  #       uses: actions/checkout@v4.1.1
-  #       with:
-  #         fetch-depth: 2 # needed for detecting changes
-  #         submodules: "true"
-  #         token: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout OpenFL repository
+        id: checkout_openfl
+        uses: actions/checkout@v4.1.1
+        with:
+          fetch-depth: 2 # needed for detecting changes
+          submodules: "true"
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-  #     - name: Set up Python
-  #       id: setup_python
-  #       uses: actions/setup-python@v3
-  #       with:
-  #         python-version: ${{ env.PYTHON_VERSION }}
+      - name: Set up Python
+        id: setup_python
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
 
-  #     - name: Install dependencies
-  #       id: install_dependencies
-  #       run: |
-  #         python -m pip install --upgrade pip
-  #         pip install .
-  #         pip install -r test-requirements.txt
+      - name: Install dependencies
+        id: install_dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          pip install -r test-requirements.txt
 
-  #     - name: Run Task Runner E2E tests without TLS
-  #       id: run_tests
-  #       run: |
-  #         python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
-  #         -m ${{ env.MODEL_NAME }} --model_name ${{ env.MODEL_NAME }} \
-  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_tls
-  #         echo "Task runner end to end test run completed"
+      - name: Run Task Runner E2E tests without TLS
+        id: run_tests
+        run: |
+          python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+          -m ${{ env.MODEL_NAME }} --model_name ${{ env.MODEL_NAME }} \
+          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_tls
+          echo "Task runner end to end test run completed"
 
-  #     - name: Print test summary
-  #       id: print_test_summary
-  #       if: ${{ always() }}
-  #       run: |
-  #         export PYTHONPATH="$PYTHONPATH:."
-  #         python tests/end_to_end/utils/summary_helper.py
-  #         echo "Test summary printed"
+      - name: Print test summary
+        id: print_test_summary
+        if: ${{ always() }}
+        run: |
+          export PYTHONPATH="$PYTHONPATH:."
+          python tests/end_to_end/utils/summary_helper.py
+          echo "Test summary printed"
 
-  #     - name: Create Tar (exclude cert and data folders)
-  #       id: tar_files
-  #       if: ${{ always() }}
-  #       run: |
-  #         tar -cvf result.tar --exclude="cert" --exclude="data" --exclude="__pycache__" $HOME/results
+      - name: Create Tar (exclude cert and data folders)
+        id: tar_files
+        if: ${{ always() }}
+        run: |
+          tar -cvf result.tar --exclude="cert" --exclude="data" --exclude="__pycache__" $HOME/results
 
-  #     - name: Upload Artifacts
-  #       id: upload_artifacts
-  #       uses: actions/upload-artifact@v4
-  #       if: ${{ always() }}
-  #       with:
-  #         name: tr_non_tls_${{ env.MODEL_NAME }}_python${{ env.PYTHON_VERSION }}_${{ github.run_id }}
-  #         path: result.tar
+      - name: Upload Artifacts
+        id: upload_artifacts
+        uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: tr_non_tls_${{ env.MODEL_NAME }}_python${{ env.PYTHON_VERSION }}_${{ github.run_id }}
+          path: result.tar
 
-  # test_with_no_client_auth:
-  #   name: tr_no_client_auth
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 15
-  #   strategy:
-  #     matrix:
-  #       # Testing non TLS scenario only for torch_cnn_mnist model and python 3.10
-  #       # If required, this can be extended to other models and python versions
-  #       model_name: ["keras_cnn_mnist"]
-  #       python_version: ["3.10"]
-  #     fail-fast: false # do not immediately fail if one of the combinations fail
+  test_with_no_client_auth:
+    name: tr_no_client_auth
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        # Testing non TLS scenario only for torch_cnn_mnist model and python 3.10
+        # If required, this can be extended to other models and python versions
+        model_name: ["keras_cnn_mnist"]
+        python_version: ["3.10"]
+      fail-fast: false # do not immediately fail if one of the combinations fail
 
-  #   env:
-  #     MODEL_NAME: ${{ matrix.model_name }}
-  #     PYTHON_VERSION: ${{ matrix.python_version }}
+    env:
+      MODEL_NAME: ${{ matrix.model_name }}
+      PYTHON_VERSION: ${{ matrix.python_version }}
 
-  #   steps:
-  #     - name: Checkout OpenFL repository
-  #       id: checkout_openfl
-  #       uses: actions/checkout@v4.1.1
-  #       with:
-  #         fetch-depth: 2 # needed for detecting changes
-  #         submodules: "true"
-  #         token: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout OpenFL repository
+        id: checkout_openfl
+        uses: actions/checkout@v4.1.1
+        with:
+          fetch-depth: 2 # needed for detecting changes
+          submodules: "true"
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-  #     - name: Set up Python
-  #       id: setup_python
-  #       uses: actions/setup-python@v3
-  #       with:
-  #         python-version: ${{ env.PYTHON_VERSION }}
+      - name: Set up Python
+        id: setup_python
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
 
-  #     - name: Install dependencies
-  #       id: install_dependencies
-  #       run: |
-  #         python -m pip install --upgrade pip
-  #         pip install .
-  #         pip install -r test-requirements.txt
+      - name: Install dependencies
+        id: install_dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          pip install -r test-requirements.txt
 
-  #     - name: Run Task Runner E2E tests without TLS
-  #       id: run_tests
-  #       run: |
-  #         python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
-  #         -m ${{ env.MODEL_NAME }} --model_name ${{ env.MODEL_NAME }} \
-  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_client_auth
-  #         echo "Task runner end to end test run completed"
+      - name: Run Task Runner E2E tests without TLS
+        id: run_tests
+        run: |
+          python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+          -m ${{ env.MODEL_NAME }} --model_name ${{ env.MODEL_NAME }} \
+          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_client_auth
+          echo "Task runner end to end test run completed"
 
-  #     - name: Print test summary
-  #       id: print_test_summary
-  #       if: ${{ always() }}
-  #       run: |
-  #         export PYTHONPATH="$PYTHONPATH:."
-  #         python tests/end_to_end/utils/summary_helper.py
-  #         echo "Test summary printed"
+      - name: Print test summary
+        id: print_test_summary
+        if: ${{ always() }}
+        run: |
+          export PYTHONPATH="$PYTHONPATH:."
+          python tests/end_to_end/utils/summary_helper.py
+          echo "Test summary printed"
 
-  #     - name: Create Tar (exclude cert and data folders)
-  #       id: tar_files
-  #       if: ${{ always() }}
-  #       run: |
-  #         tar -cvf result.tar --exclude="cert" --exclude="data" --exclude="__pycache__" $HOME/results
+      - name: Create Tar (exclude cert and data folders)
+        id: tar_files
+        if: ${{ always() }}
+        run: |
+          tar -cvf result.tar --exclude="cert" --exclude="data" --exclude="__pycache__" $HOME/results
 
-  #     - name: Upload Artifacts
-  #       id: upload_artifacts
-  #       uses: actions/upload-artifact@v4
-  #       if: ${{ always() }}
-  #       with:
-  #         name: tr_no_client_auth_${{ env.MODEL_NAME }}_python${{ env.PYTHON_VERSION }}_${{ github.run_id }}
-  #         path: result.tar
+      - name: Upload Artifacts
+        id: upload_artifacts
+        uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: tr_no_client_auth_${{ env.MODEL_NAME }}_python${{ env.PYTHON_VERSION }}_${{ github.run_id }}
+          path: result.tar
 
   test_memory_logs:
     name: tr_tls_memory_logs
@@ -272,7 +272,7 @@ jobs:
           pip install .
           pip install -r test-requirements.txt
 
-      - name: Run Task Runner E2E tests without TLS
+      - name: Run Task Runner E2E tests with TLS and memory logs
         id: run_tests
         run: |
           python -m pytest -s tests/end_to_end/test_suites/memory_logs_tests.py \

--- a/.github/workflows/task_runner_e2e.yml
+++ b/.github/workflows/task_runner_e2e.yml
@@ -30,209 +30,209 @@ env:
   NUM_COLLABORATORS: ${{ inputs.num_collaborators || '2' }}
 
 jobs:
-  test_with_tls:
-    name: tr_tls
-    runs-on: ubuntu-22.04
-    timeout-minutes: 15
-    strategy:
-      matrix:
-        # There are open issues for some of the models, so excluding them for now:
-        # model_name: [ "torch_cnn_mnist", "keras_cnn_mnist", "torch_cnn_histology" ]
-        model_name: ["torch_cnn_mnist", "keras_cnn_mnist"]
-        python_version: ["3.9", "3.10", "3.11"]
-      fail-fast: false # do not immediately fail if one of the combinations fail
+  # test_with_tls:
+  #   name: tr_tls
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: 15
+  #   strategy:
+  #     matrix:
+  #       # There are open issues for some of the models, so excluding them for now:
+  #       # model_name: [ "torch_cnn_mnist", "keras_cnn_mnist", "torch_cnn_histology" ]
+  #       model_name: ["torch_cnn_mnist", "keras_cnn_mnist"]
+  #       python_version: ["3.9", "3.10", "3.11"]
+  #     fail-fast: false # do not immediately fail if one of the combinations fail
 
-    env:
-      MODEL_NAME: ${{ matrix.model_name }}
-      PYTHON_VERSION: ${{ matrix.python_version }}
+  #   env:
+  #     MODEL_NAME: ${{ matrix.model_name }}
+  #     PYTHON_VERSION: ${{ matrix.python_version }}
 
-    steps:
-      - name: Checkout OpenFL repository
-        id: checkout_openfl
-        uses: actions/checkout@v4.1.1
-        with:
-          fetch-depth: 2 # needed for detecting changes
-          submodules: "true"
-          token: ${{ secrets.GITHUB_TOKEN }}
+  #   steps:
+  #     - name: Checkout OpenFL repository
+  #       id: checkout_openfl
+  #       uses: actions/checkout@v4.1.1
+  #       with:
+  #         fetch-depth: 2 # needed for detecting changes
+  #         submodules: "true"
+  #         token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Python
-        id: setup_python
-        uses: actions/setup-python@v3
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
+  #     - name: Set up Python
+  #       id: setup_python
+  #       uses: actions/setup-python@v3
+  #       with:
+  #         python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install dependencies
-        id: install_dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install .
-          pip install -r test-requirements.txt
+  #     - name: Install dependencies
+  #       id: install_dependencies
+  #       run: |
+  #         python -m pip install --upgrade pip
+  #         pip install .
+  #         pip install -r test-requirements.txt
 
-      - name: Run Task Runner E2E tests with TLS
-        id: run_tests
-        run: |
-          python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
-          -m ${{ env.MODEL_NAME }} --model_name ${{ env.MODEL_NAME }} \
-          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
-          echo "Task runner end to end test run completed"
+  #     - name: Run Task Runner E2E tests with TLS
+  #       id: run_tests
+  #       run: |
+  #         python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+  #         -m ${{ env.MODEL_NAME }} --model_name ${{ env.MODEL_NAME }} \
+  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
+  #         echo "Task runner end to end test run completed"
 
-      - name: Print test summary
-        id: print_test_summary
-        if: ${{ always() }}
-        run: |
-          export PYTHONPATH="$PYTHONPATH:."
-          python tests/end_to_end/utils/summary_helper.py
-          echo "Test summary printed"
+  #     - name: Print test summary
+  #       id: print_test_summary
+  #       if: ${{ always() }}
+  #       run: |
+  #         export PYTHONPATH="$PYTHONPATH:."
+  #         python tests/end_to_end/utils/summary_helper.py
+  #         echo "Test summary printed"
 
-      - name: Create Tar (exclude cert and data folders)
-        id: tar_files
-        if: ${{ always() }}
-        run: |
-          tar -cvf result.tar --exclude="cert" --exclude="data" --exclude="__pycache__" $HOME/results
+  #     - name: Create Tar (exclude cert and data folders)
+  #       id: tar_files
+  #       if: ${{ always() }}
+  #       run: |
+  #         tar -cvf result.tar --exclude="cert" --exclude="data" --exclude="__pycache__" $HOME/results
 
-      - name: Upload Artifacts
-        id: upload_artifacts
-        uses: actions/upload-artifact@v4
-        if: ${{ always() }}
-        with:
-          name: tr_tls_${{ env.MODEL_NAME }}_python${{ env.PYTHON_VERSION }}_${{ github.run_id }}
-          path: result.tar
+  #     - name: Upload Artifacts
+  #       id: upload_artifacts
+  #       uses: actions/upload-artifact@v4
+  #       if: ${{ always() }}
+  #       with:
+  #         name: tr_tls_${{ env.MODEL_NAME }}_python${{ env.PYTHON_VERSION }}_${{ github.run_id }}
+  #         path: result.tar
 
-  test_with_non_tls:
-    name: tr_non_tls
-    runs-on: ubuntu-22.04
-    timeout-minutes: 15
-    strategy:
-      matrix:
-        # Testing non TLS scenario only for torch_cnn_mnist model and python 3.10
-        # If required, this can be extended to other models and python versions
-        model_name: ["torch_cnn_mnist"]
-        python_version: ["3.10"]
-      fail-fast: false # do not immediately fail if one of the combinations fail
+  # test_with_non_tls:
+  #   name: tr_non_tls
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: 15
+  #   strategy:
+  #     matrix:
+  #       # Testing non TLS scenario only for torch_cnn_mnist model and python 3.10
+  #       # If required, this can be extended to other models and python versions
+  #       model_name: ["torch_cnn_mnist"]
+  #       python_version: ["3.10"]
+  #     fail-fast: false # do not immediately fail if one of the combinations fail
 
-    env:
-      MODEL_NAME: ${{ matrix.model_name }}
-      PYTHON_VERSION: ${{ matrix.python_version }}
+  #   env:
+  #     MODEL_NAME: ${{ matrix.model_name }}
+  #     PYTHON_VERSION: ${{ matrix.python_version }}
 
-    steps:
-      - name: Checkout OpenFL repository
-        id: checkout_openfl
-        uses: actions/checkout@v4.1.1
-        with:
-          fetch-depth: 2 # needed for detecting changes
-          submodules: "true"
-          token: ${{ secrets.GITHUB_TOKEN }}
+  #   steps:
+  #     - name: Checkout OpenFL repository
+  #       id: checkout_openfl
+  #       uses: actions/checkout@v4.1.1
+  #       with:
+  #         fetch-depth: 2 # needed for detecting changes
+  #         submodules: "true"
+  #         token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Python
-        id: setup_python
-        uses: actions/setup-python@v3
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
+  #     - name: Set up Python
+  #       id: setup_python
+  #       uses: actions/setup-python@v3
+  #       with:
+  #         python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install dependencies
-        id: install_dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install .
-          pip install -r test-requirements.txt
+  #     - name: Install dependencies
+  #       id: install_dependencies
+  #       run: |
+  #         python -m pip install --upgrade pip
+  #         pip install .
+  #         pip install -r test-requirements.txt
 
-      - name: Run Task Runner E2E tests without TLS
-        id: run_tests
-        run: |
-          python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
-          -m ${{ env.MODEL_NAME }} --model_name ${{ env.MODEL_NAME }} \
-          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_tls
-          echo "Task runner end to end test run completed"
+  #     - name: Run Task Runner E2E tests without TLS
+  #       id: run_tests
+  #       run: |
+  #         python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+  #         -m ${{ env.MODEL_NAME }} --model_name ${{ env.MODEL_NAME }} \
+  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_tls
+  #         echo "Task runner end to end test run completed"
 
-      - name: Print test summary
-        id: print_test_summary
-        if: ${{ always() }}
-        run: |
-          export PYTHONPATH="$PYTHONPATH:."
-          python tests/end_to_end/utils/summary_helper.py
-          echo "Test summary printed"
+  #     - name: Print test summary
+  #       id: print_test_summary
+  #       if: ${{ always() }}
+  #       run: |
+  #         export PYTHONPATH="$PYTHONPATH:."
+  #         python tests/end_to_end/utils/summary_helper.py
+  #         echo "Test summary printed"
 
-      - name: Create Tar (exclude cert and data folders)
-        id: tar_files
-        if: ${{ always() }}
-        run: |
-          tar -cvf result.tar --exclude="cert" --exclude="data" --exclude="__pycache__" $HOME/results
+  #     - name: Create Tar (exclude cert and data folders)
+  #       id: tar_files
+  #       if: ${{ always() }}
+  #       run: |
+  #         tar -cvf result.tar --exclude="cert" --exclude="data" --exclude="__pycache__" $HOME/results
 
-      - name: Upload Artifacts
-        id: upload_artifacts
-        uses: actions/upload-artifact@v4
-        if: ${{ always() }}
-        with:
-          name: tr_non_tls_${{ env.MODEL_NAME }}_python${{ env.PYTHON_VERSION }}_${{ github.run_id }}
-          path: result.tar
+  #     - name: Upload Artifacts
+  #       id: upload_artifacts
+  #       uses: actions/upload-artifact@v4
+  #       if: ${{ always() }}
+  #       with:
+  #         name: tr_non_tls_${{ env.MODEL_NAME }}_python${{ env.PYTHON_VERSION }}_${{ github.run_id }}
+  #         path: result.tar
 
-  test_with_no_client_auth:
-    name: tr_no_client_auth
-    runs-on: ubuntu-22.04
-    timeout-minutes: 15
-    strategy:
-      matrix:
-        # Testing non TLS scenario only for torch_cnn_mnist model and python 3.10
-        # If required, this can be extended to other models and python versions
-        model_name: ["keras_cnn_mnist"]
-        python_version: ["3.10"]
-      fail-fast: false # do not immediately fail if one of the combinations fail
+  # test_with_no_client_auth:
+  #   name: tr_no_client_auth
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: 15
+  #   strategy:
+  #     matrix:
+  #       # Testing non TLS scenario only for torch_cnn_mnist model and python 3.10
+  #       # If required, this can be extended to other models and python versions
+  #       model_name: ["keras_cnn_mnist"]
+  #       python_version: ["3.10"]
+  #     fail-fast: false # do not immediately fail if one of the combinations fail
 
-    env:
-      MODEL_NAME: ${{ matrix.model_name }}
-      PYTHON_VERSION: ${{ matrix.python_version }}
+  #   env:
+  #     MODEL_NAME: ${{ matrix.model_name }}
+  #     PYTHON_VERSION: ${{ matrix.python_version }}
 
-    steps:
-      - name: Checkout OpenFL repository
-        id: checkout_openfl
-        uses: actions/checkout@v4.1.1
-        with:
-          fetch-depth: 2 # needed for detecting changes
-          submodules: "true"
-          token: ${{ secrets.GITHUB_TOKEN }}
+  #   steps:
+  #     - name: Checkout OpenFL repository
+  #       id: checkout_openfl
+  #       uses: actions/checkout@v4.1.1
+  #       with:
+  #         fetch-depth: 2 # needed for detecting changes
+  #         submodules: "true"
+  #         token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Python
-        id: setup_python
-        uses: actions/setup-python@v3
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
+  #     - name: Set up Python
+  #       id: setup_python
+  #       uses: actions/setup-python@v3
+  #       with:
+  #         python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install dependencies
-        id: install_dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install .
-          pip install -r test-requirements.txt
+  #     - name: Install dependencies
+  #       id: install_dependencies
+  #       run: |
+  #         python -m pip install --upgrade pip
+  #         pip install .
+  #         pip install -r test-requirements.txt
 
-      - name: Run Task Runner E2E tests without TLS
-        id: run_tests
-        run: |
-          python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
-          -m ${{ env.MODEL_NAME }} --model_name ${{ env.MODEL_NAME }} \
-          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_client_auth
-          echo "Task runner end to end test run completed"
+  #     - name: Run Task Runner E2E tests without TLS
+  #       id: run_tests
+  #       run: |
+  #         python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+  #         -m ${{ env.MODEL_NAME }} --model_name ${{ env.MODEL_NAME }} \
+  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_client_auth
+  #         echo "Task runner end to end test run completed"
 
-      - name: Print test summary
-        id: print_test_summary
-        if: ${{ always() }}
-        run: |
-          export PYTHONPATH="$PYTHONPATH:."
-          python tests/end_to_end/utils/summary_helper.py
-          echo "Test summary printed"
+  #     - name: Print test summary
+  #       id: print_test_summary
+  #       if: ${{ always() }}
+  #       run: |
+  #         export PYTHONPATH="$PYTHONPATH:."
+  #         python tests/end_to_end/utils/summary_helper.py
+  #         echo "Test summary printed"
 
-      - name: Create Tar (exclude cert and data folders)
-        id: tar_files
-        if: ${{ always() }}
-        run: |
-          tar -cvf result.tar --exclude="cert" --exclude="data" --exclude="__pycache__" $HOME/results
+  #     - name: Create Tar (exclude cert and data folders)
+  #       id: tar_files
+  #       if: ${{ always() }}
+  #       run: |
+  #         tar -cvf result.tar --exclude="cert" --exclude="data" --exclude="__pycache__" $HOME/results
 
-      - name: Upload Artifacts
-        id: upload_artifacts
-        uses: actions/upload-artifact@v4
-        if: ${{ always() }}
-        with:
-          name: tr_no_client_auth_${{ env.MODEL_NAME }}_python${{ env.PYTHON_VERSION }}_${{ github.run_id }}
-          path: result.tar
+  #     - name: Upload Artifacts
+  #       id: upload_artifacts
+  #       uses: actions/upload-artifact@v4
+  #       if: ${{ always() }}
+  #       with:
+  #         name: tr_no_client_auth_${{ env.MODEL_NAME }}_python${{ env.PYTHON_VERSION }}_${{ github.run_id }}
+  #         path: result.tar
 
   test_memory_logs:
     name: tr_tls_memory_logs
@@ -291,7 +291,7 @@ jobs:
       - name: Tar files
         id: tar_files
         if: ${{ always() }}
-        run: tar -cvf result.tar results
+        run: tar -cvf result.tar --exclude="cert" --exclude="data" --exclude="__pycache__" $HOME/results
 
       - name: Upload Artifacts
         id: upload_artifacts

--- a/tests/end_to_end/README.md
+++ b/tests/end_to_end/README.md
@@ -8,7 +8,7 @@ This project aims at integration testing of ```openfl-workspace``` using pytest 
 tests/end_to_end
 ├── models                  # Central location for all model-related code for testing purpose
 ├── test_suites             # Folder containing test files
-├── utils                   # Folder containing helper files
+├── utils                   # Folder containing fixture and helper files
 ├── conftest.py             # Pytest framework configuration file
 ├── pytest.ini              # Pytest initialisation file
 └── README.md               # Readme file

--- a/tests/end_to_end/conftest.py
+++ b/tests/end_to_end/conftest.py
@@ -2,25 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-import collections
+
 import os
 import shutil
 import xml.etree.ElementTree as ET
 import logging
-import concurrent.futures
+
 
 from tests.end_to_end.utils.logger import configure_logging
 from tests.end_to_end.utils.logger import logger as log
 from tests.end_to_end.utils.conftest_helper import parse_arguments
-import tests.end_to_end.utils.docker_helper as dh
-import tests.end_to_end.utils.federation_helper as fh
-from tests.end_to_end.models import aggregator as agg_model, model_owner as mo_model
 
-# Define a named tuple to store the objects for model owner, aggregator, and collaborators
-federation_fixture = collections.namedtuple(
-    "federation_fixture",
-    "model_owner, aggregator, collaborators, workspace_path, local_bind_path",
-)
 
 def pytest_addoption(parser):
     """
@@ -217,100 +209,3 @@ def pytest_configure(config):
     config.use_tls = not args.disable_tls
     config.log_memory_usage = args.log_memory_usage
     config.results_dir = config.getini("results_dir")
-
-
-@pytest.fixture(scope="function")
-def fx_federation(request):
-    """
-    Fixture for federation. This fixture is used to create the model owner, aggregator, and collaborators.
-    It also creates workspace.
-    Assumption: OpenFL workspace is present for the model being tested.
-    Args:
-        request: pytest request object. Model name is passed as a parameter to the fixture from test cases.
-    Returns:
-        federation_fixture: Named tuple containing the objects for model owner, aggregator, and collaborators
-
-    Note: As this is a function level fixture, thus no import is required at test level.
-    """
-    collaborators = []
-    executor = concurrent.futures.ThreadPoolExecutor()
-
-    test_env, model_name, workspace_path, local_bind_path, agg_domain_name = fh.federation_env_setup_and_validate(request)
-    agg_workspace_path = os.path.join(workspace_path, "aggregator", "workspace")
-
-    # Create model owner object and the workspace for the model
-    # Workspace name will be same as the model name
-    model_owner = mo_model.ModelOwner(model_name, request.config.log_memory_usage, workspace_path=agg_workspace_path)
-
-    # Create workspace for given model name
-    fh.create_persistent_store(model_owner.name, local_bind_path)
-
-    # Start the docker container for aggregator in case of docker environment
-    if test_env == "docker":
-        container = dh.start_docker_container(
-            container_name="aggregator",
-            workspace_path=workspace_path,
-            local_bind_path=local_bind_path,
-        )
-        model_owner.container_id = container.id
-
-    model_owner.create_workspace()
-    fh.add_local_workspace_permission(local_bind_path)
-
-    # Modify the plan
-    plan_path = os.path.join(local_bind_path, "aggregator", "workspace", "plan")
-    model_owner.modify_plan(
-        plan_path=plan_path,
-        new_rounds=request.config.num_rounds,
-        num_collaborators=request.config.num_collaborators,
-        disable_client_auth=not request.config.require_client_auth,
-        disable_tls=not request.config.use_tls,
-    )
-
-    # Certify the workspace in case of TLS
-    # Register the collaborators in case of non-TLS
-    if request.config.use_tls:
-        model_owner.certify_workspace()
-    else:
-        model_owner.register_collaborators(plan_path, request.config.num_collaborators)
-
-    # Initialize the plan
-    model_owner.initialize_plan(agg_domain_name=agg_domain_name)
-
-    # Create the objects for aggregator and collaborators
-    # Workspace path for aggregator is uniform in case of docker or task_runner
-    # But, for collaborators, it is different
-    aggregator = agg_model.Aggregator(
-        agg_domain_name=agg_domain_name,
-        workspace_path=agg_workspace_path,
-        container_id=model_owner.container_id, # None in case of non-docker environment
-    )
-
-    # Generate the sign request and certify the aggregator in case of TLS
-    if request.config.use_tls:
-        aggregator.generate_sign_request()
-        model_owner.certify_aggregator(agg_domain_name)
-
-    # Export the workspace
-    # By default the workspace will be exported to workspace.zip
-    model_owner.export_workspace()
-
-    futures = [
-        executor.submit(
-            fh.setup_collaborator,
-            count=i,
-            workspace_path=workspace_path,
-            local_bind_path=local_bind_path,
-        )
-        for i in range(request.config.num_collaborators)
-    ]
-    collaborators = [f.result() for f in futures]
-
-    # Return the federation fixture
-    return federation_fixture(
-        model_owner=model_owner,
-        aggregator=aggregator,
-        collaborators=collaborators,
-        workspace_path=workspace_path,
-        local_bind_path=local_bind_path,
-    )

--- a/tests/end_to_end/test_suites/docker_tests.py
+++ b/tests/end_to_end/test_suites/docker_tests.py
@@ -4,6 +4,7 @@
 import pytest
 import logging
 
+from tests.end_to_end.utils.common_fixtures import fx_federation
 from tests.end_to_end.utils import federation_helper as fed_helper
 
 log = logging.getLogger(__name__)

--- a/tests/end_to_end/test_suites/memory_logs_tests.py
+++ b/tests/end_to_end/test_suites/memory_logs_tests.py
@@ -38,36 +38,55 @@ def test_log_memory_usage(request, fx_federation):
 
     # Setup PKI for trusted communication within the federation
     if request.config.use_tls:
-        assert fed_helper.setup_pki(fx_federation), "Failed to setup PKI for trusted communication"
+        assert fed_helper.setup_pki(
+            fx_federation
+        ), "Failed to setup PKI for trusted communication"
 
     # Start the federation
     results = fed_helper.run_federation(fx_federation)
 
     # Verify the completion of the federation run
-    assert fed_helper.verify_federation_run_completion(fx_federation, results, \
-                                num_rounds=request.config.num_rounds), "Federation completion failed"
+    assert fed_helper.verify_federation_run_completion(
+        fx_federation, results, num_rounds=request.config.num_rounds
+    ), "Federation completion failed"
     # Verify the aggregator memory logs
-    aggregator_memory_usage_file = os.path.join(fx_federation.workspace_path, "logs", "aggregator_memory_usage.json")
-    assert os.path.exists(aggregator_memory_usage_file), "Aggregator memory usage file is not available"
+    aggregator_memory_usage_file = os.path.join(
+        fx_federation.workspace_path,
+        "aggregator",
+        "workspace",
+        "logs",
+        "aggregator_memory_usage.json",
+    )
+    assert os.path.exists(
+        aggregator_memory_usage_file
+    ), "Aggregator memory usage file is not available"
 
     # Log the aggregator memory usage details
     memory_usage_dict = json.load(open(aggregator_memory_usage_file))
 
     # check memory usage entries for each round
-    assert len(memory_usage_dict) == request.config.num_rounds, \
-                "Memory usage details are not available for all rounds"
+    assert (
+        len(memory_usage_dict) == request.config.num_rounds
+    ), "Memory usage details are not available for all rounds"
 
     # check memory usage entries for each collaborator
     for collaborator in fx_federation.collaborators:
-        collaborator_memory_usage_file = os.path.join(fx_federation.workspace_path,
-                                                      "logs",
-                                                      f"{collaborator.collaborator_name}_memory_usage.json")
+        collaborator_memory_usage_file = os.path.join(
+            fx_federation.workspace_path,
+            collaborator.name,
+            "workspace",
+            "logs",
+            f"{collaborator.collaborator_name}_memory_usage.json",
+        )
 
-        assert os.path.exists(collaborator_memory_usage_file), f"Memory usage file for collaborator {collaborator.collaborator_name} is not available"
+        assert os.path.exists(
+            collaborator_memory_usage_file
+        ), f"Memory usage file for collaborator {collaborator.collaborator_name} is not available"
 
         memory_usage_dict = json.load(open(collaborator_memory_usage_file))
 
-        assert len(memory_usage_dict) == request.config.num_rounds, \
-                f"Memory usage details are not available for all rounds for collaborator {collaborator.collaborator_name}"
+        assert (
+            len(memory_usage_dict) == request.config.num_rounds
+        ), f"Memory usage details are not available for all rounds for collaborator {collaborator.collaborator_name}"
 
     log.info("Memory usage details are available for all participants")

--- a/tests/end_to_end/test_suites/memory_logs_tests.py
+++ b/tests/end_to_end/test_suites/memory_logs_tests.py
@@ -6,6 +6,7 @@ import logging
 import os
 import json
 
+from tests.end_to_end.utils.common_fixtures import fx_federation
 from tests.end_to_end.utils import federation_helper as fed_helper
 
 log = logging.getLogger(__name__)

--- a/tests/end_to_end/test_suites/sample_tests.py
+++ b/tests/end_to_end/test_suites/sample_tests.py
@@ -4,6 +4,7 @@
 import pytest
 import logging
 
+from tests.end_to_end.utils.common_fixtures import fx_federation
 from tests.end_to_end.utils import federation_helper as fed_helper
 
 log = logging.getLogger(__name__)

--- a/tests/end_to_end/test_suites/task_runner_tests.py
+++ b/tests/end_to_end/test_suites/task_runner_tests.py
@@ -4,6 +4,7 @@
 import pytest
 import logging
 
+from tests.end_to_end.utils.common_fixtures import fx_federation
 from tests.end_to_end.utils import federation_helper as fed_helper
 
 log = logging.getLogger(__name__)

--- a/tests/end_to_end/utils/common_fixtures.py
+++ b/tests/end_to_end/utils/common_fixtures.py
@@ -1,0 +1,115 @@
+# Copyright 2020-2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import collections
+import concurrent.futures
+import os
+
+import tests.end_to_end.utils.docker_helper as dh
+import tests.end_to_end.utils.federation_helper as fh
+from tests.end_to_end.models import aggregator as agg_model, model_owner as mo_model
+
+
+# Define a named tuple to store the objects for model owner, aggregator, and collaborators
+federation_fixture = collections.namedtuple(
+    "federation_fixture",
+    "model_owner, aggregator, collaborators, workspace_path, local_bind_path",
+)
+
+
+@pytest.fixture(scope="function")
+def fx_federation(request):
+    """
+    Fixture for federation. This fixture is used to create the model owner, aggregator, and collaborators.
+    It also creates workspace.
+    Assumption: OpenFL workspace is present for the model being tested.
+    Args:
+        request: pytest request object. Model name is passed as a parameter to the fixture from test cases.
+    Returns:
+        federation_fixture: Named tuple containing the objects for model owner, aggregator, and collaborators
+
+    Note: As this is a function level fixture, thus no import is required at test level.
+    """
+    collaborators = []
+    executor = concurrent.futures.ThreadPoolExecutor()
+
+    test_env, model_name, workspace_path, local_bind_path, agg_domain_name = fh.federation_env_setup_and_validate(request)
+    agg_workspace_path = os.path.join(workspace_path, "aggregator", "workspace")
+
+    # Create model owner object and the workspace for the model
+    # Workspace name will be same as the model name
+    model_owner = mo_model.ModelOwner(model_name, request.config.log_memory_usage, workspace_path=agg_workspace_path)
+
+    # Create workspace for given model name
+    fh.create_persistent_store(model_owner.name, local_bind_path)
+
+    # Start the docker container for aggregator in case of docker environment
+    if test_env == "docker":
+        container = dh.start_docker_container(
+            container_name="aggregator",
+            workspace_path=workspace_path,
+            local_bind_path=local_bind_path,
+        )
+        model_owner.container_id = container.id
+
+    model_owner.create_workspace()
+    fh.add_local_workspace_permission(local_bind_path)
+
+    # Modify the plan
+    plan_path = os.path.join(local_bind_path, "aggregator", "workspace", "plan")
+    model_owner.modify_plan(
+        plan_path=plan_path,
+        new_rounds=request.config.num_rounds,
+        num_collaborators=request.config.num_collaborators,
+        disable_client_auth=not request.config.require_client_auth,
+        disable_tls=not request.config.use_tls,
+    )
+
+    # Certify the workspace in case of TLS
+    # Register the collaborators in case of non-TLS
+    if request.config.use_tls:
+        model_owner.certify_workspace()
+    else:
+        model_owner.register_collaborators(plan_path, request.config.num_collaborators)
+
+    # Initialize the plan
+    model_owner.initialize_plan(agg_domain_name=agg_domain_name)
+
+    # Create the objects for aggregator and collaborators
+    # Workspace path for aggregator is uniform in case of docker or task_runner
+    # But, for collaborators, it is different
+    aggregator = agg_model.Aggregator(
+        agg_domain_name=agg_domain_name,
+        workspace_path=agg_workspace_path,
+        container_id=model_owner.container_id, # None in case of non-docker environment
+    )
+
+    # Generate the sign request and certify the aggregator in case of TLS
+    if request.config.use_tls:
+        aggregator.generate_sign_request()
+        model_owner.certify_aggregator(agg_domain_name)
+
+    # Export the workspace
+    # By default the workspace will be exported to workspace.zip
+    model_owner.export_workspace()
+
+    futures = [
+        executor.submit(
+            fh.setup_collaborator,
+            count=i,
+            workspace_path=workspace_path,
+            local_bind_path=local_bind_path,
+        )
+        for i in range(request.config.num_collaborators)
+    ]
+    collaborators = [f.result() for f in futures]
+
+    # Return the federation fixture
+    return federation_fixture(
+        model_owner=model_owner,
+        aggregator=aggregator,
+        collaborators=collaborators,
+        workspace_path=workspace_path,
+        local_bind_path=local_bind_path,
+    )

--- a/tests/end_to_end/utils/summary_helper.py
+++ b/tests/end_to_end/utils/summary_helper.py
@@ -11,7 +11,12 @@ import tests.end_to_end.utils.constants as constants
 parser = etree.XMLParser(recover=True, encoding='utf-8')
 
 result_path = os.path.join(os.getenv("HOME"), "results")
-tree = ET.parse(f"{result_path}/results.xml", parser=parser)
+result_xml = os.path.join(result_path, "results.xml")
+if not os.path.exists(result_xml):
+    print(f"Results XML file not found at {result_xml}. Exiting...")
+    exit(1)
+
+tree = ET.parse(result_xml, parser=parser)
 
 # Get the root element
 testsuites = tree.getroot()


### PR DESCRIPTION
Changes done:

1. Fixture `fx_federation` moved out of `conftest.py` to newly created `common_fixtures.py` under `tests/end_to_end/utils` to keep conftest file short and simple.
2. Correction made to docker workflow for OpenFL image creation step.
3. Correction made to task runner workflow for memory logs.
4. `README.md` updated to indicate that utils contain fixture file.

Successful jobs:

1. Task Runner workflow - https://github.com/noopurintel/openfl/actions/runs/12292745031
2. Task Runner via Docker workflow - https://github.com/noopurintel/openfl/actions/runs/12292746636
