### PR TITLE
[v1.7.x] Setting ruff to working version 0.8.1

### DIFF
--- a/linters-requirements.txt
+++ b/linters-requirements.txt
@@ -1,2 +1,2 @@
 pre-commit
-ruff
+ruff==0.8.1


### PR DESCRIPTION
Cherry-picking the corresponding commit from `develop`.