### PR TITLE
Streamline FederatedRuntime Workspace by removing Unnecessary Files

### DIFF
--- a/openfl/experimental/workflow/workspace_export/export.py
+++ b/openfl/experimental/workflow/workspace_export/export.py
@@ -361,8 +361,8 @@ class WorkspaceExport:
 
     def _clean_generated_workspace(self) -> None:
         """
-        Removes unnecessary files (cols.yaml and data.yaml)
-        from the director workspace
+        Remove cols.yaml and data.yaml from the generated workspace
+        as these are not needed in FederatedRuntime (Director based workflow)
 
         """
         cols_file = self.output_workspace_path.joinpath("plan", "cols.yaml")

--- a/openfl/experimental/workflow/workspace_export/export.py
+++ b/openfl/experimental/workflow/workspace_export/export.py
@@ -289,6 +289,8 @@ class WorkspaceExport:
         instance = cls(notebook_path, output_workspace)
         instance.generate_requirements()
         instance.generate_plan_yaml()
+        instance._clean_generated_workspace()
+        print_tree(output_workspace, level=2)
         return instance.generate_experiment_archive()
 
     @classmethod
@@ -300,10 +302,10 @@ class WorkspaceExport:
             output_workspace (str): Path for the generated workspace directory.
         """
         instance = cls(notebook_path, output_workspace)
-        print_tree(output_workspace, level=2)
         instance.generate_requirements()
         instance.generate_plan_yaml()
         instance.generate_data_yaml()
+        print_tree(output_workspace, level=2)
 
     def generate_experiment_archive(self) -> Tuple[str, str]:
         """
@@ -315,12 +317,10 @@ class WorkspaceExport:
         """
         parent_directory = self.output_workspace_path.parent
         archive_path = parent_directory / "experiment"
-        self._clean_generated_workspace()
 
         # Create a ZIP archive of the generated_workspace directory
         arch_path = shutil.make_archive(str(archive_path), "zip", str(self.output_workspace_path))
 
-        print_tree(self.output_workspace_path, level=2)
         print(f"Archive created at {archive_path}.zip")
 
         return arch_path, self.flow_class_name

--- a/openfl/experimental/workflow/workspace_export/export.py
+++ b/openfl/experimental/workflow/workspace_export/export.py
@@ -315,6 +315,7 @@ class WorkspaceExport:
         """
         parent_directory = self.output_workspace_path.parent
         archive_path = parent_directory / "experiment"
+        self._clean_generated_workspace()
 
         # Create a ZIP archive of the generated_workspace directory
         arch_path = shutil.make_archive(str(archive_path), "zip", str(self.output_workspace_path))
@@ -356,6 +357,20 @@ class WorkspaceExport:
             for i, line in enumerate(data):
                 if i not in line_nos:
                     f.write(line)
+
+    def _clean_generated_workspace(self) -> None:
+        """
+        Removes unnecessary files (cols.yaml and data.yaml)
+        from the director workspace
+
+        """
+        cols_file = self.created_workspace_path.joinpath("plan", "cols.yaml")
+        data_file = self.created_workspace_path.joinpath("plan", "data.yaml")
+
+        if cols_file.exists():
+            cols_file.unlink()
+        if data_file.exists():
+            data_file.unlink()
 
     def generate_plan_yaml(self) -> None:
         """

--- a/openfl/experimental/workflow/workspace_export/export.py
+++ b/openfl/experimental/workflow/workspace_export/export.py
@@ -88,7 +88,6 @@ class WorkspaceExport:
                 f"{export_filename}.py",
             )
         ).resolve()
-        print_tree(self.created_workspace_path, level=2)
 
         # Generated python script name without .py extension
         self.script_name = self.script_path.name.split(".")[0].strip()
@@ -301,6 +300,7 @@ class WorkspaceExport:
             output_workspace (str): Path for the generated workspace directory.
         """
         instance = cls(notebook_path, output_workspace)
+        print_tree(output_workspace, level=2)
         instance.generate_requirements()
         instance.generate_plan_yaml()
         instance.generate_data_yaml()
@@ -320,6 +320,7 @@ class WorkspaceExport:
         # Create a ZIP archive of the generated_workspace directory
         arch_path = shutil.make_archive(str(archive_path), "zip", str(self.output_workspace_path))
 
+        print_tree(self.output_workspace_path, level=2)
         print(f"Archive created at {archive_path}.zip")
 
         return arch_path, self.flow_class_name
@@ -364,8 +365,8 @@ class WorkspaceExport:
         from the director workspace
 
         """
-        cols_file = self.created_workspace_path.joinpath("plan", "cols.yaml")
-        data_file = self.created_workspace_path.joinpath("plan", "data.yaml")
+        cols_file = self.output_workspace_path.joinpath("plan", "cols.yaml")
+        data_file = self.output_workspace_path.joinpath("plan", "data.yaml")
 
         if cols_file.exists():
             cols_file.unlink()


### PR DESCRIPTION
**Description**:
Current (Experimental) `FederatedRuntime` implementation uses the same workspace template as the `Aggregator-Based-Workflow,` resulting in inclusion of unnecessary files (`cols.yaml` and `data.yaml`) in the generated workspace. This PR enhances `FederatedRuntime` workspace management by introducing logic to exclude these files ensuring only essential files are retained

**Change Description**:

- Introduced `_clean_generated_workspace `method to remove un-necessary files from the director workspace

**Modifications**:

- `openfl/experimental/workflow/workspace_export/export.py`

**Validation**: 
- Successfully validated by running the `301_MNIST_Watermaking` tutorial in `openfl/openfl-tutorials/experimental/workflow/FederatedRuntime`. Verified that the generated workspace no longer includes the unwanted files

- Successfully executed the `1001_Workspace_Creation_from_JupyterNotebook.ipynb` tutorial in `openfl/openfl-tutorials/experimental/workflow/` and used `fx` commands to ensure there is no impact on `Aggregator-Based-Workflow`
