### PR TITLE
Implement task_group filtering for FedEval

### DIFF
--- a/openfl-workspace/torch_cnn_mnist/plan/plan.yaml
+++ b/openfl-workspace/torch_cnn_mnist/plan/plan.yaml
@@ -10,16 +10,8 @@ aggregator:
     rounds_to_train: 2
     write_logs: false
   template: openfl.component.aggregator.Aggregator
-assigner:
-  settings:
-    task_groups:
-    - name: learning
-      percentage: 1.0
-      tasks:
-      - aggregated_model_validation
-      - train
-      - locally_tuned_model_validation
-  template: openfl.component.RandomGroupedAssigner
+assigner :
+  defaults : plan/defaults/assigner.yaml
 collaborator:
   settings:
     db_store_rounds: 1

--- a/openfl-workspace/torch_cnn_mnist_fed_eval/plan/plan.yaml
+++ b/openfl-workspace/torch_cnn_mnist_fed_eval/plan/plan.yaml
@@ -32,10 +32,12 @@ network :
   defaults : plan/defaults/network.yaml
 
 assigner :
-  defaults : plan/defaults/federated-evaluation/assigner.yaml
-  
+  defaults : plan/defaults/assigner.yaml
+  settings :
+    selected_task_group : evaluation
+
 tasks :
-  defaults : plan/defaults/federated-evaluation/tasks_torch.yaml
+  defaults : plan/defaults/tasks_torch.yaml
 
 compression_pipeline :
   defaults : plan/defaults/compression_pipeline.yaml

--- a/openfl-workspace/workspace/plan/defaults/aggregator.yaml
+++ b/openfl-workspace/workspace/plan/defaults/aggregator.yaml
@@ -3,3 +3,4 @@ settings :
     db_store_rounds : 2
     persist_checkpoint: True
     persistent_db_path: local_state/tensor.db
+

--- a/openfl-workspace/workspace/plan/defaults/assigner.yaml
+++ b/openfl-workspace/workspace/plan/defaults/assigner.yaml
@@ -7,3 +7,7 @@ settings :
         - aggregated_model_validation
         - train
         - locally_tuned_model_validation
+    - name       : evaluation
+      percentage : 0
+      tasks      :
+        - aggregated_model_validation

--- a/openfl-workspace/workspace/plan/defaults/federated-evaluation/assigner.yaml
+++ b/openfl-workspace/workspace/plan/defaults/federated-evaluation/assigner.yaml
@@ -1,7 +1,0 @@
-template : openfl.component.RandomGroupedAssigner
-settings :
-  task_groups  :
-    - name       : evaluation
-      percentage : 1.0
-      tasks      :
-        - aggregated_model_validation

--- a/openfl-workspace/workspace/plan/defaults/federated-evaluation/tasks_torch.yaml
+++ b/openfl-workspace/workspace/plan/defaults/federated-evaluation/tasks_torch.yaml
@@ -1,7 +1,0 @@
-aggregated_model_validation:
-  function : validate_task
-  kwargs   :
-    apply   : global
-    metrics :
-      - acc
-  

--- a/openfl/component/__init__.py
+++ b/openfl/component/__init__.py
@@ -1,6 +1,7 @@
 # Copyright 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+"""OpenFL Component Module."""
 
 from openfl.component.aggregator.aggregator import Aggregator
 from openfl.component.assigner.assigner import Assigner

--- a/openfl/component/aggregator/aggregator.py
+++ b/openfl/component/aggregator/aggregator.py
@@ -130,15 +130,25 @@ class Aggregator:
         self.straggler_handling_policy = (
             straggler_handling_policy or CutoffTimeBasedStragglerHandling()
         )
-        self._end_of_round_check_done = [False] * rounds_to_train
-        self.stragglers = []
 
         self.rounds_to_train = rounds_to_train
+        if self.task_group == "evaluation":
+            self.rounds_to_train = 1
+            logger.info(
+                f"task_group is {self.task_group}, setting rounds_to_train = {self.rounds_to_train}"
+            )
+
+        self._end_of_round_check_done = [False] * rounds_to_train
+        self.stragglers = []
 
         # if the collaborator requests a delta, this value is set to true
         self.authorized_cols = authorized_cols
         self.uuid = aggregator_uuid
         self.federation_uuid = federation_uuid
+        # # override the assigner selected_task_group
+        # # FIXME check the case of CustomAssigner as base class Assigner is redefined
+        # # and doesn't have selected_task_group as attribute
+        # assigner.selected_task_group = task_group
         self.assigner = assigner
         self.quit_job_sent_to = []
 

--- a/openfl/component/assigner/__init__.py
+++ b/openfl/component/assigner/__init__.py
@@ -1,6 +1,7 @@
 # Copyright 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+"""OpenFL Assigner Module."""
 
 from openfl.component.assigner.assigner import Assigner
 from openfl.component.assigner.random_grouped_assigner import RandomGroupedAssigner

--- a/openfl/component/assigner/random_grouped_assigner.py
+++ b/openfl/component/assigner/random_grouped_assigner.py
@@ -6,7 +6,7 @@
 
 import numpy as np
 
-from openfl.component.assigner.assigner import Assigner
+from openfl.component.assigner import Assigner
 
 
 class RandomGroupedAssigner(Assigner):
@@ -33,16 +33,19 @@ class RandomGroupedAssigner(Assigner):
         \* - Plan setting.
     """
 
+    with_selected_task_group = Assigner.with_selected_task_group
+
     def __init__(self, task_groups, **kwargs):
         """Initializes the RandomGroupedAssigner.
 
         Args:
             task_groups (list of object): Task groups to assign.
-            **kwargs: Additional keyword arguments.
+            **kwargs: Additional keyword arguments, including mode.
         """
         self.task_groups = task_groups
         super().__init__(**kwargs)
 
+    @with_selected_task_group
     def define_task_assignments(self):
         """Define task assignments for each round and collaborator.
 

--- a/openfl/component/assigner/static_grouped_assigner.py
+++ b/openfl/component/assigner/static_grouped_assigner.py
@@ -32,6 +32,8 @@ class StaticGroupedAssigner(Assigner):
         \* - Plan setting.
     """
 
+    with_selected_task_group = Assigner.with_selected_task_group
+
     def __init__(self, task_groups, **kwargs):
         """Initializes the StaticGroupedAssigner.
 
@@ -42,6 +44,7 @@ class StaticGroupedAssigner(Assigner):
         self.task_groups = task_groups
         super().__init__(**kwargs)
 
+    @with_selected_task_group
     def define_task_assignments(self):
         """Define task assignments for each round and collaborator.
 

--- a/openfl/interface/aggregator.py
+++ b/openfl/interface/aggregator.py
@@ -70,8 +70,7 @@ def aggregator(context):
 @option(
     "--task_group",
     required=False,
-    default="learning",
-    help="Selected task-group for assignment - defaults to learning",
+    help="Selected task-group for assignment",
 )
 def start_(plan, authorized_cols, task_group):
     """Start the aggregator service.
@@ -94,11 +93,13 @@ def start_(plan, authorized_cols, task_group):
         cols_config_path=Path(authorized_cols).absolute(),
     )
 
-    # Set task_group in aggregator settings
-    if "settings" not in parsed_plan.config["aggregator"]:
-        parsed_plan.config["aggregator"]["settings"] = {}
-    parsed_plan.config["aggregator"]["settings"]["task_group"] = task_group
-    logger.info(f"Setting aggregator to assign: {task_group} task_group")
+    # Set task_group in aggregator and assigner settings if provided
+    if task_group:
+        if "settings" not in parsed_plan.config["aggregator"]:
+            parsed_plan.config["aggregator"]["settings"] = {}
+        parsed_plan.config["aggregator"]["settings"]["task_group"] = task_group
+        parsed_plan.config["assigner"]["settings"]["selected_task_group"] = task_group
+        logger.info(f"Setting aggregator to assign: {task_group} task_group")
 
     logger.info("🧿 Starting the Aggregator Service.")
 

--- a/tests/openfl/component/assigner/test_assigner.py
+++ b/tests/openfl/component/assigner/test_assigner.py
@@ -19,7 +19,7 @@ def assigner():
 
 def test_get_aggregation_type_for_task_none(assigner):
     """Assert that aggregation type of custom task is None."""
-    task_name = 'test_name'
+    task_name = "test_name"
     tasks = {task_name: {}}
 
     assigner = assigner(tasks, None, None)
@@ -31,11 +31,9 @@ def test_get_aggregation_type_for_task_none(assigner):
 
 def test_get_aggregation_type_for_task(assigner):
     """Assert that aggregation type of task is getting correctly."""
-    task_name = 'test_name'
-    test_aggregation_type = 'test_aggregation_type'
-    tasks = {task_name: {
-        'aggregation_type': test_aggregation_type
-    }}
+    task_name = "test_name"
+    test_aggregation_type = "test_aggregation_type"
+    tasks = {task_name: {"aggregation_type": test_aggregation_type}}
     assigner = assigner(tasks, None, None)
 
     aggregation_type = assigner.get_aggregation_type_for_task(task_name)
@@ -46,13 +44,23 @@ def test_get_aggregation_type_for_task(assigner):
 def test_get_all_tasks_for_round(assigner):
     """Assert that assigner tasks object is list."""
     assigner = Assigner(None, None, None)
-    tasks = assigner.get_all_tasks_for_round('test')
+    tasks = assigner.get_all_tasks_for_round("test")
 
     assert isinstance(tasks, list)
 
+def test_default_task_group(assigner):
+    """Assert that by default learning task_group is assigned."""
+    assigner = Assigner(None,None,None)
+    assert assigner.selected_task_group == None
+
+def test_task_group_filtering_no_task_groups(assigner):
+    """Assert that task_group_filtering does not filter when no task_groups are defined."""
+    assigner = Assigner(None,None,None)
+    assigner.selected_task_group = "test_group"
+    assigner.define_task_assignments()
+    assert not hasattr(assigner, "task_groups")
 
 class TestNotImplError(TestCase):
-
     def test_define_task_assignments(self):
         # TODO: define_task_assignments is defined as a mock in multiple fixtures,
         # which leads the function to behave as a mock here and other tests.
@@ -61,9 +69,9 @@ class TestNotImplError(TestCase):
     def test_get_tasks_for_collaborator(self):
         with self.assertRaises(NotImplementedError):
             assigner = Assigner(None, None, None)
-            assigner.get_tasks_for_collaborator('col1', 0)
+            assigner.get_tasks_for_collaborator("col1", 0)
 
     def test_get_collaborators_for_task(self):
         with self.assertRaises(NotImplementedError):
             assigner = Assigner(None, None, None)
-            assigner.get_collaborators_for_task('task_name', 0)
+            assigner.get_collaborators_for_task("task_name", 0)

--- a/tests/openfl/component/assigner/test_random_grouped_assigner.py
+++ b/tests/openfl/component/assigner/test_random_grouped_assigner.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from openfl.component.assigner import RandomGroupedAssigner
+from openfl.component.assigner import RandomGroupedAssigner, Assigner
 
 ROUNDS_TO_TRAIN = 10
 
@@ -14,14 +14,21 @@ def task_groups():
     """Initialize task groups."""
     task_groups = [
         {
-            'name': 'train_and_validate',
+            'name': 'learning',
             'percentage': 1.0,
             'tasks': [
                 'aggregated_model_validation',
                 'train',
                 'locally_tuned_model_validation'
             ]
-        }
+        },
+        {
+            'name': 'evaluation',
+            'percentage': 0,
+            'tasks': [
+                'aggregated_model_validation'
+            ]
+        },
     ]
     return task_groups
 
@@ -35,12 +42,12 @@ def authorized_cols():
 @pytest.fixture
 def assigner(task_groups, authorized_cols):
     """Initialize assigner."""
-    assigner = RandomGroupedAssigner
-
-    assigner = assigner(task_groups,
-                        tasks=None,
-                        authorized_cols=authorized_cols,
-                        rounds_to_train=ROUNDS_TO_TRAIN)
+    assigner = RandomGroupedAssigner(
+        task_groups=task_groups,  # Pass task_groups here
+        tasks=None,
+        authorized_cols=authorized_cols,
+        rounds_to_train=ROUNDS_TO_TRAIN
+    )
     return assigner
 
 
@@ -48,6 +55,18 @@ def test_define_task_assignments(assigner):
     """Test `define_task_assignments` is working."""
     assigner.define_task_assignments()
 
+def test_check_default_task_group(assigner):
+    """Assert that by default learning task_group is assigned."""
+    assert assigner.selected_task_group == None
+
+@pytest.mark.parametrize('round_number', range(ROUNDS_TO_TRAIN))
+def test_get_default_tasks_for_collaborator(assigner, task_groups,
+                                    authorized_cols, round_number):
+    """Test that assigner tasks correspond to task groups defined."""
+    tasks = assigner.get_tasks_for_collaborator(
+        authorized_cols[0], round_number)
+    assert tasks == task_groups[0]['tasks']
+    assert assigner.selected_task_group == None
 
 @pytest.mark.parametrize('round_number', range(ROUNDS_TO_TRAIN))
 def test_get_tasks_for_collaborator(assigner, task_groups,
@@ -57,7 +76,6 @@ def test_get_tasks_for_collaborator(assigner, task_groups,
         authorized_cols[0], round_number)
     assert tasks == task_groups[0]['tasks']
 
-
 @pytest.mark.parametrize('round_number', range(ROUNDS_TO_TRAIN))
 def test_get_collaborators_for_task(
         assigner, task_groups, round_number, authorized_cols):
@@ -65,3 +83,23 @@ def test_get_collaborators_for_task(
     for task_name in task_groups[0]['tasks']:
         cols = assigner.get_collaborators_for_task(task_name, round_number)
         assert set(cols) == set(authorized_cols)
+
+@pytest.mark.parametrize('round_number', range(ROUNDS_TO_TRAIN))
+def test_get_assigned_tasks_for_collaborator(task_groups,
+                                    authorized_cols, round_number):
+    """Test that assigner tasks correspond to task groups defined."""
+    eval_assigner = RandomGroupedAssigner(
+        task_groups=task_groups,
+        tasks=None,
+        authorized_cols=authorized_cols,
+        rounds_to_train=ROUNDS_TO_TRAIN,
+        selected_task_group="evaluation"
+    )
+    eval_assigner.define_task_assignments()
+    assert eval_assigner.selected_task_group == "evaluation"
+    tasks = eval_assigner.get_tasks_for_collaborator(
+        authorized_cols[0], round_number)
+    assert tasks == task_groups[1]['tasks']
+    assert eval_assigner.selected_task_group == task_groups[1]['name']
+    assert len(eval_assigner.task_groups) == 1
+    assert eval_assigner.task_groups[0]['percentage'] == 1.0

--- a/tests/openfl/component/assigner/test_static_grouped_assigner.py
+++ b/tests/openfl/component/assigner/test_static_grouped_assigner.py
@@ -20,7 +20,7 @@ def task_groups(authorized_cols):
     """Initialize task groups."""
     task_groups = [
         {
-            'name': 'train_and_validate',
+            'name': 'learning',
             'percentage': 1.0,
             'collaborators': authorized_cols,
             'tasks': [

--- a/tests/openfl/interface/test_aggregator_api.py
+++ b/tests/openfl/interface/test_aggregator_api.py
@@ -27,6 +27,11 @@ def test_aggregator_start(mock_parse):
             'settings': {
                 'task_group': 'learning'
             }
+        },
+        'assigner': {
+            'settings': {
+                'selected_task_group': 'learning'
+            }
         }
     }
     mock_parse.return_value = mock_plan
@@ -53,6 +58,11 @@ def test_aggregator_start_illegal_plan(mock_parse, mock_is_directory_traversal):
         'aggregator': {
             'settings': {
                 'task_group': 'learning'
+            }
+        },
+        'assigner': {
+            'settings': {
+                'selected_task_group': 'learning'
             }
         }
     }
@@ -82,6 +92,11 @@ def test_aggregator_start_illegal_cols(mock_parse, mock_is_directory_traversal):
         'aggregator': {
             'settings': {
                 'task_group': 'learning'
+            }
+        },
+        'assigner': {
+            'settings': {
+                'selected_task_group': 'learning'
             }
         }
     }


### PR DESCRIPTION
- implement a new task_group filtering decorator 'with_selected_task_group' in Assigner class
- update all the sub-classes that use task_groups to use the decorator
- update fedeval sample workspace to use default assigner, tasks and aggregator
- use of federated-evaluation/aggregator.yaml for FedEval specific workspace example to use round_number as 1
- removed assigner and tasks yaml from defaults/federated-evaluation, superseded by default assigner/tasks
- added additional checks for assigner sub-classes that might not have task_groups
- Addressing review comments
- Updated existing test cases for Assigner sub-classes
- Remove hard-coded setting in assigner for torch_cnn_mnist ws, refer to default as in other Workspaces
- Use aggregator supplied --task_group to override the assinger selected_task_group
- update existing test cases of aggregator cli
- add test cases for the decorator
- rebased 25-Jan.1
Signed-off-by: Shailesh Pant <shailesh.pant@intel.com>

- [x] Testcases for task_group_filtering decorator
- [x] Testing for all existing workspaces
- [x] we shouldn't be saving any new models if running in evaluation mode.
- [x] Change all workspaces to use new Assigner [Not needed as defaults ensure all workspace, by default use new assigner]