### PR TITLE
Recover missing state after collaborator restart

### DIFF
--- a/openfl/component/collaborator/collaborator.py
+++ b/openfl/component/collaborator/collaborator.py
@@ -382,14 +382,16 @@ class Collaborator:
                         return nparray
                     prior_round -= 1
                 logger.info(f"Cannot find any prior version of tensor {tensor_name} locally...")
-            logger.debug(
-                "Unable to get tensor from local store..." "attempting to retrieve from client"
-            )
             # Determine whether there are additional compression related
             # dependencies.
             # Typically, dependencies are only relevant to model layers
             tensor_dependencies = self.tensor_codec.find_dependencies(
                 tensor_key, self.delta_updates
+            )
+            logger.debug(
+                "Unable to get tensor from local store..."
+                "attempting to retrieve from client len tensor_dependencies"
+                f" tensor_key {tensor_key}"
             )
             if len(tensor_dependencies) > 0:
                 # Resolve dependencies
@@ -411,15 +413,27 @@ class Collaborator:
                     self.tensor_db.cache_tensor({new_model_tk: nparray})
                 else:
                     logger.info(
-                        "Count not find previous model layer."
+                        "Could not find previous model layer."
                         "Fetching latest layer from aggregator"
                     )
-                    # The original model tensor should be fetched from client
+                    # The original model tensor should be fetched from aggregator
                     nparray = self.get_aggregated_tensor_from_aggregator(
                         tensor_key, require_lossless=True
                     )
             elif "model" in tags:
                 # Pulling the model for the first time
+                nparray = self.get_aggregated_tensor_from_aggregator(
+                    tensor_key, require_lossless=True
+                )
+            else:
+                # we should try fetching the tensor from aggregator
+                tensor_name, origin, round_number, report, tags = tensor_key
+                tags = (self.collaborator_name,) + tags
+                tensor_key = (tensor_name, origin, round_number, report, tags)
+                logger.info(
+                    "Could not find previous model layer."
+                    f"Fetching latest layer from aggregator {tensor_key}"
+                )
                 nparray = self.get_aggregated_tensor_from_aggregator(
                     tensor_key, require_lossless=True
                 )

--- a/openfl/federated/task/runner_keras.py
+++ b/openfl/federated/task/runner_keras.py
@@ -182,7 +182,16 @@ class KerasTaskRunner(TaskRunner):
         #  initialization (build_model).
         #  If metrics are added (i.e. not a subset of what was originally
         #  defined) then the model must be recompiled.
-        results = self.model.get_metrics_result()
+        try:
+            results = self.model.get_metrics_result()
+        except ValueError:
+            if "batch_size" in kwargs:
+                batch_size = kwargs["batch_size"]
+            else:
+                batch_size = 1
+            # evaluation needed before metrics can be resolved
+            self.model.evaluate(self.data_loader.get_valid_loader(batch_size), verbose=1)
+            results = self.model.get_metrics_result()
 
         # TODO if there are new metrics in the flplan that were not included
         #  in the originally


### PR DESCRIPTION
After restart the collaborator gets a list of tasks that it needs to finish as part of the current round, that list might be partial as it already executed some tasks prior the restart, previous tasks might have generated state that is needed for the future tasks of this round.
This PR recover or initialized the state of previous tasks enabling the collaborator to resume the execution of the current round.

https://jira.devtools.intel.com/browse/FEDAI-1229

