### PR TITLE
Use localhost for the aggregator in the quick-start tutorial

### DIFF
--- a/docs/get_started/quickstart.rst
+++ b/docs/get_started/quickstart.rst
@@ -57,13 +57,13 @@ Now you're ready to run your first federation! Copying these commands to your te
    #################################################################
 
    # Generate a Certificate Signing Request (CSR) for the Aggregator
-   fx aggregator generate-cert-request
+   fx aggregator generate-cert-request --fqdn localhost
 
    # The CA signs the aggregator's request, which is now available in the workspace
-   fx aggregator certify --silent
+   fx aggregator --fqdn localhost certify --silent
 
    # Initialize FL Plan and Model Weights for the Federation
-   fx plan initialize
+   fx plan initialize --aggregator_address localhost
 
    ################################
    # Step 3: Setup Collaborator 1 #


### PR DESCRIPTION
To simplify the local OpenFL run, we can deploy the aggregator on `localhost`, instead of a dynamically generated FQDN (which could lead to proxy or certificate issues, among others). Running the federation in a distributed setting requires a different FL plan setup anyway, which seems out of scope for a "quick start" tutorial.

The proposed change aims to make the initial developer experience with OpenFL smoother.