### PR TITLE
Add persistent db module and recovery logic

### DIFF
--- a/docs/about/features_index/taskrunner.rst
+++ b/docs/about/features_index/taskrunner.rst
@@ -44,7 +44,8 @@ Configurable Settings
  - :code:`best_state_path`: (str:path) Defines the weight protobuf file path that will be saved to for the highest accuracy model during the experiment.
  - :code:`last_state_path`: (str:path)  Defines the weight protobuf file path that will be saved to during the last round completed in each experiment.
  - :code:`rounds_to_train`: (int) Specifies the number of rounds in a federation. A federated learning round is defined as one complete iteration when the collaborators train the model and send the updated model weights back to the aggregator to form a new global model. Within a round, collaborators can train the model for multiple iterations called epochs.
- - :code:`write_logs`: (boolean) Metric logging callback feature. By default, logging is done through `tensorboard <https://www.tensorflow.org/tensorboard/get_started>`_ but users can also use custom metric logging function for each task.      
+ - :code:`write_logs`: (boolean) Metric logging callback feature. By default, logging is done through `tensorboard <https://www.tensorflow.org/tensorboard/get_started>`_ but users can also use custom metric logging function for each task.     
+ - :code:`persist_checkpoint`: (boolean) Specifies whether to enable the storage of a persistent checkpoint in non-volatile storage for recovery purposes. When enabled, the aggregator will restore its state to what it was prior to the restart, ensuring continuity after a restart. 
 
 
 - :class:`Collaborator <openfl.component.Collaborator>`

--- a/docs/about/features_index/taskrunner.rst
+++ b/docs/about/features_index/taskrunner.rst
@@ -46,7 +46,7 @@ Configurable Settings
  - :code:`rounds_to_train`: (int) Specifies the number of rounds in a federation. A federated learning round is defined as one complete iteration when the collaborators train the model and send the updated model weights back to the aggregator to form a new global model. Within a round, collaborators can train the model for multiple iterations called epochs.
  - :code:`write_logs`: (boolean) Metric logging callback feature. By default, logging is done through `tensorboard <https://www.tensorflow.org/tensorboard/get_started>`_ but users can also use custom metric logging function for each task.     
  - :code:`persist_checkpoint`: (boolean) Specifies whether to enable the storage of a persistent checkpoint in non-volatile storage for recovery purposes. When enabled, the aggregator will restore its state to what it was prior to the restart, ensuring continuity after a restart. 
-
+ - :code:`persistent_db_path`: (str:path) Defines the persisted database path. 
 
 - :class:`Collaborator <openfl.component.Collaborator>`
     `openfl.component.Collaborator <https://github.com/intel/openfl/blob/develop/openfl/component/collaborator/collaborator.py>`_

--- a/openfl-workspace/workspace/plan/defaults/aggregator.yaml
+++ b/openfl-workspace/workspace/plan/defaults/aggregator.yaml
@@ -2,3 +2,4 @@ template : openfl.component.Aggregator
 settings :
     db_store_rounds : 2
     persist_checkpoint: True
+    persistent_db_path: save/tensor.db

--- a/openfl-workspace/workspace/plan/defaults/aggregator.yaml
+++ b/openfl-workspace/workspace/plan/defaults/aggregator.yaml
@@ -1,3 +1,4 @@
 template : openfl.component.Aggregator
 settings :
     db_store_rounds : 2
+    persist_checkpoint: True

--- a/openfl/component/collaborator/collaborator.py
+++ b/openfl/component/collaborator/collaborator.py
@@ -409,17 +409,22 @@ class Collaborator:
                         creates_model=True,
                     )
                     self.tensor_db.cache_tensor({new_model_tk: nparray})
-                else:
-                    logger.info(
-                        "Count not find previous model layer."
-                        "Fetching latest layer from aggregator"
-                    )
-                    # The original model tensor should be fetched from client
-                    nparray = self.get_aggregated_tensor_from_aggregator(
-                        tensor_key, require_lossless=True
-                    )
             elif "model" in tags:
                 # Pulling the model for the first time
+                logger.info("Getting model from aggregator key %s ", tensor_key)
+                nparray = self.get_aggregated_tensor_from_aggregator(
+                    tensor_key, require_lossless=True
+                )
+            else:
+
+                # The original model tensor should be fetched from client
+                tensor_name, origin, round_number, report, tags = tensor_key
+                tags = (self.collaborator_name,) + tags
+                tensor_key = (tensor_name, origin, round_number, report, tags)
+                logger.info(
+                    f"Couldnt not find previous model layer."
+                    "Fetching latest layer from aggregator {tensor_key}"
+                )
                 nparray = self.get_aggregated_tensor_from_aggregator(
                     tensor_key, require_lossless=True
                 )

--- a/openfl/component/collaborator/collaborator.py
+++ b/openfl/component/collaborator/collaborator.py
@@ -409,22 +409,17 @@ class Collaborator:
                         creates_model=True,
                     )
                     self.tensor_db.cache_tensor({new_model_tk: nparray})
+                else:
+                    logger.info(
+                        "Count not find previous model layer."
+                        "Fetching latest layer from aggregator"
+                    )
+                    # The original model tensor should be fetched from client
+                    nparray = self.get_aggregated_tensor_from_aggregator(
+                        tensor_key, require_lossless=True
+                    )
             elif "model" in tags:
                 # Pulling the model for the first time
-                logger.info("Getting model from aggregator key %s ", tensor_key)
-                nparray = self.get_aggregated_tensor_from_aggregator(
-                    tensor_key, require_lossless=True
-                )
-            else:
-
-                # The original model tensor should be fetched from client
-                tensor_name, origin, round_number, report, tags = tensor_key
-                tags = (self.collaborator_name,) + tags
-                tensor_key = (tensor_name, origin, round_number, report, tags)
-                logger.info(
-                    f"Couldnt not find previous model layer."
-                    "Fetching latest layer from aggregator {tensor_key}"
-                )
                 nparray = self.get_aggregated_tensor_from_aggregator(
                     tensor_key, require_lossless=True
                 )

--- a/openfl/databases/__init__.py
+++ b/openfl/databases/__init__.py
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from openfl.databases.tensor_db import TensorDB
 from openfl.databases.persistent_db import PersistentTensorDB
+from openfl.databases.tensor_db import TensorDB

--- a/openfl/databases/__init__.py
+++ b/openfl/databases/__init__.py
@@ -3,3 +3,4 @@
 
 
 from openfl.databases.tensor_db import TensorDB
+from openfl.databases.persistent_db import PersistentTensorDB

--- a/openfl/databases/persistent_db.py
+++ b/openfl/databases/persistent_db.py
@@ -1,0 +1,299 @@
+import json
+import pickle
+import sqlite3
+import numpy as np
+from threading import Lock
+from typing import Dict, Iterator, Optional
+
+from openfl.interface.aggregation_functions import AggregationFunction
+from openfl.utilities import LocalTensor, TensorKey, change_tags
+
+__all__ = ['PersistentTensorDB']
+
+
+class PersistentTensorDB:
+    """
+    The PersistentTensorDB class implements a database for storing tensors using SQLite.
+
+    Attributes:
+        conn: The SQLite connection object.
+        cursor: The SQLite cursor object.
+        mutex: A threading Lock object used to ensure thread-safe operations.
+    """
+
+    def __init__(self, db_file: str = "tensordb.sqlite") -> None:
+        """Initializes a new instance of the PersistentTensorDB class."""
+        self.conn = sqlite3.connect(db_file, check_same_thread=False)
+        self.cursor = self.conn.cursor()
+        self.mutex = Lock()
+        self._create_model_tensors_table()
+        self._create_task_results_table()
+        self._create_key_value_Store()
+
+    def _create_model_tensors_table(self) -> None:
+        """Create the database schema if it does not exist."""
+        self.cursor.execute("""
+            CREATE TABLE IF NOT EXISTS tensors (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                tensor_name TEXT,
+                origin TEXT,
+                round INTEGER,
+                report INTEGER,
+                tags TEXT,
+                nparray BLOB
+            )
+        """)
+        self.conn.commit()
+    
+    def _create_task_results_table(self) -> None:
+        """Creates a table for storing task results."""
+        create_table_query = """
+        CREATE TABLE IF NOT EXISTS task_results (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            collaborator_name TEXT NOT NULL,
+            round_number INTEGER NOT NULL,
+            task_name TEXT NOT NULL,
+            data_size INTEGER NOT NULL,
+            named_tensors BLOB NOT NULL
+        );
+        """
+        self.cursor.execute(create_table_query)
+        self.conn.commit()
+    
+    def _create_key_value_Store(self) -> None:
+        self.cursor.execute("""
+            CREATE TABLE IF NOT EXISTS key_value_store (
+                key TEXT PRIMARY KEY,
+                value REAL
+            )
+        """)
+        self.conn.commit()
+    
+    def init_task_results_table(self):
+        """
+        Creates a table for storing task results. Drops the table first if it already exists.
+        """
+        drop_table_query = "DROP TABLE IF EXISTS task_results"
+        self.cursor.execute(drop_table_query)
+        
+        create_table_query = """
+        CREATE TABLE IF NOT EXISTS task_results (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            collaborator_name TEXT NOT NULL,
+            round_number INTEGER NOT NULL,
+            task_name TEXT NOT NULL,
+            data_size INTEGER NOT NULL,
+            named_tensors BLOB NOT NULL
+        );
+        """
+        self.cursor.execute(create_table_query)
+        self.conn.commit()
+
+    def save_task_results(
+        self,
+        collaborator_name: str,
+        round_number: int,
+        task_name: str,
+        data_size: int,
+        serialized_tensors,
+    ):
+        """
+        Saves task results to the task_results table.
+
+        Args:
+            collaborator_name (str): Collaborator name.
+            round_number (int): Round number.
+            task_name (str): Task name.
+            data_size (int): Data size.
+            named_tensors: Named tensors (e.g., protobuf, stored as serialized binary).
+        """
+        serialized_blob = pickle.dumps(serialized_tensors)
+
+
+        # Insert into the database
+        insert_query = """
+        INSERT INTO task_results 
+        (collaborator_name, round_number, task_name, data_size, named_tensors)
+        VALUES (?, ?, ?, ?, ?);
+        """
+        self.cursor.execute(
+            insert_query,
+            (collaborator_name, round_number, task_name, data_size, serialized_blob),
+        )
+        print(f"Saves task result for collaborator {collaborator_name} round number {round_number} taks_name {task_name} data_size {data_size}")
+        self.conn.commit()
+
+    def get_task_result_by_id(self, task_result_id: int):
+        """
+        Retrieve a task result by its ID.
+
+        Args:
+            task_result_id (int): The ID of the task result to retrieve.
+
+        Returns:
+            A dictionary containing the task result details, or None if not found.
+        """
+        with self.mutex:
+            self.cursor.execute("""
+                SELECT collaborator_name, round_number, task_name, data_size, named_tensors
+                FROM task_results
+                WHERE id = ?
+            """, (task_result_id,))
+            result = self.cursor.fetchone()
+            if result:
+                collaborator_name, round_number, task_name, data_size, serialized_blob = result
+                serialized_tensors = pickle.loads(serialized_blob)
+                return {
+                    "collaborator_name": collaborator_name,
+                    "round_number": round_number,
+                    "task_name": task_name,
+                    "data_size": data_size,
+                    "named_tensors": serialized_tensors
+                }
+            return None
+
+    def _serialize_array(self, array: np.ndarray) -> bytes:
+        """Serialize a NumPy array into bytes for storing in SQLite."""
+        return array.tobytes()
+
+    def _deserialize_array(self, blob: bytes, dtype: Optional[np.dtype] = None) -> np.ndarray:
+        """Deserialize bytes from SQLite into a NumPy array."""
+        return np.frombuffer(blob, dtype=dtype)
+
+    def __repr__(self) -> str:
+        """Returns a string representation of the PersistentTensorDB."""
+        with self.mutex:
+            self.cursor.execute("SELECT tensor_name, origin, round, report, tags FROM tensors")
+            rows = self.cursor.fetchall()
+            return f"PersistentTensorDB contents:\n{rows}"
+
+    def finalize_round(self,tensor_key_dict: Dict[TensorKey, np.ndarray],round_number: int, best_score: float):
+        with self.mutex:
+            try:
+                # Begin transaction
+                self.cursor.execute("BEGIN TRANSACTION")
+                self._persist_tensors(tensor_key_dict)
+                self._init_task_results_table()
+                self._save_round_and_best_score(round_number,best_score)
+                # Commit transaction
+                self.conn.commit()
+                print(f"Committed model for round {round_number}, saved {len(tensor_key_dict)} model tensors with best_score {best_score}")
+            except Exception as e:
+                # Rollback transaction in case of an error
+                self.conn.rollback()
+                raise RuntimeError(f"Failed to finalize round: {e}")
+            
+    def _persist_tensors(self, tensor_key_dict: Dict[TensorKey, np.ndarray]) -> None:
+        """Insert a dictionary of tensors into the SQLite database in a single transaction."""
+        for tensor_key, nparray in tensor_key_dict.items():
+            tensor_name, origin, fl_round, report, tags = tensor_key
+            serialized_array = self._serialize_array(nparray)
+            serialized_tags = json.dumps(tags) 
+            self.cursor.execute("""
+                INSERT INTO tensors (tensor_name, origin, round, report, tags, nparray)
+                VALUES (?, ?, ?, ?, ?, ?)
+            """, (tensor_name, origin, fl_round, int(report), serialized_tags, serialized_array))
+            print(f"transaction - Saved tensor: {tensor_name}, origin: {origin}, round: {fl_round}, report: {report}, tags: {serialized_tags}")
+    
+    def _init_task_results_table(self):
+        """
+        Creates a table for storing task results. Drops the table first if it already exists.
+        """
+        drop_table_query = "DROP TABLE IF EXISTS task_results"
+        self.cursor.execute(drop_table_query)
+        
+        create_table_query = """
+        CREATE TABLE IF NOT EXISTS task_results (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            collaborator_name TEXT NOT NULL,
+            round_number INTEGER NOT NULL,
+            task_name TEXT NOT NULL,
+            data_size INTEGER NOT NULL,
+            named_tensors BLOB NOT NULL
+        );
+        """
+        self.cursor.execute(create_table_query)
+    
+    def _save_round_and_best_score(self, round_number: int, best_score: float) -> None:
+        """Save the round number and best score as key-value pairs in the database."""
+        # Create a table with key-value structure where values can be integer or float
+        # Insert or update the round_number
+        self.cursor.execute("""
+            INSERT OR REPLACE INTO key_value_store (key, value)
+            VALUES (?, ?)
+        """, ("round_number", float(round_number)))
+
+        # Insert or update the best_score
+        self.cursor.execute("""
+            INSERT OR REPLACE INTO key_value_store (key, value)
+            VALUES (?, ?)
+        """, ("best_score", float(best_score)))
+
+    
+
+    def load_tensors(self) -> Dict[TensorKey, np.ndarray]:
+        """Load all tensors from the SQLite database and return them as a dictionary."""
+        tensor_dict = {}
+        with self.mutex:
+            self.cursor.execute("SELECT tensor_name, origin, round, report, tags, nparray FROM tensors")
+            rows = self.cursor.fetchall()
+            for row in rows:
+                tensor_name, origin, fl_round, report, tags, nparray = row
+                # Deserialize the JSON string back to a Python list
+                deserialized_tags = tuple(json.loads(tags))
+                tensor_key = TensorKey(tensor_name, origin, fl_round, report, deserialized_tags)
+                tensor_dict[tensor_key] = self._deserialize_array(nparray)
+        return tensor_dict
+
+   
+    def get_round_and_best_score(self) -> tuple[int, float]:
+        """Retrieve the round number and best score from the database."""
+        with self.mutex:
+            # Fetch the round_number
+            self.cursor.execute("""
+                SELECT value FROM key_value_store WHERE key = ?
+            """, ("round_number",))
+            round_number = self.cursor.fetchone()
+            if round_number is None:
+                round_number = -1
+            else:
+                round_number = int(round_number[0])  # Cast to int
+
+            # Fetch the best_score
+            self.cursor.execute("""
+                SELECT value FROM key_value_store WHERE key = ?
+            """, ("best_score",))
+            best_score = self.cursor.fetchone()
+            if best_score is None:
+                best_score = 0
+            else:
+                best_score = float(best_score[0])  # Cast to float
+        return round_number, best_score
+
+
+    def clean_up(self, remove_older_than: int = 1) -> None:
+        """Remove old entries from the database."""
+        if remove_older_than < 0:
+            return
+        with self.mutex:
+            self.cursor.execute("SELECT MAX(round) FROM tensors")
+            current_round = self.cursor.fetchone()[0]
+            if current_round is None:
+                return
+            self.cursor.execute("""
+                DELETE FROM tensors
+                WHERE round <= ? AND report = 0
+            """, (current_round - remove_older_than,))
+            self.conn.commit()
+
+
+    def close(self) -> None:
+        """Close the SQLite database connection."""
+        self.conn.close()
+
+    def is_task_table_empty(self) -> bool:
+        """Check if the task table is empty."""
+        with self.mutex:
+            self.cursor.execute("SELECT COUNT(*) FROM task_results")
+            count = self.cursor.fetchone()[0]
+            return count == 0

--- a/openfl/databases/tensor_db.py
+++ b/openfl/databases/tensor_db.py
@@ -150,6 +150,41 @@ class TensorDB:
         if len(df) == 0:
             return None
         return np.array(df["nparray"].iloc[0])
+    
+    def get_tensors_by_round_and_tags(self, fl_round: int, tags: tuple) -> dict:
+        """Retrieve all tensors that match the specified round and tags.
+
+        Args:
+            fl_round (int): The round number to filter tensors.
+            tags (tuple): The tags to filter tensors.
+
+        Returns:
+            dict: A dictionary where the keys are TensorKey objects and the values are numpy arrays.
+        """
+        # Filter the DataFrame based on the round and tags
+        df = self.tensor_db[
+            (self.tensor_db["round"] == fl_round) &
+            (self.tensor_db["tags"] == tags)
+        ]
+
+        # Check if any tensors match the criteria
+        if len(df) == 0:
+            return {}
+
+        # Construct a dictionary mapping TensorKey to np.ndarray
+        tensor_dict = {}
+        for _, row in df.iterrows():
+            tensor_key = TensorKey(
+                tensor_name=row["tensor_name"],
+                origin=row["origin"],
+                round_number=row["round"],
+                report=row["report"],
+                tags=row["tags"]
+            )
+            tensor_dict[tensor_key] = np.array(row["nparray"])
+
+        return tensor_dict
+
 
     def get_aggregated_tensor(
         self,

--- a/openfl/databases/tensor_db.py
+++ b/openfl/databases/tensor_db.py
@@ -150,7 +150,7 @@ class TensorDB:
         if len(df) == 0:
             return None
         return np.array(df["nparray"].iloc[0])
-    
+
     def get_tensors_by_round_and_tags(self, fl_round: int, tags: tuple) -> dict:
         """Retrieve all tensors that match the specified round and tags.
 
@@ -163,8 +163,7 @@ class TensorDB:
         """
         # Filter the DataFrame based on the round and tags
         df = self.tensor_db[
-            (self.tensor_db["round"] == fl_round) &
-            (self.tensor_db["tags"] == tags)
+            (self.tensor_db["round"] == fl_round) & (self.tensor_db["tags"] == tags)
         ]
 
         # Check if any tensors match the criteria
@@ -179,12 +178,11 @@ class TensorDB:
                 origin=row["origin"],
                 round_number=row["round"],
                 report=row["report"],
-                tags=row["tags"]
+                tags=row["tags"],
             )
             tensor_dict[tensor_key] = np.array(row["nparray"])
 
         return tensor_dict
-
 
     def get_aggregated_tensor(
         self,


### PR DESCRIPTION

- Introduce a new persistent DB module.
- Create tables and logic to persist the data needed to recovery the Aggregator after restart.
- Use the database from the Aggregator.
- Introduce recovery logic to use the persisted data to recover the Aggregator state as it was before the crash.
- Fix for collaborator to send correct tensor key.
