### PR TITLE
1.7.x: Replace dill serialization with cloudpickle

### DIFF
--- a/openfl/experimental/workflow/component/aggregator/aggregator.py
+++ b/openfl/experimental/workflow/component/aggregator/aggregator.py
@@ -12,7 +12,7 @@ from logging import getLogger
 from threading import Event
 from typing import Any, Callable, Dict, List, Tuple
 
-import dill
+import cloudpickle
 
 from openfl.experimental.workflow.interface import FLSpec
 from openfl.experimental.workflow.runtime import FederatedRuntime
@@ -270,14 +270,14 @@ class Aggregator:
         # Perform checkpoint if enabled
         if self.checkpoint:
             if not isinstance(ctx, FLSpec):
-                ctx = dill.loads(ctx)
+                ctx = cloudpickle.loads(ctx)
                 # Update metaflow interface object
                 ctx._metaflow_interface = self.flow._metaflow_interface
             # Deserialize objects if passed in serialized form
             if not isinstance(f, Callable):
-                f = dill.loads(f)
+                f = cloudpickle.loads(f)
             if stream_buffer and isinstance(stream_buffer, bytes):
-                f.__func__._stream_buffer = dill.loads(stream_buffer)
+                f.__func__._stream_buffer = cloudpickle.loads(stream_buffer)
 
             stdout = checkpoint(ctx, f)
             # Retrieve and log stdout
@@ -339,7 +339,7 @@ class Aggregator:
         return (
             self.current_round,
             next_step,
-            dill.dumps(clone),
+            cloudpickle.dumps(clone),
             0,
             self.time_to_quit,
         )
@@ -465,7 +465,7 @@ class Aggregator:
                 f"Collaborator {collab_name} sent task results" f" for round {round_number}."
             )
         # Unpickle the clone (FLSpec object)
-        clone = dill.loads(clone_bytes)
+        clone = cloudpickle.loads(clone_bytes)
         # Update the clone in clones_dict dictionary
         self.clones_dict[clone.input] = clone
         self.next_step = next_step[0]

--- a/openfl/experimental/workflow/component/collaborator/collaborator.py
+++ b/openfl/experimental/workflow/component/collaborator/collaborator.py
@@ -164,10 +164,7 @@ class Collaborator:
             f"Round {self.round_number}," f" collaborator {self.name} is sending results..."
         )
         self.client.send_task_results(
-            self.name,
-            self.round_number,
-            next_step,
-            cloudpickle.dumps(clone)
+            self.name, self.round_number, next_step, cloudpickle.dumps(clone)
         )
 
     def get_tasks(self) -> Tuple:

--- a/openfl/experimental/workflow/component/collaborator/collaborator.py
+++ b/openfl/experimental/workflow/component/collaborator/collaborator.py
@@ -8,7 +8,7 @@ import time
 from logging import getLogger
 from typing import Any, Callable, Dict, Tuple
 
-import dill
+import cloudpickle
 
 
 class Collaborator:
@@ -121,9 +121,9 @@ class Collaborator:
         """
         self.client.call_checkpoint(
             self.name,
-            dill.dumps(ctx),
-            dill.dumps(f),
-            dill.dumps(stream_buffer),
+            cloudpickle.dumps(ctx),
+            cloudpickle.dumps(f),
+            cloudpickle.dumps(stream_buffer),
         )
 
     def run(self) -> None:
@@ -163,7 +163,12 @@ class Collaborator:
         self.logger.info(
             f"Round {self.round_number}," f" collaborator {self.name} is sending results..."
         )
-        self.client.send_task_results(self.name, self.round_number, next_step, dill.dumps(clone))
+        self.client.send_task_results(
+            self.name,
+            self.round_number,
+            next_step,
+            cloudpickle.dumps(clone)
+        )
 
     def get_tasks(self) -> Tuple:
         """Get tasks from the aggregator.
@@ -182,7 +187,7 @@ class Collaborator:
         self.round_number, next_step, clone_bytes, sleep_time, time_to_quit = temp
         if time_to_quit:
             return next_step, "", sleep_time, time_to_quit
-        return next_step, dill.loads(clone_bytes), sleep_time, time_to_quit
+        return next_step, cloudpickle.loads(clone_bytes), sleep_time, time_to_quit
 
     def do_task(self, f_name: str, ctx: Any) -> Tuple:
         """Run collaborator steps until transition.


### PR DESCRIPTION
Pickle and modules that wrap it can be unsafe when used to deserialize untrusted data, possible security issue.
[Ref](https://bandit.readthedocs.io/en/1.7.10/blacklists/blacklist_calls.html#b301-pickle).

Hence replacing [dill](https://pypi.org/project/dill/) with [cloudpickle](https://github.com/cloudpipe/cloudpickle) which is already a requirement and being used in the repository.