### PR TITLE
Restrict openfl_container_image_workflow on approved branches

### DIFF
--- a/.github/workflows/openfl-docker-build.yml
+++ b/.github/workflows/openfl-docker-build.yml
@@ -13,7 +13,7 @@ on:
         default: 'latest'
 
 env:
-  VERSION: ${{ github.ref == 'refs/heads/develop' && 'latest' || '1.7' }}
+  DEFAULT_VERSION: ${{ github.ref == 'refs/heads/develop' && 'latest' || '1.7' }}
 
 permissions:
   contents: read
@@ -36,6 +36,9 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Determine Image Tag
+      run: echo "IMAGE_TAG=${{ github.event.inputs.version || env.DEFAULT_VERSION }}" >> $GITHUB_ENV
 
     - name: Build and Push OpenFL Base Image
       uses: docker/build-push-action@v4
@@ -44,4 +47,4 @@ jobs:
         file: openfl-docker/Dockerfile.base
         push: true
         tags: |
-          ghcr.io/${{ github.repository }}/openfl:${{ env.VERSION }}
+          ghcr.io/${{ github.repository }}/openfl:${{ env.IMAGE_TAG }}

--- a/.github/workflows/openfl-docker-build.yml
+++ b/.github/workflows/openfl-docker-build.yml
@@ -44,4 +44,4 @@ jobs:
         file: openfl-docker/Dockerfile.base
         push: true
         tags: |
-          ghcr.io/${{ github.repository }}/openfl:${{ github.event.inputs.version || 'latest' }}
+          ghcr.io/${{ github.repository }}/openfl:${{ env.VERSION }}

--- a/.github/workflows/openfl-docker-build.yml
+++ b/.github/workflows/openfl-docker-build.yml
@@ -13,7 +13,10 @@ on:
         default: 'latest'
 
 env:
-  DEFAULT_VERSION: ${{ github.ref == 'refs/heads/develop' && 'latest' || '1.7' }}
+  DEFAULT_VERSION: ${{ 
+    github.ref == 'refs/heads/develop' && 'latest' || 
+    github.ref == 'refs/heads/v1.7.x' && '1.7' || 
+    'fail' }}
 
 permissions:
   contents: read
@@ -24,6 +27,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:      
+    - name: Fail if invalid branch
+      if: env.DEFAULT_VERSION == 'fail'
+      run: |
+        echo "Invalid branch. The workflow only supports 'develop' or 'v1.7.x'."
+        exit 1
+
     - name: Checkout code
       uses: actions/checkout@v3
 


### PR DESCRIPTION
This PR introduces few changes  to .github/workflows/openfl-docker-build.yml. The workflow is designed to build the OpenFL project as a Docker container image and publish it to the GitHub Container Registry (GHCR).

Supported Branches: The workflow supports building images for the following branches:
develop (tags the image as latest).
v1.7.x (tags the image as 1.7).
For any other branches, the workflow will fail with an appropriate message.

