### PR TITLE
TaskRunner E2E: Parameterised input and coverity fix

### DIFF
--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -5,42 +5,42 @@ name: Task_Runner_E2E  # Please do not modify the name as it is used in the comp
 
 on:
   schedule:
-    - cron: '0 0 * * *' # Run every day at midnight
+    - cron: "0 0 * * *" # Run every day at midnight
   workflow_dispatch:
     inputs:
       num_rounds:
-        description: 'Number of rounds to train'
+        description: "Number of rounds to train"
         required: false
-        default: '5'
+        default: "5"
         type: string
       num_collaborators:
-        description: 'Number of collaborators'
+        description: "Number of collaborators"
         required: false
-        default: '2'
+        default: "2"
         type: string
       model_name:
-        description: 'Model name'
+        description: "Model name"
         required: false
-        default: 'all'
+        default: "all"
         type: choice
         options:
           - all
           - torch_cnn_mnist
           - keras_cnn_mnist
       python_version:
-        description: 'Python version'
+        description: "Python version"
         required: false
-        default: 'all'
+        default: "all"
         type: choice
         options:
           - all
-          - '3.10'
-          - '3.11'
-          - '3.12'
+          - "3.10"
+          - "3.11"
+          - "3.12"
       jobs_to_run:
-        description: 'Jobs to run'
+        description: "Jobs to run"
         type: choice
-        default: 'all'
+        default: "all"
         options:
           - all
           - test_with_tls
@@ -139,7 +139,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 2 # needed for detecting changes
-          submodules: 'true'
+          submodules: "true"
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pre test run
@@ -152,13 +152,13 @@ jobs:
           python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
           -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
           --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
-          echo 'Task runner end to end test run completed'
+          echo "Task runner end to end test run completed"
 
       - name: Post test run
         uses: ./.github/actions/tr_post_test_run
         if: ${{ always() }}
         with:
-          test_type: 'tr_tls'
+          test_type: "tr_tls"
 
   test_with_non_tls:
     name: Test without TLS
@@ -182,7 +182,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 2 # needed for detecting changes
-          submodules: 'true'
+          submodules: "true"
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pre test run
@@ -195,13 +195,13 @@ jobs:
           python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
           -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
           --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_tls
-          echo 'Task runner end to end test run completed'
+          echo "Task runner end to end test run completed"
 
       - name: Post test run
         uses: ./.github/actions/tr_post_test_run
         if: ${{ always() }}
         with:
-          test_type: 'tr_non_tls'
+          test_type: "tr_non_tls"
 
   test_with_no_client_auth:
     name: Test without client auth
@@ -225,7 +225,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 2 # needed for detecting changes
-          submodules: 'true'
+          submodules: "true"
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pre test run
@@ -238,7 +238,7 @@ jobs:
           python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
           -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
           --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_client_auth
-          echo 'Task runner end to end test run completed'
+          echo "Task runner end to end test run completed"
 
       - name: Post test run
         uses: ./.github/actions/tr_post_test_run
@@ -268,7 +268,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 2 # needed for detecting changes
-          submodules: 'true'
+          submodules: "true"
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pre test run
@@ -282,10 +282,10 @@ jobs:
           -k test_log_memory_usage_basic --model_name ${{ env.MODEL_NAME }} \
           --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} \
           --log_memory_usage
-          echo 'Task runner memory logs test run completed'
+          echo "Task runner memory logs test run completed"
 
       - name: Post test run
         uses: ./.github/actions/tr_post_test_run
         if: ${{ always() }}
         with:
-          test_type: 'tr_tls_memory_logs'
+          test_type: "tr_tls_memory_logs"

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -124,16 +124,16 @@ jobs:
           echo "Selected jobs: ${{ steps.input_value_selection.outputs.jobs_to_run }}" >> $GITHUB_STEP_SUMMARY
           echo "| Job | Model | Python Version |" >> $GITHUB_STEP_SUMMARY
           echo "| ---- | ---- | ---- |" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ env.JOBS_TO_RUN }}" == 'all' || "${{ env.JOBS_TO_RUN }}" == "test_with_tls" ]; then
+          if [ "${{ steps.input_value_selection.outputs.jobs_to_run }}" == 'all' || "${{ steps.input_value_selection.outputs.jobs_to_run }}" == "test_with_tls" ]; then
             echo "| Test with TLS | ${{ steps.input_value_selection.outputs.models_for_tls }} | ${{ steps.input_value_selection.outputs.python_for_tls }} |" >> $GITHUB_STEP_SUMMARY
             fi
-          if [ "${{ env.JOBS_TO_RUN }}" == 'all' || "${{ env.JOBS_TO_RUN }}" == "test_with_non_tls" ]; then
+          if [ "${{ steps.input_value_selection.outputs.jobs_to_run }}" == 'all' || "${{ steps.input_value_selection.outputs.jobs_to_run }}" == "test_with_non_tls" ]; then
             echo "| Test without TLS | ${{ steps.input_value_selection.outputs.models_for_non_tls }} | ${{ steps.input_value_selection.outputs.python_for_non_tls }} |" >> $GITHUB_STEP_SUMMARY
           fi
-          if [ "${{ env.JOBS_TO_RUN }}" == 'all' || "${{ env.JOBS_TO_RUN }}" == "test_with_no_client_auth" ]; then
+          if [ "${{ steps.input_value_selection.outputs.jobs_to_run }}" == 'all' || "${{ steps.input_value_selection.outputs.jobs_to_run }}" == "test_with_no_client_auth" ]; then
             echo "| Test without client auth | ${{ steps.input_value_selection.outputs.models_for_no_client_auth }} | ${{ steps.input_value_selection.outputs.python_for_no_client_auth }} |" >> $GITHUB_STEP_SUMMARY
           fi
-          if [ "${{ env.JOBS_TO_RUN }}" == 'all' || "${{ env.JOBS_TO_RUN }}" == "test_memory_logs" ]; then
+          if [ "${{ steps.input_value_selection.outputs.jobs_to_run }}" == 'all' || "${{ steps.input_value_selection.outputs.jobs_to_run }}" == "test_memory_logs" ]; then
             echo "| Test memory logs | ${{ steps.input_value_selection.outputs.models_for_memory_logs }} | ${{ steps.input_value_selection.outputs.python_for_memory_logs }} |" >> $GITHUB_STEP_SUMMARY
           fi
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -89,6 +89,7 @@ jobs:
       - name: Run Task Runner E2E tests with TLS
         id: run_tests
         run: |
+          echo ${{ needs.initial_job.outputs.jobs_to_run }}
           python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
           -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
           --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
@@ -134,6 +135,7 @@ jobs:
       - name: Run Task Runner E2E tests without TLS
         id: run_tests
         run: |
+          echo ${{ needs.initial_job.outputs.jobs_to_run }}
           python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
           -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
           --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_tls
@@ -179,6 +181,7 @@ jobs:
       - name: Run Task Runner E2E tests without TLS
         id: run_tests
         run: |
+          echo ${{ needs.initial_job.outputs.jobs_to_run }}
           python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
           -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
           --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_client_auth
@@ -224,6 +227,7 @@ jobs:
       - name: Run Task Runner E2E tests with TLS and memory logs
         id: run_tests
         run: |
+          echo ${{ needs.initial_job.outputs.jobs_to_run }}
           python -m pytest -s tests/end_to_end/test_suites/memory_logs_tests.py \
           -k test_log_memory_usage_basic --model_name ${{ env.MODEL_NAME }} \
           --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} \

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -124,6 +124,15 @@ jobs:
           if [ "${{ steps.input_selection.outputs.jobs_to_run }}" == "all" ] || [ "${{ steps.input_selection.outputs.jobs_to_run }}" == "test_with_tls" ]; then
             echo "| Test with TLS | ${{ steps.input_selection.outputs.models_for_tls }} | ${{ steps.input_selection.outputs.python_for_tls }} |" >> $GITHUB_STEP_SUMMARY
           fi
+          if [ "${{ steps.input_selection.outputs.jobs_to_run }}" == "all" ] || [ "${{ steps.input_selection.outputs.jobs_to_run }}" == "test_with_non_tls" ]; then
+            echo "| Test without TLS | ${{ steps.input_selection.outputs.models_for_non_tls }} | ${{ steps.input_selection.outputs.python_for_non_tls }} |" >> $GITHUB_STEP_SUMMARY
+          fi
+          if [ "${{ steps.input_selection.outputs.jobs_to_run }}" == "all" ] || [ "${{ steps.input_selection.outputs.jobs_to_run }}" == "test_with_no_client_auth" ]; then
+            echo "| Test without client auth | ${{ steps.input_selection.outputs.models_for_no_client_auth }} | ${{ steps.input_selection.outputs.python_for_no_client_auth }} |" >> $GITHUB_STEP_SUMMARY
+          fi
+          if [ "${{ steps.input_selection.outputs.jobs_to_run }}" == "all" ] || [ "${{ steps.input_selection.outputs.jobs_to_run }}" == "test_memory_logs" ]; then
+            echo "| Test memory logs | ${{ steps.input_selection.outputs.models_for_memory_logs }} | ${{ steps.input_selection.outputs.python_for_memory_logs }} |" >> $GITHUB_STEP_SUMMARY
+          fi
           echo "" >> $GITHUB_STEP_SUMMARY
 
   test_with_tls:

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -121,7 +121,7 @@ jobs:
           echo "Selected jobs: ${{ steps.input_selection.outputs.jobs_to_run }}" >> $GITHUB_STEP_SUMMARY
           echo "| Job | Model | Python Version |" >> $GITHUB_STEP_SUMMARY
           echo "| ---- | ---- | ---- |" >> $GITHUB_STEP_SUMMARY
-          if [ ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'all' || ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'test_with_tls' ]; then
+          if [ "${{ steps.input_selection.outputs.jobs_to_run }}" == "all" || "${{ steps.input_selection.outputs.jobs_to_run }}" == "test_with_tls" ]; then
             echo "| Test with TLS | ${{ steps.input_selection.outputs.models_for_tls }} | ${{ steps.input_selection.outputs.python_for_tls }} |" >> $GITHUB_STEP_SUMMARY
           fi
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -215,7 +215,7 @@ jobs:
           test_type: "tr_non_tls"
 
   test_with_no_client_auth:
-    name: Test without client authentication
+    name: Test without client auth
     needs: input_value_selection
     if: needs.input_value_selection.outputs.selected_jobs == 'all' || needs.input_value_selection.outputs.selected_jobs == 'test_with_no_client_auth'
     runs-on: ubuntu-22.04

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -121,7 +121,7 @@ jobs:
           echo "Selected jobs: ${{ steps.input_selection.outputs.jobs_to_run }}" >> $GITHUB_STEP_SUMMARY
           echo "| Job | Model | Python Version |" >> $GITHUB_STEP_SUMMARY
           echo "| ---- | ---- | ---- |" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ steps.input_selection.outputs.jobs_to_run }}" == "all" || "${{ steps.input_selection.outputs.jobs_to_run }}" == "test_with_tls" ]; then
+          if [ "${{ steps.input_selection.outputs.jobs_to_run }}" == "all" ] || [ "${{ steps.input_selection.outputs.jobs_to_run }}" == "test_with_tls" ]; then
             echo "| Test with TLS | ${{ steps.input_selection.outputs.models_for_tls }} | ${{ steps.input_selection.outputs.python_for_tls }} |" >> $GITHUB_STEP_SUMMARY
           fi
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -42,7 +42,7 @@ env:
 jobs:
   test_with_tls:
     name: tr_tls
-    if: ${{ contains(env.JOBS_TO_RUN, 'all') || contains(env.JOBS_TO_RUN, 'test_with_tls') }}
+    if: ${{ env.JOBS_TO_RUN == 'all' }} || ${{ env.JOBS_TO_RUN == 'test_with_tls' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
@@ -86,7 +86,7 @@ jobs:
 
   test_with_non_tls:
     name: tr_non_tls
-    if: ${{ contains(env.JOBS_TO_RUN, 'all') || contains(env.JOBS_TO_RUN, 'test_with_non_tls') }}
+    if: ${{ env.JOBS_TO_RUN == 'all' }} || ${{ env.JOBS_TO_RUN == 'test_with_non_tls' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
@@ -130,7 +130,7 @@ jobs:
 
   test_with_no_client_auth:
     name: tr_no_client_auth
-    if: ${{ contains(env.JOBS_TO_RUN, 'all') || contains(env.JOBS_TO_RUN, 'test_with_no_client_auth') }}
+    if: ${{ env.JOBS_TO_RUN == 'all' }} || ${{ env.JOBS_TO_RUN == 'test_with_no_client_auth' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
@@ -174,7 +174,7 @@ jobs:
 
   test_memory_logs:
     name: tr_tls_memory_logs
-    if: ${{ contains(env.JOBS_TO_RUN, 'all') || contains(env.JOBS_TO_RUN, 'test_memory_logs') }}
+    if: ${{ env.JOBS_TO_RUN == 'all' }} || ${{ env.JOBS_TO_RUN == 'test_memory_logs' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -146,8 +146,8 @@ jobs:
       matrix:
         # Testing this scenario only for torch_cnn_mnist model and python 3.10
         # If required, this can be extended to other models and python versions
-        model_name: ${{ needs.input_value_selection.outputs.selected_models == 'all' && ['torch_cnn_mnist'] || needs.input_value_selection.outputs.selected_models }}
-        python_version: ${{ needs.input_value_selection.outputs.selected_python_versions == 'all' && ['3.10'] || needs.input_value_selection.outputs.selected_python_versions }}
+        model_name: ${{ needs.input_value_selection.outputs.selected_models == 'all' && [\'torch_cnn_mnist\'] || needs.input_value_selection.outputs.selected_models }}
+        python_version: ${{ needs.input_value_selection.outputs.selected_python_versions == 'all' && [\'3.10\'] || needs.input_value_selection.outputs.selected_python_versions }}
       fail-fast: false # do not immediately fail if one of the combinations fail
 
     env:
@@ -191,8 +191,8 @@ jobs:
       matrix:
         # Testing this scenario for keras_cnn_mnist model and python 3.10
         # If required, this can be extended to other models and python versions
-        model_name: ${{ needs.input_value_selection.outputs.selected_models == 'all' && ['keras_cnn_mnist'] || needs.input_value_selection.outputs.selected_models }}
-        python_version: ${{ needs.input_value_selection.outputs.selected_python_versions == 'all' && ['3.10'] || needs.input_value_selection.outputs.selected_python_versions }}
+        model_name: ${{ needs.input_value_selection.outputs.selected_models == 'all' && [\'keras_cnn_mnist\'] || needs.input_value_selection.outputs.selected_models }}
+        python_version: ${{ needs.input_value_selection.outputs.selected_python_versions == 'all' && [\'3.10\'] || needs.input_value_selection.outputs.selected_python_versions }}
       fail-fast: false # do not immediately fail if one of the combinations fail
 
     env:
@@ -236,8 +236,8 @@ jobs:
       matrix:
         # Testing this scenario only for torch_cnn_mnist model and python 3.10
         # If required, this can be extended to other models and python versions
-        model_name: ${{ needs.input_value_selection.outputs.selected_models == 'all' && ['torch_cnn_mnist'] || needs.input_value_selection.outputs.selected_models }}
-        python_version: ${{ needs.input_value_selection.outputs.selected_python_versions == 'all' && ['3.10'] || needs.input_value_selection.outputs.selected_python_versions }}
+        model_name: ${{ needs.input_value_selection.outputs.selected_models == 'all' && [\'torch_cnn_mnist\'] || needs.input_value_selection.outputs.selected_models }}
+        python_version: ${{ needs.input_value_selection.outputs.selected_python_versions == 'all' && [\'3.10\'] || needs.input_value_selection.outputs.selected_python_versions }}
       fail-fast: false # do not immediately fail if one of the combinations fail
 
     env:

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -18,6 +18,17 @@ on:
         required: false
         default: "2"
         type: string
+      jobs_to_run:
+        description: "Jobs to run"
+        type: choice
+        default: "all"
+        options:
+          - all
+          - test_with_tls
+          - test_with_non_tls
+          - test_with_no_client_auth
+          - test_memory_logs
+        required: false
 
 permissions:
   contents: read
@@ -26,10 +37,12 @@ permissions:
 env:
   NUM_ROUNDS: ${{ inputs.num_rounds || '5' }}
   NUM_COLLABORATORS: ${{ inputs.num_collaborators || '2' }}
+  JOBS_TO_RUN: ${{ inputs.jobs_to_run || 'all' }}
 
 jobs:
   test_with_tls:
     name: tr_tls
+    if: ${{ contains(env.JOBS_TO_RUN, 'all') || contains(env.JOBS_TO_RUN, 'test_with_tls') }}
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
@@ -73,6 +86,7 @@ jobs:
 
   test_with_non_tls:
     name: tr_non_tls
+    if: ${{ contains(env.JOBS_TO_RUN, 'all') || contains(env.JOBS_TO_RUN, 'test_with_non_tls') }}
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
@@ -116,6 +130,7 @@ jobs:
 
   test_with_no_client_auth:
     name: tr_no_client_auth
+    if: ${{ contains(env.JOBS_TO_RUN, 'all') || contains(env.JOBS_TO_RUN, 'test_with_no_client_auth') }}
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
@@ -159,6 +174,7 @@ jobs:
 
   test_memory_logs:
     name: tr_tls_memory_logs
+    if: ${{ contains(env.JOBS_TO_RUN, 'all') || contains(env.JOBS_TO_RUN, 'test_memory_logs') }}
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -125,18 +125,18 @@ jobs:
           echo ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} >> $GITHUB_STEP_SUMMARY
           echo "| Job | Model | Python Version |" >> $GITHUB_STEP_SUMMARY
           echo "| ---- | ---- | ---- |" >> $GITHUB_STEP_SUMMARY
-          if [ ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'all' || ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'test_with_tls' ]; then
-            echo "| Test with TLS | ${{ steps.input_selection.outputs.models_for_tls }} | ${{ steps.input_selection.outputs.python_for_tls }} |" >> $GITHUB_STEP_SUMMARY
-            fi
-          if [ ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'all' || ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'test_with_non_tls' ]; then
-            echo "| Test without TLS | ${{ steps.input_selection.outputs.models_for_non_tls }} | ${{ steps.input_selection.outputs.python_for_non_tls }} |" >> $GITHUB_STEP_SUMMARY
-          fi
-          if [ ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'all' || ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'test_with_no_client_auth' ]; then
-            echo "| Test without client auth | ${{ steps.input_selection.outputs.models_for_no_client_auth }} | ${{ steps.input_selection.outputs.python_for_no_client_auth }} |" >> $GITHUB_STEP_SUMMARY
-          fi
-          if [ ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'all' || ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'test_memory_logs' ]; then
-            echo "| Test memory logs | ${{ steps.input_selection.outputs.models_for_memory_logs }} | ${{ steps.input_selection.outputs.python_for_memory_logs }} |" >> $GITHUB_STEP_SUMMARY
-          fi
+          # if [ ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'all' || ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'test_with_tls' ]; then
+          #   echo "| Test with TLS | ${{ steps.input_selection.outputs.models_for_tls }} | ${{ steps.input_selection.outputs.python_for_tls }} |" >> $GITHUB_STEP_SUMMARY
+          #   fi
+          # if [ ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'all' || ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'test_with_non_tls' ]; then
+          #   echo "| Test without TLS | ${{ steps.input_selection.outputs.models_for_non_tls }} | ${{ steps.input_selection.outputs.python_for_non_tls }} |" >> $GITHUB_STEP_SUMMARY
+          # fi
+          # if [ ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'all' || ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'test_with_no_client_auth' ]; then
+          #   echo "| Test without client auth | ${{ steps.input_selection.outputs.models_for_no_client_auth }} | ${{ steps.input_selection.outputs.python_for_no_client_auth }} |" >> $GITHUB_STEP_SUMMARY
+          # fi
+          # if [ ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'all' || ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'test_memory_logs' ]; then
+          #   echo "| Test memory logs | ${{ steps.input_selection.outputs.models_for_memory_logs }} | ${{ steps.input_selection.outputs.python_for_memory_logs }} |" >> $GITHUB_STEP_SUMMARY
+          # fi
           echo "" >> $GITHUB_STEP_SUMMARY
 
   test_with_tls:

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -118,8 +118,7 @@ jobs:
       - name: Print output values
         id: print_output_values
         run: |
-          echo "Selected jobs: ${{ steps.input_selection.outputs.jobs_to_run }}" >> $GITHUB_STEP_SUMMARY
-          echo "| Job | Model | Python Version |" >> $GITHUB_STEP_SUMMARY
+          echo "| Selected job(s) | Model(s) | Python version(s) |" >> $GITHUB_STEP_SUMMARY
           echo "| ---- | ---- | ---- |" >> $GITHUB_STEP_SUMMARY
           if [ "${{ steps.input_selection.outputs.jobs_to_run }}" == "all" ] || [ "${{ steps.input_selection.outputs.jobs_to_run }}" == "test_with_tls" ]; then
             echo "| Test with TLS | ${{ steps.input_selection.outputs.models_for_tls }} | ${{ steps.input_selection.outputs.python_for_tls }} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -84,11 +84,11 @@ jobs:
           # ---------------------------------------------------------------
           # Models like XGBoost (xgb_higgs) and torch_cnn_histology require runners with higher memory and CPU to run.
           # Thus these models are excluded from the matrix for now.
-          # Below combinations will be used by default if no input is provided.
-          # TLS - models [torch_cnn_mnist, keras_cnn_mnist] and python versions [3.10, 3.11, 3.12]
-          # Non-TLS - models [torch_cnn_mnist] and python version [3.10]
-          # No client auth - models [keras_cnn_mnist] and python version [3.10]
-          # Memory logs - models [torch_cnn_mnist] and python version [3.10]
+          # Default combination if no input is provided.
+          # * TLS - models [torch_cnn_mnist, keras_cnn_mnist] and python versions [3.10, 3.11, 3.12]
+          # * Non-TLS - models [torch_cnn_mnist] and python version [3.10]
+          # * No client auth - models [keras_cnn_mnist] and python version [3.10]
+          # * Memory logs - models [torch_cnn_mnist] and python version [3.10]
           # ---------------------------------------------------------------
           echo "jobs_to_run=${{ env.JOBS_TO_RUN }}" >> "$GITHUB_OUTPUT"
 
@@ -121,6 +121,9 @@ jobs:
           echo "Selected jobs: ${{ steps.input_selection.outputs.jobs_to_run }}" >> $GITHUB_STEP_SUMMARY
           echo "| Job | Model | Python Version |" >> $GITHUB_STEP_SUMMARY
           echo "| ---- | ---- | ---- |" >> $GITHUB_STEP_SUMMARY
+          if [ ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'all' || ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'test_with_tls' ]; then
+            echo "| Test with TLS | ${{ steps.input_selection.outputs.models_for_tls }} | ${{ steps.input_selection.outputs.python_for_tls }} |" >> $GITHUB_STEP_SUMMARY
+          fi
           echo "" >> $GITHUB_STEP_SUMMARY
 
   test_with_tls:

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -21,7 +21,7 @@ on:
       model_name:
         description: "Model name"
         required: false
-        default: "all"
+        default: 'all'
         type: choice
         options:
           - all
@@ -30,17 +30,17 @@ on:
       python_version:
         description: "Python version"
         required: false
-        default: "all"
+        default: 'all'
         type: choice
         options:
           - all
-          - "3.10"
+          - '3.10'
           - "3.11"
           - "3.12"
       jobs_to_run:
         description: "Jobs to run"
         type: choice
-        default: "all"
+        default: 'all'
         options:
           - all
           - test_with_tls
@@ -75,12 +75,12 @@ jobs:
       - name: Job to select input values
         id: input_value_selection
         run: |
-          if [ "${{ env.MODEL_NAME }}" == "all" ]; then
+          if [ "${{ env.MODEL_NAME }}" == 'all' ]; then
             echo "models_to_run=[\"torch_cnn_mnist\", \"keras_cnn_mnist\"]" >> "$GITHUB_OUTPUT"
           else
             echo "models_to_run=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
           fi
-          if [ "${{ env.PYTHON_VERSION }}" == "all" ]; then
+          if [ "${{ env.PYTHON_VERSION }}" == 'all' ]; then
             echo "python_versions_to_run=[\"3.10\", \"3.11\", \"3.12\"]" >> "$GITHUB_OUTPUT"
           else
             echo "python_versions_to_run=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
@@ -146,8 +146,8 @@ jobs:
       matrix:
         # Testing this scenario only for torch_cnn_mnist model and python 3.10
         # If required, this can be extended to other models and python versions
-        model_name: ${{ needs.input_value_selection.outputs.selected_models == "all" && ["torch_cnn_mnist"] || needs.input_value_selection.outputs.selected_models }}
-        python_version: ${{ needs.input_value_selection.outputs.selected_python_versions == "all" && ["3.10"] || needs.input_value_selection.outputs.selected_python_versions }}
+        model_name: ${{ needs.input_value_selection.outputs.selected_models == 'all' && ['torch_cnn_mnist'] || needs.input_value_selection.outputs.selected_models }}
+        python_version: ${{ needs.input_value_selection.outputs.selected_python_versions == 'all' && ['3.10'] || needs.input_value_selection.outputs.selected_python_versions }}
       fail-fast: false # do not immediately fail if one of the combinations fail
 
     env:
@@ -191,8 +191,8 @@ jobs:
       matrix:
         # Testing this scenario for keras_cnn_mnist model and python 3.10
         # If required, this can be extended to other models and python versions
-        model_name: ${{ needs.input_value_selection.outputs.selected_models == "all" && ["keras_cnn_mnist"] || needs.input_value_selection.outputs.selected_models }}
-        python_version: ${{ needs.input_value_selection.outputs.selected_python_versions == "all" && ["3.10"] || needs.input_value_selection.outputs.selected_python_versions }}
+        model_name: ${{ needs.input_value_selection.outputs.selected_models == 'all' && ['keras_cnn_mnist'] || needs.input_value_selection.outputs.selected_models }}
+        python_version: ${{ needs.input_value_selection.outputs.selected_python_versions == 'all' && ['3.10'] || needs.input_value_selection.outputs.selected_python_versions }}
       fail-fast: false # do not immediately fail if one of the combinations fail
 
     env:
@@ -236,8 +236,8 @@ jobs:
       matrix:
         # Testing this scenario only for torch_cnn_mnist model and python 3.10
         # If required, this can be extended to other models and python versions
-        model_name: ${{ needs.input_value_selection.outputs.selected_models == "all" && ["torch_cnn_mnist"] || needs.input_value_selection.outputs.selected_models }}
-        python_version: ${{ needs.input_value_selection.outputs.selected_python_versions == "all" && ["3.10"] || needs.input_value_selection.outputs.selected_python_versions }}
+        model_name: ${{ needs.input_value_selection.outputs.selected_models == 'all' && ['torch_cnn_mnist'] || needs.input_value_selection.outputs.selected_models }}
+        python_version: ${{ needs.input_value_selection.outputs.selected_python_versions == 'all' && ['3.10'] || needs.input_value_selection.outputs.selected_python_versions }}
       fail-fast: false # do not immediately fail if one of the combinations fail
 
     env:

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -61,25 +61,25 @@ env:
   JOBS_TO_RUN: ${{ inputs.jobs_to_run || 'all' }}
 
 jobs:
-  input_value_selection:
+  input_selection:
     if: |
       (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
       (github.event_name == 'workflow_dispatch')
     name: Input value selection
     runs-on: ubuntu-22.04
     outputs:
-      selected_jobs: ${{ steps.input_value_selection.outputs.jobs_to_run }}
-      selected_models_for_tls: ${{ steps.input_value_selection.outputs.models_for_tls }}
-      selected_python_for_tls: ${{ steps.input_value_selection.outputs.python_for_tls }}
-      selected_models_for_non_tls: ${{ steps.input_value_selection.outputs.models_for_non_tls }}
-      selected_models_for_no_client_auth: ${{ steps.input_value_selection.outputs.models_for_no_client_auth }}
-      selected_models_for_memory_logs: ${{ steps.input_value_selection.outputs.models_for_memory_logs }}
-      selected_python_for_non_tls: ${{ steps.input_value_selection.outputs.python_for_non_tls }}
-      selected_python_for_no_client_auth: ${{ steps.input_value_selection.outputs.python_for_no_client_auth }}
-      selected_python_for_memory_logs: ${{ steps.input_value_selection.outputs.python_for_memory_logs }}
+      selected_jobs: ${{ steps.input_selection.outputs.jobs_to_run }}
+      selected_models_for_tls: ${{ steps.input_selection.outputs.models_for_tls }}
+      selected_python_for_tls: ${{ steps.input_selection.outputs.python_for_tls }}
+      selected_models_for_non_tls: ${{ steps.input_selection.outputs.models_for_non_tls }}
+      selected_models_for_no_client_auth: ${{ steps.input_selection.outputs.models_for_no_client_auth }}
+      selected_models_for_memory_logs: ${{ steps.input_selection.outputs.models_for_memory_logs }}
+      selected_python_for_non_tls: ${{ steps.input_selection.outputs.python_for_non_tls }}
+      selected_python_for_no_client_auth: ${{ steps.input_selection.outputs.python_for_no_client_auth }}
+      selected_python_for_memory_logs: ${{ steps.input_selection.outputs.python_for_memory_logs }}
     steps:
       - name: Job to select input values
-        id: input_value_selection
+        id: input_selection
         run: |
           # ---------------------------------------------------------------
           # Models like XGBoost (xgb_higgs) and torch_cnn_histology require runners with higher memory and CPU to run.
@@ -121,33 +121,33 @@ jobs:
           # ---------------------------------------------------------------
           # Print the selected values as a summary for better visibility
           # ---------------------------------------------------------------
-          echo "Selected jobs: ${{ steps.input_value_selection.outputs.jobs_to_run }}" >> $GITHUB_STEP_SUMMARY
+          echo "Selected jobs: ${{ steps.input_selection.outputs.jobs_to_run }}" >> $GITHUB_STEP_SUMMARY
           echo "| Job | Model | Python Version |" >> $GITHUB_STEP_SUMMARY
           echo "| ---- | ---- | ---- |" >> $GITHUB_STEP_SUMMARY
-          if [ steps.input_value_selection.outputs.jobs_to_run == 'all' || steps.input_value_selection.outputs.jobs_to_run == 'test_with_tls' ]; then
-            echo "| Test with TLS | ${{ steps.input_value_selection.outputs.models_for_tls }} | ${{ steps.input_value_selection.outputs.python_for_tls }} |" >> $GITHUB_STEP_SUMMARY
+          if [ ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'all' || ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'test_with_tls' ]; then
+            echo "| Test with TLS | ${{ steps.input_selection.outputs.models_for_tls }} | ${{ steps.input_selection.outputs.python_for_tls }} |" >> $GITHUB_STEP_SUMMARY
             fi
-          if [ steps.input_value_selection.outputs.jobs_to_run == 'all' || steps.input_value_selection.outputs.jobs_to_run == 'test_with_non_tls' ]; then
-            echo "| Test without TLS | ${{ steps.input_value_selection.outputs.models_for_non_tls }} | ${{ steps.input_value_selection.outputs.python_for_non_tls }} |" >> $GITHUB_STEP_SUMMARY
+          if [ ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'all' || ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'test_with_non_tls' ]; then
+            echo "| Test without TLS | ${{ steps.input_selection.outputs.models_for_non_tls }} | ${{ steps.input_selection.outputs.python_for_non_tls }} |" >> $GITHUB_STEP_SUMMARY
           fi
-          if [ steps.input_value_selection.outputs.jobs_to_run == 'all' || steps.input_value_selection.outputs.jobs_to_run == 'test_with_no_client_auth' ]; then
-            echo "| Test without client auth | ${{ steps.input_value_selection.outputs.models_for_no_client_auth }} | ${{ steps.input_value_selection.outputs.python_for_no_client_auth }} |" >> $GITHUB_STEP_SUMMARY
+          if [ ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'all' || ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'test_with_no_client_auth' ]; then
+            echo "| Test without client auth | ${{ steps.input_selection.outputs.models_for_no_client_auth }} | ${{ steps.input_selection.outputs.python_for_no_client_auth }} |" >> $GITHUB_STEP_SUMMARY
           fi
-          if [ steps.input_value_selection.outputs.jobs_to_run == 'all' || steps.input_value_selection.outputs.jobs_to_run == 'test_memory_logs' ]; then
-            echo "| Test memory logs | ${{ steps.input_value_selection.outputs.models_for_memory_logs }} | ${{ steps.input_value_selection.outputs.python_for_memory_logs }} |" >> $GITHUB_STEP_SUMMARY
+          if [ ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'all' || ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'test_memory_logs' ]; then
+            echo "| Test memory logs | ${{ steps.input_selection.outputs.models_for_memory_logs }} | ${{ steps.input_selection.outputs.python_for_memory_logs }} |" >> $GITHUB_STEP_SUMMARY
           fi
           echo "" >> $GITHUB_STEP_SUMMARY
 
   test_with_tls:
     name: Test with TLS
-    needs: input_value_selection
-    if: needs.input_value_selection.outputs.selected_jobs == 'all' || needs.input_value_selection.outputs.selected_jobs == 'test_with_tls'
+    needs: input_selection
+    if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_with_tls'
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
       matrix:
-        model_name: ${{ fromJson(needs.input_value_selection.outputs.selected_models_for_tls) }}
-        python_version: ${{ fromJson(needs.input_value_selection.outputs.selected_python_for_tls) }}
+        model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_tls) }}
+        python_version: ${{ fromJson(needs.input_selection.outputs.selected_python_for_tls) }}
       fail-fast: false # do not immediately fail if one of the combinations fail
 
     env:
@@ -183,14 +183,14 @@ jobs:
 
   test_with_non_tls:
     name: Test without TLS
-    needs: input_value_selection
-    if: needs.input_value_selection.outputs.selected_jobs == 'all' || needs.input_value_selection.outputs.selected_jobs == 'test_with_non_tls'
+    needs: input_selection
+    if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_with_non_tls'
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
       matrix:
-        model_name: ${{ fromJson(needs.input_value_selection.outputs.selected_models_for_non_tls) }}
-        python_version: ${{ fromJson(needs.input_value_selection.outputs.selected_python_for_non_tls) }}
+        model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_non_tls) }}
+        python_version: ${{ fromJson(needs.input_selection.outputs.selected_python_for_non_tls) }}
       fail-fast: false # do not immediately fail if one of the combinations fail
 
     env:
@@ -226,14 +226,14 @@ jobs:
 
   test_with_no_client_auth:
     name: Test without client auth
-    needs: input_value_selection
-    if: needs.input_value_selection.outputs.selected_jobs == 'all' || needs.input_value_selection.outputs.selected_jobs == 'test_with_no_client_auth'
+    needs: input_selection
+    if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_with_no_client_auth'
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
       matrix:
-        model_name: ${{ fromJson(needs.input_value_selection.outputs.selected_models_for_no_client_auth) }}
-        python_version: ${{ fromJson(needs.input_value_selection.outputs.selected_python_for_no_client_auth) }}
+        model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_no_client_auth) }}
+        python_version: ${{ fromJson(needs.input_selection.outputs.selected_python_for_no_client_auth) }}
       fail-fast: false # do not immediately fail if one of the combinations fail
 
     env:
@@ -269,14 +269,14 @@ jobs:
 
   test_memory_logs:
     name: Test memory usage
-    needs: input_value_selection
-    if: needs.input_value_selection.outputs.selected_jobs == 'all' || needs.input_value_selection.outputs.selected_jobs == 'test_memory_logs'
+    needs: input_selection
+    if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_memory_logs'
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
       matrix:
-        model_name: ${{ fromJson(needs.input_value_selection.outputs.selected_models_for_memory_logs) }}
-        python_version: ${{ fromJson(needs.input_value_selection.outputs.selected_python_for_memory_logs) }}
+        model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_memory_logs) }}
+        python_version: ${{ fromJson(needs.input_selection.outputs.selected_python_for_memory_logs) }}
       fail-fast: false # do not immediately fail if one of the combinations fail
 
     env:

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -114,6 +114,8 @@ jobs:
           fi
           echo "jobs_to_run=${{ env.JOBS_TO_RUN }}" >> "$GITHUB_OUTPUT"
 
+      - name: Print output values
+        run: |
           # ---------------------------------------------------------------
           # Print the selected values as a summary for better visibility
           # ---------------------------------------------------------------

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -58,7 +58,7 @@ jobs:
   test_with_tls:
     name: tr_tls
     needs: initial_job
-    if: ${{ needs.initial_job.outputs.jobs_to_run == 'all' }} || ${{ needs.initial_job.outputs.jobs_to_run == 'test_with_tls' }}
+    if: needs.initial_job.outputs.jobs_to_run == 'all' || needs.initial_job.outputs.jobs_to_run == 'test_with_tls'
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
@@ -104,7 +104,7 @@ jobs:
   test_with_non_tls:
     name: tr_non_tls
     needs: initial_job
-    if: ${{ needs.initial_job.outputs.jobs_to_run == 'all' }} || ${{ needs.initial_job.outputs.jobs_to_run == 'test_with_non_tls' }}
+    if: needs.initial_job.outputs.jobs_to_run == 'all' || needs.initial_job.outputs.jobs_to_run == 'test_with_non_tls'
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
@@ -150,7 +150,7 @@ jobs:
   test_with_no_client_auth:
     name: tr_no_client_auth
     needs: initial_job
-    if: ${{ needs.initial_job.outputs.jobs_to_run == 'all' }} || ${{ needs.initial_job.outputs.jobs_to_run == 'test_with_no_client_auth' }}
+    if: needs.initial_job.outputs.jobs_to_run == 'all' || needs.initial_job.outputs.jobs_to_run == 'test_with_no_client_auth'
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
@@ -196,7 +196,7 @@ jobs:
   test_memory_logs:
     name: tr_tls_memory_logs
     needs: initial_job
-    if: ${{ needs.initial_job.outputs.jobs_to_run == 'all' }} || ${{ needs.initial_job.outputs.jobs_to_run == 'test_memory_logs' }}
+    if: needs.initial_job.outputs.jobs_to_run == 'all' || needs.initial_job.outputs.jobs_to_run == 'test_memory_logs'
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -115,25 +115,6 @@ jobs:
             echo "python_for_memory_logs=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Print output values
-        id: print_output_values
-        run: |
-          echo "| Selected job(s) | Model(s) | Python version(s) |" >> $GITHUB_STEP_SUMMARY
-          echo "| ---- | ---- | ---- |" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ steps.input_selection.outputs.jobs_to_run }}" == "all" ] || [ "${{ steps.input_selection.outputs.jobs_to_run }}" == "test_with_tls" ]; then
-            echo "| Test with TLS | ${{ steps.input_selection.outputs.models_for_tls }} | ${{ steps.input_selection.outputs.python_for_tls }} |" >> $GITHUB_STEP_SUMMARY
-          fi
-          if [ "${{ steps.input_selection.outputs.jobs_to_run }}" == "all" ] || [ "${{ steps.input_selection.outputs.jobs_to_run }}" == "test_with_non_tls" ]; then
-            echo "| Test without TLS | ${{ steps.input_selection.outputs.models_for_non_tls }} | ${{ steps.input_selection.outputs.python_for_non_tls }} |" >> $GITHUB_STEP_SUMMARY
-          fi
-          if [ "${{ steps.input_selection.outputs.jobs_to_run }}" == "all" ] || [ "${{ steps.input_selection.outputs.jobs_to_run }}" == "test_with_no_client_auth" ]; then
-            echo "| Test without client auth | ${{ steps.input_selection.outputs.models_for_no_client_auth }} | ${{ steps.input_selection.outputs.python_for_no_client_auth }} |" >> $GITHUB_STEP_SUMMARY
-          fi
-          if [ "${{ steps.input_selection.outputs.jobs_to_run }}" == "all" ] || [ "${{ steps.input_selection.outputs.jobs_to_run }}" == "test_memory_logs" ]; then
-            echo "| Test memory logs | ${{ steps.input_selection.outputs.models_for_memory_logs }} | ${{ steps.input_selection.outputs.python_for_memory_logs }} |" >> $GITHUB_STEP_SUMMARY
-          fi
-          echo "" >> $GITHUB_STEP_SUMMARY
-
   test_with_tls:
     name: Test with TLS
     needs: input_selection

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -124,16 +124,16 @@ jobs:
           echo "Selected jobs: ${{ steps.input_value_selection.outputs.jobs_to_run }}" >> $GITHUB_STEP_SUMMARY
           echo "| Job | Model | Python Version |" >> $GITHUB_STEP_SUMMARY
           echo "| ---- | ---- | ---- |" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ steps.input_value_selection.outputs.jobs_to_run }}" == 'all' || "${{ steps.input_value_selection.outputs.jobs_to_run }}" == "test_with_tls" ]; then
+          if [ steps.input_value_selection.outputs.jobs_to_run == 'all' || steps.input_value_selection.outputs.jobs_to_run == 'test_with_tls' ]; then
             echo "| Test with TLS | ${{ steps.input_value_selection.outputs.models_for_tls }} | ${{ steps.input_value_selection.outputs.python_for_tls }} |" >> $GITHUB_STEP_SUMMARY
             fi
-          if [ "${{ steps.input_value_selection.outputs.jobs_to_run }}" == 'all' || "${{ steps.input_value_selection.outputs.jobs_to_run }}" == "test_with_non_tls" ]; then
+          if [ steps.input_value_selection.outputs.jobs_to_run == 'all' || steps.input_value_selection.outputs.jobs_to_run == 'test_with_non_tls' ]; then
             echo "| Test without TLS | ${{ steps.input_value_selection.outputs.models_for_non_tls }} | ${{ steps.input_value_selection.outputs.python_for_non_tls }} |" >> $GITHUB_STEP_SUMMARY
           fi
-          if [ "${{ steps.input_value_selection.outputs.jobs_to_run }}" == 'all' || "${{ steps.input_value_selection.outputs.jobs_to_run }}" == "test_with_no_client_auth" ]; then
+          if [ steps.input_value_selection.outputs.jobs_to_run == 'all' || steps.input_value_selection.outputs.jobs_to_run == 'test_with_no_client_auth' ]; then
             echo "| Test without client auth | ${{ steps.input_value_selection.outputs.models_for_no_client_auth }} | ${{ steps.input_value_selection.outputs.python_for_no_client_auth }} |" >> $GITHUB_STEP_SUMMARY
           fi
-          if [ "${{ steps.input_value_selection.outputs.jobs_to_run }}" == 'all' || "${{ steps.input_value_selection.outputs.jobs_to_run }}" == "test_memory_logs" ]; then
+          if [ steps.input_value_selection.outputs.jobs_to_run == 'all' || steps.input_value_selection.outputs.jobs_to_run == 'test_memory_logs' ]; then
             echo "| Test memory logs | ${{ steps.input_value_selection.outputs.models_for_memory_logs }} | ${{ steps.input_value_selection.outputs.python_for_memory_logs }} |" >> $GITHUB_STEP_SUMMARY
           fi
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -122,7 +122,7 @@ jobs:
           # Print the selected values as a summary for better visibility
           # ---------------------------------------------------------------
           echo "Selected jobs: ${{ steps.input_selection.outputs.jobs_to_run }}" >> $GITHUB_STEP_SUMMARY
-          echo ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} >> $GITHUB_STEP_SUMMARY
+          # echo ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} >> $GITHUB_STEP_SUMMARY
           echo "| Job | Model | Python Version |" >> $GITHUB_STEP_SUMMARY
           echo "| ---- | ---- | ---- |" >> $GITHUB_STEP_SUMMARY
           # if [ ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'all' || ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'test_with_tls' ]; then

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -54,8 +54,8 @@ permissions:
 
 # Environment variables common for all the jobs
 env:
-  NUM_ROUNDS: ${{ inputs.num_rounds || "5" }}
-  NUM_COLLABORATORS: ${{ inputs.num_collaborators || "2" }}
+  NUM_ROUNDS: ${{ inputs.num_rounds || 5 }}
+  NUM_COLLABORATORS: ${{ inputs.num_collaborators || 2 }}
   MODEL_NAME: ${{ inputs.model_name || "all" }}
   PYTHON_VERSION: ${{ inputs.python_version || "all" }}
   JOBS_TO_RUN: ${{ inputs.jobs_to_run || "all" }}

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -21,7 +21,7 @@ on:
       model_name:
         description: "Model name"
         required: false
-        default: 'all'
+        default: "all"
         type: choice
         options:
           - all
@@ -30,17 +30,17 @@ on:
       python_version:
         description: "Python version"
         required: false
-        default: 'all'
+        default: "all"
         type: choice
         options:
           - all
-          - '3.10'
+          - "3.10"
           - "3.11"
           - "3.12"
       jobs_to_run:
         description: "Jobs to run"
         type: choice
-        default: 'all'
+        default: "all"
         options:
           - all
           - test_with_tls
@@ -54,20 +54,22 @@ permissions:
 
 # Environment variables common for all the jobs
 env:
-  NUM_ROUNDS: ${{ inputs.num_rounds || '5' }}
-  NUM_COLLABORATORS: ${{ inputs.num_collaborators || '2' }}
-  MODEL_NAME: ${{ inputs.model_name || 'all' }}
-  PYTHON_VERSION: ${{ inputs.python_version || 'all' }}
-  JOBS_TO_RUN: ${{ inputs.jobs_to_run || 'all' }}
+  NUM_ROUNDS: ${{ inputs.num_rounds || "5" }}
+  NUM_COLLABORATORS: ${{ inputs.num_collaborators || "2" }}
+  MODEL_NAME: ${{ inputs.model_name || "all" }}
+  PYTHON_VERSION: ${{ inputs.python_version || "all" }}
+  JOBS_TO_RUN: ${{ inputs.jobs_to_run || "all" }}
 
 jobs:
   input_selection:
     if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
+      (github.event_name == "schedule" && github.repository_owner == "securefederatedai") ||
+      (github.event_name == "workflow_dispatch")
     name: Input value selection
     runs-on: ubuntu-22.04
     outputs:
+      # Output all the variables related to models and python versions to be used in the matrix strategy
+      # for different jobs, however their usage depends on the selected job.
       selected_jobs: ${{ steps.input_selection.outputs.jobs_to_run }}
       selected_models_for_tls: ${{ steps.input_selection.outputs.models_for_tls }}
       selected_python_for_tls: ${{ steps.input_selection.outputs.python_for_tls }}
@@ -84,7 +86,7 @@ jobs:
           # ---------------------------------------------------------------
           # Models like XGBoost (xgb_higgs) and torch_cnn_histology require runners with higher memory and CPU to run.
           # Thus these models are excluded from the matrix for now.
-          # Default combination if no input is provided.
+          # Default combination if no input is provided (i.e. "all" is selected).
           # * TLS - models [torch_cnn_mnist, keras_cnn_mnist] and python versions [3.10, 3.11, 3.12]
           # * Non-TLS - models [torch_cnn_mnist] and python version [3.10]
           # * No client auth - models [keras_cnn_mnist] and python version [3.10]
@@ -92,7 +94,7 @@ jobs:
           # ---------------------------------------------------------------
           echo "jobs_to_run=${{ env.JOBS_TO_RUN }}" >> "$GITHUB_OUTPUT"
 
-          if [ "${{ env.MODEL_NAME }}" == 'all' ]; then
+          if [ "${{ env.MODEL_NAME }}" == "all" ]; then
             echo "models_for_tls=[\"torch_cnn_mnist\", \"keras_cnn_mnist\"]" >> "$GITHUB_OUTPUT"
             echo "models_for_non_tls=[\"torch_cnn_mnist\"]" >> "$GITHUB_OUTPUT"
             echo "models_for_no_client_auth=[\"keras_cnn_mnist\"]" >> "$GITHUB_OUTPUT"
@@ -103,7 +105,7 @@ jobs:
             echo "models_for_no_client_auth=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
             echo "models_for_memory_logs=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
           fi
-          if [ "${{ env.PYTHON_VERSION }}" == 'all' ]; then
+          if [ "${{ env.PYTHON_VERSION }}" == "all" ]; then
             echo "python_for_tls=[\"3.10\", \"3.11\", \"3.12\"]" >> "$GITHUB_OUTPUT"
             echo "python_for_non_tls=[\"3.10\"]" >> "$GITHUB_OUTPUT"
             echo "python_for_no_client_auth=[\"3.10\"]" >> "$GITHUB_OUTPUT"
@@ -118,7 +120,7 @@ jobs:
   test_with_tls:
     name: Test with TLS
     needs: input_selection
-    if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_with_tls'
+    if: needs.input_selection.outputs.selected_jobs == "all" || needs.input_selection.outputs.selected_jobs == "test_with_tls"
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
@@ -161,7 +163,7 @@ jobs:
   test_with_non_tls:
     name: Test without TLS
     needs: input_selection
-    if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_with_non_tls'
+    if: needs.input_selection.outputs.selected_jobs == "all" || needs.input_selection.outputs.selected_jobs == "test_with_non_tls"
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
@@ -204,7 +206,7 @@ jobs:
   test_with_no_client_auth:
     name: Test without client auth
     needs: input_selection
-    if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_with_no_client_auth'
+    if: needs.input_selection.outputs.selected_jobs == "all" || needs.input_selection.outputs.selected_jobs == "test_with_no_client_auth"
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
@@ -247,7 +249,7 @@ jobs:
   test_memory_logs:
     name: Test memory usage
     needs: input_selection
-    if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_memory_logs'
+    if: needs.input_selection.outputs.selected_jobs == "all" || needs.input_selection.outputs.selected_jobs == "test_memory_logs"
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -18,6 +18,25 @@ on:
         required: false
         default: "2"
         type: string
+      model_name:
+        description: "Model name"
+        required: false
+        default: "all"
+        type: choice
+        options:
+          - all
+          - torch_cnn_mnist
+          - keras_cnn_mnist
+      python_version:
+        description: "Python version"
+        required: false
+        default: "all"
+        type: choice
+        options:
+          - all
+          - "3.10"
+          - "3.11"
+          - "3.12"
       jobs_to_run:
         description: "Jobs to run"
         type: choice
@@ -37,36 +56,53 @@ permissions:
 env:
   NUM_ROUNDS: ${{ inputs.num_rounds || '5' }}
   NUM_COLLABORATORS: ${{ inputs.num_collaborators || '2' }}
+  MODEL_NAME: ${{ inputs.model_name || 'all' }}
+  PYTHON_VERSION: ${{ inputs.python_version || 'all' }}
   JOBS_TO_RUN: ${{ inputs.jobs_to_run || 'all' }}
 
 jobs:
-  initial_job:
+  input_value_selection:
     if: |
       (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
       (github.event_name == 'workflow_dispatch')
     name: Initial Job
     runs-on: ubuntu-22.04
     outputs:
-      jobs_to_run: ${{ steps.jobs_to_run.outputs.jobs_to_run }}
+      selected_jobs: ${{ steps.input_value_selection.outputs.jobs_to_run }}
+      selected_models: ${{ steps.input_value_selection.outputs.models_to_run }}
+      selected_python_versions: ${{ steps.input_value_selection.outputs.python_versions_to_run }}
     steps:
-      - name: Jobs to run
-        id: jobs_to_run
+      - name: Job to select input values
+        id: input_value_selection
         run: |
-          echo Jobs to run: ${{ env.JOBS_TO_RUN }}
+          if [ "${{ env.MODEL_NAME }}" == "all" ]; then
+            echo "models_to_run=[\"torch_cnn_mnist\", \"keras_cnn_mnist\"]" >> "$GITHUB_OUTPUT"
+          else
+            echo "models_to_run=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
+          fi
+          if [ "${{ env.PYTHON_VERSION }}" == "all" ]; then
+            echo "python_versions_to_run=[\"3.10\", \"3.11\", \"3.12\"]" >> "$GITHUB_OUTPUT"
+          else
+            echo "python_versions_to_run=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
+          fi
           echo "jobs_to_run=${{ env.JOBS_TO_RUN }}" >> "$GITHUB_OUTPUT"
+
+          echo "Selected model(s): $models_to_run" >> $GITHUB_STEP_SUMMARY
+          echo "Selected python version(s): $python_versions_to_run" >> $GITHUB_STEP_SUMMARY
+          echo "Selected job(s): $jobs_to_run" >> $GITHUB_STEP_SUMMARY
 
   test_with_tls:
     name: tr_tls
-    needs: initial_job
-    if: needs.initial_job.outputs.jobs_to_run == 'all' || needs.initial_job.outputs.jobs_to_run == 'test_with_tls'
+    needs: input_value_selection
+    if: needs.input_value_selection.outputs.selected_jobs == 'all' || needs.input_value_selection.outputs.selected_jobs == 'test_with_tls'
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
       matrix:
         # Models like XGBoost (xgb_higgs) and torch_cnn_histology require runners with higher memory and CPU to run.
         # Thus these models are excluded from the matrix for now.
-        model_name: ["torch_cnn_mnist", "keras_cnn_mnist"]
-        python_version: ["3.10", "3.11", "3.12"]
+        model_name: ${{ needs.input_value_selection.outputs.selected_models }}
+        python_version: ${{ needs.input_value_selection.outputs.selected_python_versions }}
       fail-fast: false # do not immediately fail if one of the combinations fail
 
     env:
@@ -89,7 +125,6 @@ jobs:
       - name: Run Task Runner E2E tests with TLS
         id: run_tests
         run: |
-          echo ${{ needs.initial_job.outputs.jobs_to_run }}
           python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
           -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
           --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
@@ -103,16 +138,16 @@ jobs:
 
   test_with_non_tls:
     name: tr_non_tls
-    needs: initial_job
-    if: needs.initial_job.outputs.jobs_to_run == 'all' || needs.initial_job.outputs.jobs_to_run == 'test_with_non_tls'
+    needs: input_value_selection
+    if: needs.input_value_selection.outputs.selected_jobs == 'all' || needs.input_value_selection.outputs.selected_jobs == 'test_with_non_tls'
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
       matrix:
         # Testing this scenario only for torch_cnn_mnist model and python 3.10
         # If required, this can be extended to other models and python versions
-        model_name: ["torch_cnn_mnist"]
-        python_version: ["3.10"]
+        model_name: ${{ needs.input_value_selection.outputs.selected_models == "all" && ["torch_cnn_mnist"] || needs.input_value_selection.outputs.selected_models }}
+        python_version: ${{ needs.input_value_selection.outputs.selected_python_versions == "all" && ["3.10"] || needs.input_value_selection.outputs.selected_python_versions }}
       fail-fast: false # do not immediately fail if one of the combinations fail
 
     env:
@@ -135,7 +170,6 @@ jobs:
       - name: Run Task Runner E2E tests without TLS
         id: run_tests
         run: |
-          echo ${{ needs.initial_job.outputs.jobs_to_run }}
           python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
           -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
           --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_tls
@@ -149,16 +183,16 @@ jobs:
 
   test_with_no_client_auth:
     name: tr_no_client_auth
-    needs: initial_job
-    if: needs.initial_job.outputs.jobs_to_run == 'all' || needs.initial_job.outputs.jobs_to_run == 'test_with_no_client_auth'
+    needs: input_value_selection
+    if: needs.input_value_selection.outputs.selected_jobs == 'all' || needs.input_value_selection.outputs.selected_jobs == 'test_with_no_client_auth'
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
       matrix:
         # Testing this scenario for keras_cnn_mnist model and python 3.10
         # If required, this can be extended to other models and python versions
-        model_name: ["keras_cnn_mnist"]
-        python_version: ["3.10"]
+        model_name: ${{ needs.input_value_selection.outputs.selected_models == "all" && ["keras_cnn_mnist"] || needs.input_value_selection.outputs.selected_models }}
+        python_version: ${{ needs.input_value_selection.outputs.selected_python_versions == "all" && ["3.10"] || needs.input_value_selection.outputs.selected_python_versions }}
       fail-fast: false # do not immediately fail if one of the combinations fail
 
     env:
@@ -181,7 +215,6 @@ jobs:
       - name: Run Task Runner E2E tests without TLS
         id: run_tests
         run: |
-          echo ${{ needs.initial_job.outputs.jobs_to_run }}
           python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
           -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
           --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_client_auth
@@ -195,16 +228,16 @@ jobs:
 
   test_memory_logs:
     name: tr_tls_memory_logs
-    needs: initial_job
-    if: needs.initial_job.outputs.jobs_to_run == 'all' || needs.initial_job.outputs.jobs_to_run == 'test_memory_logs'
+    needs: input_value_selection
+    if: needs.input_value_selection.outputs.selected_jobs == 'all' || needs.input_value_selection.outputs.selected_jobs == 'test_memory_logs'
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
       matrix:
         # Testing this scenario only for torch_cnn_mnist model and python 3.10
         # If required, this can be extended to other models and python versions
-        model_name: ["torch_cnn_mnist"]
-        python_version: ["3.10"]
+        model_name: ${{ needs.input_value_selection.outputs.selected_models == "all" && ["torch_cnn_mnist"] || needs.input_value_selection.outputs.selected_models }}
+        python_version: ${{ needs.input_value_selection.outputs.selected_python_versions == "all" && ["3.10"] || needs.input_value_selection.outputs.selected_python_versions }}
       fail-fast: false # do not immediately fail if one of the combinations fail
 
     env:
@@ -227,7 +260,6 @@ jobs:
       - name: Run Task Runner E2E tests with TLS and memory logs
         id: run_tests
         run: |
-          echo ${{ needs.initial_job.outputs.jobs_to_run }}
           python -m pytest -s tests/end_to_end/test_suites/memory_logs_tests.py \
           -k test_log_memory_usage_basic --model_name ${{ env.MODEL_NAME }} \
           --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} \

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -5,42 +5,42 @@ name: Task_Runner_E2E  # Please do not modify the name as it is used in the comp
 
 on:
   schedule:
-    - cron: "0 0 * * *" # Run every day at midnight
+    - cron: '0 0 * * *' # Run every day at midnight
   workflow_dispatch:
     inputs:
       num_rounds:
-        description: "Number of rounds to train"
+        description: 'Number of rounds to train'
         required: false
-        default: "5"
+        default: '5'
         type: string
       num_collaborators:
-        description: "Number of collaborators"
+        description: 'Number of collaborators'
         required: false
-        default: "2"
+        default: '2'
         type: string
       model_name:
-        description: "Model name"
+        description: 'Model name'
         required: false
-        default: "all"
+        default: 'all'
         type: choice
         options:
           - all
           - torch_cnn_mnist
           - keras_cnn_mnist
       python_version:
-        description: "Python version"
+        description: 'Python version'
         required: false
-        default: "all"
+        default: 'all'
         type: choice
         options:
           - all
-          - "3.10"
-          - "3.11"
-          - "3.12"
+          - '3.10'
+          - '3.11'
+          - '3.12'
       jobs_to_run:
-        description: "Jobs to run"
+        description: 'Jobs to run'
         type: choice
-        default: "all"
+        default: 'all'
         options:
           - all
           - test_with_tls
@@ -64,8 +64,8 @@ env:
 jobs:
   input_selection:
     if: |
-      (github.event_name == "schedule" && github.repository_owner == "securefederatedai") ||
-      (github.event_name == "workflow_dispatch")
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
     name: Input value selection
     runs-on: ubuntu-22.04
     outputs:
@@ -87,41 +87,41 @@ jobs:
           # ---------------------------------------------------------------
           # Models like XGBoost (xgb_higgs) and torch_cnn_histology require runners with higher memory and CPU to run.
           # Thus these models are excluded from the matrix for now.
-          # Default combination if no input is provided (i.e. "all" is selected).
+          # Default combination if no input is provided (i.e. 'all' is selected).
           # * TLS - models [torch_cnn_mnist, keras_cnn_mnist] and python versions [3.10, 3.11, 3.12]
           # * Non-TLS - models [torch_cnn_mnist] and python version [3.10]
           # * No client auth - models [keras_cnn_mnist] and python version [3.10]
           # * Memory logs - models [torch_cnn_mnist] and python version [3.10]
           # ---------------------------------------------------------------
-          echo "jobs_to_run=${{ env.JOBS_TO_RUN }}" >> "$GITHUB_OUTPUT"
+          echo 'jobs_to_run=${{ env.JOBS_TO_RUN }}' >> '$GITHUB_OUTPUT'
 
-          if [ "${{ env.MODEL_NAME }}" == "all" ]; then
-            echo "models_for_tls=[\"torch_cnn_mnist\", \"keras_cnn_mnist\"]" >> "$GITHUB_OUTPUT"
-            echo "models_for_non_tls=[\"torch_cnn_mnist\"]" >> "$GITHUB_OUTPUT"
-            echo "models_for_no_client_auth=[\"keras_cnn_mnist\"]" >> "$GITHUB_OUTPUT"
-            echo "models_for_memory_logs=[\"torch_cnn_mnist\"]" >> "$GITHUB_OUTPUT"
+          if [ '${{ env.MODEL_NAME }}' == 'all' ]; then
+            echo 'models_for_tls=[\'torch_cnn_mnist\', \'keras_cnn_mnist\']' >> '$GITHUB_OUTPUT'
+            echo 'models_for_non_tls=[\'torch_cnn_mnist\']' >> '$GITHUB_OUTPUT'
+            echo 'models_for_no_client_auth=[\'keras_cnn_mnist\']' >> '$GITHUB_OUTPUT'
+            echo 'models_for_memory_logs=[\'torch_cnn_mnist\']' >> '$GITHUB_OUTPUT'
           else
-            echo "models_for_tls=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
-            echo "models_for_non_tls=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
-            echo "models_for_no_client_auth=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
-            echo "models_for_memory_logs=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
+            echo 'models_for_tls=[\'${{env.MODEL_NAME}}\']' >> '$GITHUB_OUTPUT'
+            echo 'models_for_non_tls=[\'${{env.MODEL_NAME}}\']' >> '$GITHUB_OUTPUT'
+            echo 'models_for_no_client_auth=[\'${{env.MODEL_NAME}}\']' >> '$GITHUB_OUTPUT'
+            echo 'models_for_memory_logs=[\'${{env.MODEL_NAME}}\']' >> '$GITHUB_OUTPUT'
           fi
-          if [ "${{ env.PYTHON_VERSION }}" == "all" ]; then
-            echo "python_for_tls=[\"3.10\", \"3.11\", \"3.12\"]" >> "$GITHUB_OUTPUT"
-            echo "python_for_non_tls=[\"3.10\"]" >> "$GITHUB_OUTPUT"
-            echo "python_for_no_client_auth=[\"3.10\"]" >> "$GITHUB_OUTPUT"
-            echo "python_for_memory_logs=[\"3.10\"]" >> "$GITHUB_OUTPUT"
+          if [ '${{ env.PYTHON_VERSION }}' == 'all' ]; then
+            echo 'python_for_tls=[\'3.10\', \'3.11\', \'3.12\']' >> '$GITHUB_OUTPUT'
+            echo 'python_for_non_tls=[\'3.10\']' >> '$GITHUB_OUTPUT'
+            echo 'python_for_no_client_auth=[\'3.10\']' >> '$GITHUB_OUTPUT'
+            echo 'python_for_memory_logs=[\'3.10\']' >> '$GITHUB_OUTPUT'
           else
-            echo "python_for_tls=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
-            echo "python_for_non_tls=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
-            echo "python_for_no_client_auth=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
-            echo "python_for_memory_logs=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
+            echo 'python_for_tls=[\'${{env.PYTHON_VERSION}}\']' >> '$GITHUB_OUTPUT'
+            echo 'python_for_non_tls=[\'${{env.PYTHON_VERSION}}\']' >> '$GITHUB_OUTPUT'
+            echo 'python_for_no_client_auth=[\'${{env.PYTHON_VERSION}}\']' >> '$GITHUB_OUTPUT'
+            echo 'python_for_memory_logs=[\'${{env.PYTHON_VERSION}}\']' >> '$GITHUB_OUTPUT'
           fi
 
   test_with_tls:
     name: Test with TLS
     needs: input_selection
-    if: needs.input_selection.outputs.selected_jobs == "all" || needs.input_selection.outputs.selected_jobs == "test_with_tls"
+    if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_with_tls'
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
@@ -140,7 +140,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 2 # needed for detecting changes
-          submodules: "true"
+          submodules: 'true'
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pre test run
@@ -153,18 +153,18 @@ jobs:
           python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
           -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
           --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
-          echo "Task runner end to end test run completed"
+          echo 'Task runner end to end test run completed'
 
       - name: Post test run
         uses: ./.github/actions/tr_post_test_run
         if: ${{ always() }}
         with:
-          test_type: "tr_tls"
+          test_type: 'tr_tls'
 
   test_with_non_tls:
     name: Test without TLS
     needs: input_selection
-    if: needs.input_selection.outputs.selected_jobs == "all" || needs.input_selection.outputs.selected_jobs == "test_with_non_tls"
+    if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_with_non_tls'
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
@@ -183,7 +183,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 2 # needed for detecting changes
-          submodules: "true"
+          submodules: 'true'
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pre test run
@@ -196,18 +196,18 @@ jobs:
           python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
           -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
           --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_tls
-          echo "Task runner end to end test run completed"
+          echo 'Task runner end to end test run completed'
 
       - name: Post test run
         uses: ./.github/actions/tr_post_test_run
         if: ${{ always() }}
         with:
-          test_type: "tr_non_tls"
+          test_type: 'tr_non_tls'
 
   test_with_no_client_auth:
     name: Test without client auth
     needs: input_selection
-    if: needs.input_selection.outputs.selected_jobs == "all" || needs.input_selection.outputs.selected_jobs == "test_with_no_client_auth"
+    if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_with_no_client_auth'
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
@@ -226,7 +226,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 2 # needed for detecting changes
-          submodules: "true"
+          submodules: 'true'
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pre test run
@@ -239,18 +239,18 @@ jobs:
           python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
           -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
           --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_client_auth
-          echo "Task runner end to end test run completed"
+          echo 'Task runner end to end test run completed'
 
       - name: Post test run
         uses: ./.github/actions/tr_post_test_run
         if: ${{ always() }}
         with:
-          test_type: "tr_no_client_auth"
+          test_type: 'tr_no_client_auth'
 
   test_memory_logs:
     name: Test memory usage
     needs: input_selection
-    if: needs.input_selection.outputs.selected_jobs == "all" || needs.input_selection.outputs.selected_jobs == "test_memory_logs"
+    if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_memory_logs'
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
@@ -269,7 +269,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 2 # needed for detecting changes
-          submodules: "true"
+          submodules: 'true'
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pre test run
@@ -283,10 +283,10 @@ jobs:
           -k test_log_memory_usage_basic --model_name ${{ env.MODEL_NAME }} \
           --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} \
           --log_memory_usage
-          echo "Task runner memory logs test run completed"
+          echo 'Task runner memory logs test run completed'
 
       - name: Post test run
         uses: ./.github/actions/tr_post_test_run
         if: ${{ always() }}
         with:
-          test_type: "tr_tls_memory_logs"
+          test_type: 'tr_tls_memory_logs'

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -53,12 +53,13 @@ permissions:
   contents: read
 
 # Environment variables common for all the jobs
+# DO NOT use double quotes for the values of the environment variables
 env:
   NUM_ROUNDS: ${{ inputs.num_rounds || 5 }}
   NUM_COLLABORATORS: ${{ inputs.num_collaborators || 2 }}
-  MODEL_NAME: ${{ inputs.model_name || "all" }}
-  PYTHON_VERSION: ${{ inputs.python_version || "all" }}
-  JOBS_TO_RUN: ${{ inputs.jobs_to_run || "all" }}
+  MODEL_NAME: ${{ inputs.model_name || 'all' }}
+  PYTHON_VERSION: ${{ inputs.python_version || 'all' }}
+  JOBS_TO_RUN: ${{ inputs.jobs_to_run || 'all' }}
 
 jobs:
   input_selection:

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -93,30 +93,29 @@ jobs:
           # * No client auth - models [keras_cnn_mnist] and python version [3.10]
           # * Memory logs - models [torch_cnn_mnist] and python version [3.10]
           # ---------------------------------------------------------------
-          echo 'jobs_to_run=${{ env.JOBS_TO_RUN }}' >> '$GITHUB_OUTPUT'
+          echo "jobs_to_run=${{ env.JOBS_TO_RUN }}" >> "$GITHUB_OUTPUT"
 
-          if [ '${{ env.MODEL_NAME }}' == 'all' ]; then
-            echo 'models_for_tls=[\'torch_cnn_mnist\', \'keras_cnn_mnist\']' >> '$GITHUB_OUTPUT'
-            echo 'models_for_non_tls=[\'torch_cnn_mnist\']' >> '$GITHUB_OUTPUT'
-            echo 'models_for_no_client_auth=[\'keras_cnn_mnist\']' >> '$GITHUB_OUTPUT'
-            echo 'models_for_memory_logs=[\'torch_cnn_mnist\']' >> '$GITHUB_OUTPUT'
+          if [ "${{ env.MODEL_NAME }}" == "all" ]; then
+            echo "models_for_tls=[\"torch_cnn_mnist\", \"keras_cnn_mnist\"]" >> "$GITHUB_OUTPUT"
+            echo "models_for_non_tls=[\"torch_cnn_mnist\"]" >> "$GITHUB_OUTPUT"
+            echo "models_for_no_client_auth=[\"keras_cnn_mnist\"]" >> "$GITHUB_OUTPUT"
+            echo "models_for_memory_logs=[\"torch_cnn_mnist\"]" >> "$GITHUB_OUTPUT"
           else
-            echo 'models_for_tls=[\'${{env.MODEL_NAME}}\']' >> '$GITHUB_OUTPUT'
-            echo 'models_for_non_tls=[\'${{env.MODEL_NAME}}\']' >> '$GITHUB_OUTPUT'
-            echo 'models_for_no_client_auth=[\'${{env.MODEL_NAME}}\']' >> '$GITHUB_OUTPUT'
-            echo 'models_for_memory_logs=[\'${{env.MODEL_NAME}}\']' >> '$GITHUB_OUTPUT'
+            echo "models_for_tls=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
+            echo "models_for_non_tls=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
+            echo "models_for_no_client_auth=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
+            echo "models_for_memory_logs=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
           fi
-          if [ '${{ env.PYTHON_VERSION }}' == 'all' ]; then
-            echo 'python_for_tls=[\'3.10\', \'3.11\', \'3.12\']' >> '$GITHUB_OUTPUT'
-            echo 'python_for_non_tls=[\'3.10\']' >> '$GITHUB_OUTPUT'
-            echo 'python_for_no_client_auth=[\'3.10\']' >> '$GITHUB_OUTPUT'
-            echo 'python_for_memory_logs=[\'3.10\']' >> '$GITHUB_OUTPUT'
+          if [ "${{ env.PYTHON_VERSION }}" == "all" ]; then
+            echo "python_for_tls=[\"3.10\", \"3.11\", \"3.12\"]" >> "$GITHUB_OUTPUT"
+            echo "python_for_non_tls=[\"3.10\"]" >> "$GITHUB_OUTPUT"
+            echo "python_for_no_client_auth=[\"3.10\"]" >> "$GITHUB_OUTPUT"
+            echo "python_for_memory_logs=[\"3.10\"]" >> "$GITHUB_OUTPUT"
           else
-            echo 'python_for_tls=[\'${{env.PYTHON_VERSION}}\']' >> '$GITHUB_OUTPUT'
-            echo 'python_for_non_tls=[\'${{env.PYTHON_VERSION}}\']' >> '$GITHUB_OUTPUT'
-            echo 'python_for_no_client_auth=[\'${{env.PYTHON_VERSION}}\']' >> '$GITHUB_OUTPUT'
-            echo 'python_for_memory_logs=[\'${{env.PYTHON_VERSION}}\']' >> '$GITHUB_OUTPUT'
-          fi
+            echo "python_for_tls=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
+            echo "python_for_non_tls=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
+            echo "python_for_no_client_auth=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
+            echo "python_for_memory_logs=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
 
   test_with_tls:
     name: Test with TLS

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -69,27 +69,43 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       selected_jobs: ${{ steps.input_value_selection.outputs.jobs_to_run }}
-      selected_models: ${{ steps.input_value_selection.outputs.models_to_run }}
-      selected_python_versions: ${{ steps.input_value_selection.outputs.python_versions_to_run }}
+      selected_models_for_tls: ${{ steps.input_value_selection.outputs.models_for_tls }}
+      selected_python_for_tls: ${{ steps.input_value_selection.outputs.python_for_tls }}
+      selected_models_for_non_tls: ${{ steps.input_value_selection.outputs.models_for_non_tls }}
+      selected_models_for_no_client_auth: ${{ steps.input_value_selection.outputs.models_for_no_client_auth }}
+      selected_models_for_memory_logs: ${{ steps.input_value_selection.outputs.models_for_memory_logs }}
+      selected_python_for_non_tls: ${{ steps.input_value_selection.outputs.python_for_non_tls }}
+      selected_python_for_no_client_auth: ${{ steps.input_value_selection.outputs.python_for_no_client_auth }}
+      selected_python_for_memory_logs: ${{ steps.input_value_selection.outputs.python_for_memory_logs }}
     steps:
       - name: Job to select input values
         id: input_value_selection
         run: |
           if [ "${{ env.MODEL_NAME }}" == 'all' ]; then
-            echo "models_to_run=[\"torch_cnn_mnist\", \"keras_cnn_mnist\"]" >> "$GITHUB_OUTPUT"
+            echo "models_for_tls=[\"torch_cnn_mnist\", \"keras_cnn_mnist\"]" >> "$GITHUB_OUTPUT"
+            echo "models_for_non_tls=[\"torch_cnn_mnist\"]" >> "$GITHUB_OUTPUT"
+            echo "models_for_no_client_auth=[\"keras_cnn_mnist\"]" >> "$GITHUB_OUTPUT"
+            echo "models_for_memory_logs=[\"torch_cnn_mnist\"]" >> "$GITHUB_OUTPUT"
           else
-            echo "models_to_run=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
+            echo "models_for_tls=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
+            echo "models_for_non_tls=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
+            echo "models_for_no_client_auth=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
+            echo "models_for_memory_logs=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
           fi
           if [ "${{ env.PYTHON_VERSION }}" == 'all' ]; then
-            echo "python_versions_to_run=[\"3.10\", \"3.11\", \"3.12\"]" >> "$GITHUB_OUTPUT"
+            echo "python_for_tls=[\"3.10\", \"3.11\", \"3.12\"]" >> "$GITHUB_OUTPUT"
+            echo "python_for_non_tls=[\"3.10\"]" >> "$GITHUB_OUTPUT"
+            echo "python_for_no_client_auth=[\"3.10\"]" >> "$GITHUB_OUTPUT"
+            echo "python_for_memory_logs=[\"3.10\"]" >> "$GITHUB_OUTPUT"
           else
-            echo "python_versions_to_run=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
+            echo "python_for_tls=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
+            echo "python_for_non_tls=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
+            echo "python_for_no_client_auth=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
+            echo "python_for_memory_logs=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
           fi
           echo "jobs_to_run=${{ env.JOBS_TO_RUN }}" >> "$GITHUB_OUTPUT"
 
-          echo "Selected model(s): $models_to_run" >> $GITHUB_STEP_SUMMARY
-          echo "Selected python version(s): $python_versions_to_run" >> $GITHUB_STEP_SUMMARY
-          echo "Selected job(s): $jobs_to_run" >> $GITHUB_STEP_SUMMARY
+          echo $GITHUB_OUTPUT
 
   test_with_tls:
     name: tr_tls
@@ -101,8 +117,8 @@ jobs:
       matrix:
         # Models like XGBoost (xgb_higgs) and torch_cnn_histology require runners with higher memory and CPU to run.
         # Thus these models are excluded from the matrix for now.
-        model_name: ${{ needs.input_value_selection.outputs.selected_models }}
-        python_version: ${{ needs.input_value_selection.outputs.selected_python_versions }}
+        model_name: ${{ needs.input_value_selection.outputs.selected_models_for_tls }}
+        python_version: ${{ needs.input_value_selection.outputs.selected_python_for_tls }}
       fail-fast: false # do not immediately fail if one of the combinations fail
 
     env:
@@ -146,8 +162,8 @@ jobs:
       matrix:
         # Testing this scenario only for torch_cnn_mnist model and python 3.10
         # If required, this can be extended to other models and python versions
-        model_name: ${{ needs.input_value_selection.outputs.selected_models == 'all' && [\'torch_cnn_mnist\'] || needs.input_value_selection.outputs.selected_models }}
-        python_version: ${{ needs.input_value_selection.outputs.selected_python_versions == 'all' && [\'3.10\'] || needs.input_value_selection.outputs.selected_python_versions }}
+        model_name: ${{ needs.input_value_selection.outputs.selected_models_for_non_tls }}
+        python_version: ${{ needs.input_value_selection.outputs.selected_python_for_non_tls }}
       fail-fast: false # do not immediately fail if one of the combinations fail
 
     env:
@@ -191,8 +207,8 @@ jobs:
       matrix:
         # Testing this scenario for keras_cnn_mnist model and python 3.10
         # If required, this can be extended to other models and python versions
-        model_name: ${{ needs.input_value_selection.outputs.selected_models == 'all' && [\'keras_cnn_mnist\'] || needs.input_value_selection.outputs.selected_models }}
-        python_version: ${{ needs.input_value_selection.outputs.selected_python_versions == 'all' && [\'3.10\'] || needs.input_value_selection.outputs.selected_python_versions }}
+        model_name: ${{ needs.input_value_selection.outputs.selected_models_for_no_client_auth }}
+        python_version: ${{ needs.input_value_selection.outputs.selected_python_for_no_client_auth }}
       fail-fast: false # do not immediately fail if one of the combinations fail
 
     env:
@@ -236,8 +252,8 @@ jobs:
       matrix:
         # Testing this scenario only for torch_cnn_mnist model and python 3.10
         # If required, this can be extended to other models and python versions
-        model_name: ${{ needs.input_value_selection.outputs.selected_models == 'all' && [\'torch_cnn_mnist\'] || needs.input_value_selection.outputs.selected_models }}
-        python_version: ${{ needs.input_value_selection.outputs.selected_python_versions == 'all' && [\'3.10\'] || needs.input_value_selection.outputs.selected_python_versions }}
+        model_name: ${{ needs.input_value_selection.outputs.selected_models_for_memory_logs }}
+        python_version: ${{ needs.input_value_selection.outputs.selected_python_for_memory_logs }}
       fail-fast: false # do not immediately fail if one of the combinations fail
 
     env:

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -65,7 +65,7 @@ jobs:
     if: |
       (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
       (github.event_name == 'workflow_dispatch')
-    name: Select input values
+    name: Input value selection
     runs-on: ubuntu-22.04
     outputs:
       selected_jobs: ${{ steps.input_value_selection.outputs.jobs_to_run }}
@@ -89,7 +89,9 @@ jobs:
           # Non-TLS - models [torch_cnn_mnist] and python version [3.10]
           # No client auth - models [keras_cnn_mnist] and python version [3.10]
           # Memory logs - models [torch_cnn_mnist] and python version [3.10]
-          # --------------------------------------------------------------- 
+          # ---------------------------------------------------------------
+          echo "jobs_to_run=${{ env.JOBS_TO_RUN }}" >> "$GITHUB_OUTPUT"
+
           if [ "${{ env.MODEL_NAME }}" == 'all' ]; then
             echo "models_for_tls=[\"torch_cnn_mnist\", \"keras_cnn_mnist\"]" >> "$GITHUB_OUTPUT"
             echo "models_for_non_tls=[\"torch_cnn_mnist\"]" >> "$GITHUB_OUTPUT"
@@ -112,23 +114,29 @@ jobs:
             echo "python_for_no_client_auth=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
             echo "python_for_memory_logs=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
           fi
-          echo "jobs_to_run=${{ env.JOBS_TO_RUN }}" >> "$GITHUB_OUTPUT"
 
       - name: Print output values
+        id: print_output_values
         run: |
           # ---------------------------------------------------------------
           # Print the selected values as a summary for better visibility
           # ---------------------------------------------------------------
-          echo "${{ toJSON(steps.input_value_selection.outputs) }}" >> $GITHUB_STEP_SUMMARY
-          # echo "Selected jobs: $jobs_to_run" >> $GITHUB_STEP_SUMMARY
-          # echo "Selected models for TLS: $models_for_tls" >> $GITHUB_STEP_SUMMARY
-          # echo "Selected python versions for TLS: $python_for_tls" >> $GITHUB_STEP_SUMMARY
-          # echo "Selected models for non-TLS: $models_for_non_tls" >> $GITHUB_STEP_SUMMARY
-          # echo "Selected python versions for non-TLS: $python_for_non_tls" >> $GITHUB_STEP_SUMMARY
-          # echo "Selected models for no client auth: $models_for_no_client_auth" >> $GITHUB_STEP_SUMMARY
-          # echo "Selected python versions for no client auth: $python_for_no_client_auth" >> $GITHUB_STEP_SUMMARY
-          # echo "Selected models for memory logs: $models_for_memory_logs" >> $GITHUB_STEP_SUMMARY
-          # echo "Selected python versions for memory logs: $python_for_memory_logs" >> $GITHUB_STEP_SUMMARY
+          echo "Selected jobs: ${{ steps.input_value_selection.outputs.jobs_to_run }}" >> $GITHUB_STEP_SUMMARY
+          echo "| Job | Model | Python Version |" >> $GITHUB_STEP_SUMMARY
+          echo "| ---- | ---- | ---- |" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ env.JOBS_TO_RUN }}" == 'all' || "${{ env.JOBS_TO_RUN }}" == "test_with_tls" ]; then
+            echo "| Test with TLS | ${{ steps.input_value_selection.outputs.models_for_tls }} | ${{ steps.input_value_selection.outputs.python_for_tls }} |" >> $GITHUB_STEP_SUMMARY
+            fi
+          if [ "${{ env.JOBS_TO_RUN }}" == 'all' || "${{ env.JOBS_TO_RUN }}" == "test_with_non_tls" ]; then
+            echo "| Test without TLS | ${{ steps.input_value_selection.outputs.models_for_non_tls }} | ${{ steps.input_value_selection.outputs.python_for_non_tls }} |" >> $GITHUB_STEP_SUMMARY
+          fi
+          if [ "${{ env.JOBS_TO_RUN }}" == 'all' || "${{ env.JOBS_TO_RUN }}" == "test_with_no_client_auth" ]; then
+            echo "| Test without client auth | ${{ steps.input_value_selection.outputs.models_for_no_client_auth }} | ${{ steps.input_value_selection.outputs.python_for_no_client_auth }} |" >> $GITHUB_STEP_SUMMARY
+          fi
+          if [ "${{ env.JOBS_TO_RUN }}" == 'all' || "${{ env.JOBS_TO_RUN }}" == "test_memory_logs" ]; then
+            echo "| Test memory logs | ${{ steps.input_value_selection.outputs.models_for_memory_logs }} | ${{ steps.input_value_selection.outputs.python_for_memory_logs }} |" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "" >> $GITHUB_STEP_SUMMARY
 
   test_with_tls:
     name: Test with TLS

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -116,6 +116,7 @@ jobs:
             echo "python_for_non_tls=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
             echo "python_for_no_client_auth=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
             echo "python_for_memory_logs=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
+          fi
 
   test_with_tls:
     name: Test with TLS

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -122,6 +122,7 @@ jobs:
           # Print the selected values as a summary for better visibility
           # ---------------------------------------------------------------
           echo "Selected jobs: ${{ steps.input_selection.outputs.jobs_to_run }}" >> $GITHUB_STEP_SUMMARY
+          echo ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} >> $GITHUB_STEP_SUMMARY
           echo "| Job | Model | Python Version |" >> $GITHUB_STEP_SUMMARY
           echo "| ---- | ---- | ---- |" >> $GITHUB_STEP_SUMMARY
           if [ ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'all' || ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'test_with_tls' ]; then

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -65,7 +65,7 @@ jobs:
     if: |
       (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
       (github.event_name == 'workflow_dispatch')
-    name: Initial Job
+    name: Select input values
     runs-on: ubuntu-22.04
     outputs:
       selected_jobs: ${{ steps.input_value_selection.outputs.jobs_to_run }}
@@ -81,6 +81,15 @@ jobs:
       - name: Job to select input values
         id: input_value_selection
         run: |
+          # ---------------------------------------------------------------
+          # Models like XGBoost (xgb_higgs) and torch_cnn_histology require runners with higher memory and CPU to run.
+          # Thus these models are excluded from the matrix for now.
+          # Below combinations will be used by default if no input is provided.
+          # TLS - models [torch_cnn_mnist, keras_cnn_mnist] and python versions [3.10, 3.11, 3.12]
+          # Non-TLS - models [torch_cnn_mnist] and python version [3.10]
+          # No client auth - models [keras_cnn_mnist] and python version [3.10]
+          # Memory logs - models [torch_cnn_mnist] and python version [3.10]
+          # --------------------------------------------------------------- 
           if [ "${{ env.MODEL_NAME }}" == 'all' ]; then
             echo "models_for_tls=[\"torch_cnn_mnist\", \"keras_cnn_mnist\"]" >> "$GITHUB_OUTPUT"
             echo "models_for_non_tls=[\"torch_cnn_mnist\"]" >> "$GITHUB_OUTPUT"
@@ -105,18 +114,27 @@ jobs:
           fi
           echo "jobs_to_run=${{ env.JOBS_TO_RUN }}" >> "$GITHUB_OUTPUT"
 
-          echo $GITHUB_OUTPUT
+          # ---------------------------------------------------------------
+          # Print the selected values as a summary for better visibility
+          # ---------------------------------------------------------------
+          echo "Selected jobs: $jobs_to_run" >> $GITHUB_STEP_SUMMARY
+          echo "Selected models for TLS: $models_for_tls" >> $GITHUB_STEP_SUMMARY
+          echo "Selected python versions for TLS: $python_for_tls" >> $GITHUB_STEP_SUMMARY
+          echo "Selected models for non-TLS: $models_for_non_tls" >> $GITHUB_STEP_SUMMARY
+          echo "Selected python versions for non-TLS: $python_for_non_tls" >> $GITHUB_STEP_SUMMARY
+          echo "Selected models for no client auth: $models_for_no_client_auth" >> $GITHUB_STEP_SUMMARY
+          echo "Selected python versions for no client auth: $python_for_no_client_auth" >> $GITHUB_STEP_SUMMARY
+          echo "Selected models for memory logs: $models_for_memory_logs" >> $GITHUB_STEP_SUMMARY
+          echo "Selected python versions for memory logs: $python_for_memory_logs" >> $GITHUB_STEP_SUMMARY
 
   test_with_tls:
-    name: tr_tls
+    name: Test with TLS
     needs: input_value_selection
     if: needs.input_value_selection.outputs.selected_jobs == 'all' || needs.input_value_selection.outputs.selected_jobs == 'test_with_tls'
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
       matrix:
-        # Models like XGBoost (xgb_higgs) and torch_cnn_histology require runners with higher memory and CPU to run.
-        # Thus these models are excluded from the matrix for now.
         model_name: ${{ fromJson(needs.input_value_selection.outputs.selected_models_for_tls) }}
         python_version: ${{ fromJson(needs.input_value_selection.outputs.selected_python_for_tls) }}
       fail-fast: false # do not immediately fail if one of the combinations fail
@@ -153,15 +171,13 @@ jobs:
           test_type: "tr_tls"
 
   test_with_non_tls:
-    name: tr_non_tls
+    name: Test without TLS
     needs: input_value_selection
     if: needs.input_value_selection.outputs.selected_jobs == 'all' || needs.input_value_selection.outputs.selected_jobs == 'test_with_non_tls'
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
       matrix:
-        # Testing this scenario only for torch_cnn_mnist model and python 3.10
-        # If required, this can be extended to other models and python versions
         model_name: ${{ fromJson(needs.input_value_selection.outputs.selected_models_for_non_tls) }}
         python_version: ${{ fromJson(needs.input_value_selection.outputs.selected_python_for_non_tls) }}
       fail-fast: false # do not immediately fail if one of the combinations fail
@@ -198,15 +214,13 @@ jobs:
           test_type: "tr_non_tls"
 
   test_with_no_client_auth:
-    name: tr_no_client_auth
+    name: Test without client authentication
     needs: input_value_selection
     if: needs.input_value_selection.outputs.selected_jobs == 'all' || needs.input_value_selection.outputs.selected_jobs == 'test_with_no_client_auth'
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
       matrix:
-        # Testing this scenario for keras_cnn_mnist model and python 3.10
-        # If required, this can be extended to other models and python versions
         model_name: ${{ fromJson(needs.input_value_selection.outputs.selected_models_for_no_client_auth) }}
         python_version: ${{ fromJson(needs.input_value_selection.outputs.selected_python_for_no_client_auth) }}
       fail-fast: false # do not immediately fail if one of the combinations fail
@@ -243,15 +257,13 @@ jobs:
           test_type: "tr_no_client_auth"
 
   test_memory_logs:
-    name: tr_tls_memory_logs
+    name: Test memory usage
     needs: input_value_selection
     if: needs.input_value_selection.outputs.selected_jobs == 'all' || needs.input_value_selection.outputs.selected_jobs == 'test_memory_logs'
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
       matrix:
-        # Testing this scenario only for torch_cnn_mnist model and python 3.10
-        # If required, this can be extended to other models and python versions
         model_name: ${{ fromJson(needs.input_value_selection.outputs.selected_models_for_memory_logs) }}
         python_version: ${{ fromJson(needs.input_value_selection.outputs.selected_python_for_memory_logs) }}
       fail-fast: false # do not immediately fail if one of the combinations fail

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -117,8 +117,8 @@ jobs:
       matrix:
         # Models like XGBoost (xgb_higgs) and torch_cnn_histology require runners with higher memory and CPU to run.
         # Thus these models are excluded from the matrix for now.
-        model_name: ${{ needs.input_value_selection.outputs.selected_models_for_tls }}
-        python_version: ${{ needs.input_value_selection.outputs.selected_python_for_tls }}
+        model_name: ${{ fromJson(needs.input_value_selection.outputs.selected_models_for_tls) }}
+        python_version: ${{ fromJson(needs.input_value_selection.outputs.selected_python_for_tls) }}
       fail-fast: false # do not immediately fail if one of the combinations fail
 
     env:
@@ -162,8 +162,8 @@ jobs:
       matrix:
         # Testing this scenario only for torch_cnn_mnist model and python 3.10
         # If required, this can be extended to other models and python versions
-        model_name: ${{ needs.input_value_selection.outputs.selected_models_for_non_tls }}
-        python_version: ${{ needs.input_value_selection.outputs.selected_python_for_non_tls }}
+        model_name: ${{ fromJson(needs.input_value_selection.outputs.selected_models_for_non_tls) }}
+        python_version: ${{ fromJson(needs.input_value_selection.outputs.selected_python_for_non_tls) }}
       fail-fast: false # do not immediately fail if one of the combinations fail
 
     env:
@@ -207,8 +207,8 @@ jobs:
       matrix:
         # Testing this scenario for keras_cnn_mnist model and python 3.10
         # If required, this can be extended to other models and python versions
-        model_name: ${{ needs.input_value_selection.outputs.selected_models_for_no_client_auth }}
-        python_version: ${{ needs.input_value_selection.outputs.selected_python_for_no_client_auth }}
+        model_name: ${{ fromJson(needs.input_value_selection.outputs.selected_models_for_no_client_auth) }}
+        python_version: ${{ fromJson(needs.input_value_selection.outputs.selected_python_for_no_client_auth) }}
       fail-fast: false # do not immediately fail if one of the combinations fail
 
     env:
@@ -252,8 +252,8 @@ jobs:
       matrix:
         # Testing this scenario only for torch_cnn_mnist model and python 3.10
         # If required, this can be extended to other models and python versions
-        model_name: ${{ needs.input_value_selection.outputs.selected_models_for_memory_logs }}
-        python_version: ${{ needs.input_value_selection.outputs.selected_python_for_memory_logs }}
+        model_name: ${{ fromJson(needs.input_value_selection.outputs.selected_models_for_memory_logs) }}
+        python_version: ${{ fromJson(needs.input_value_selection.outputs.selected_python_for_memory_logs) }}
       fail-fast: false # do not immediately fail if one of the combinations fail
 
     env:

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -40,9 +40,25 @@ env:
   JOBS_TO_RUN: ${{ inputs.jobs_to_run || 'all' }}
 
 jobs:
+  initial_job:
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
+    name: Initial Job
+    runs-on: ubuntu-22.04
+    outputs:
+      jobs_to_run: ${{ steps.jobs_to_run.outputs.jobs_to_run }}
+    steps:
+      - name: Jobs to run
+        id: jobs_to_run
+        run: |
+          echo Jobs to run: ${{ env.JOBS_TO_RUN }}
+          echo "jobs_to_run=${{ env.JOBS_TO_RUN }}" >> "$GITHUB_OUTPUT"
+
   test_with_tls:
     name: tr_tls
-    if: ${{ env.JOBS_TO_RUN == 'all' }} || ${{ env.JOBS_TO_RUN == 'test_with_tls' }}
+    needs: initial_job
+    if: ${{ needs.initial_job.outputs.jobs_to_run == 'all' }} || ${{ needs.initial_job.outputs.jobs_to_run == 'test_with_tls' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
@@ -86,7 +102,8 @@ jobs:
 
   test_with_non_tls:
     name: tr_non_tls
-    if: ${{ env.JOBS_TO_RUN == 'all' }} || ${{ env.JOBS_TO_RUN == 'test_with_non_tls' }}
+    needs: initial_job
+    if: ${{ needs.initial_job.outputs.jobs_to_run == 'all' }} || ${{ needs.initial_job.outputs.jobs_to_run == 'test_with_non_tls' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
@@ -130,7 +147,8 @@ jobs:
 
   test_with_no_client_auth:
     name: tr_no_client_auth
-    if: ${{ env.JOBS_TO_RUN == 'all' }} || ${{ env.JOBS_TO_RUN == 'test_with_no_client_auth' }}
+    needs: initial_job
+    if: ${{ needs.initial_job.outputs.jobs_to_run == 'all' }} || ${{ needs.initial_job.outputs.jobs_to_run == 'test_with_no_client_auth' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
@@ -174,7 +192,8 @@ jobs:
 
   test_memory_logs:
     name: tr_tls_memory_logs
-    if: ${{ env.JOBS_TO_RUN == 'all' }} || ${{ env.JOBS_TO_RUN == 'test_memory_logs' }}
+    needs: initial_job
+    if: ${{ needs.initial_job.outputs.jobs_to_run == 'all' }} || ${{ needs.initial_job.outputs.jobs_to_run == 'test_memory_logs' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -117,15 +117,16 @@ jobs:
           # ---------------------------------------------------------------
           # Print the selected values as a summary for better visibility
           # ---------------------------------------------------------------
-          echo "Selected jobs: $jobs_to_run" >> $GITHUB_STEP_SUMMARY
-          echo "Selected models for TLS: $models_for_tls" >> $GITHUB_STEP_SUMMARY
-          echo "Selected python versions for TLS: $python_for_tls" >> $GITHUB_STEP_SUMMARY
-          echo "Selected models for non-TLS: $models_for_non_tls" >> $GITHUB_STEP_SUMMARY
-          echo "Selected python versions for non-TLS: $python_for_non_tls" >> $GITHUB_STEP_SUMMARY
-          echo "Selected models for no client auth: $models_for_no_client_auth" >> $GITHUB_STEP_SUMMARY
-          echo "Selected python versions for no client auth: $python_for_no_client_auth" >> $GITHUB_STEP_SUMMARY
-          echo "Selected models for memory logs: $models_for_memory_logs" >> $GITHUB_STEP_SUMMARY
-          echo "Selected python versions for memory logs: $python_for_memory_logs" >> $GITHUB_STEP_SUMMARY
+          echo "${{ toJSON(steps.input_value_selection.outputs) }}" >> $GITHUB_STEP_SUMMARY
+          # echo "Selected jobs: $jobs_to_run" >> $GITHUB_STEP_SUMMARY
+          # echo "Selected models for TLS: $models_for_tls" >> $GITHUB_STEP_SUMMARY
+          # echo "Selected python versions for TLS: $python_for_tls" >> $GITHUB_STEP_SUMMARY
+          # echo "Selected models for non-TLS: $models_for_non_tls" >> $GITHUB_STEP_SUMMARY
+          # echo "Selected python versions for non-TLS: $python_for_non_tls" >> $GITHUB_STEP_SUMMARY
+          # echo "Selected models for no client auth: $models_for_no_client_auth" >> $GITHUB_STEP_SUMMARY
+          # echo "Selected python versions for no client auth: $python_for_no_client_auth" >> $GITHUB_STEP_SUMMARY
+          # echo "Selected models for memory logs: $models_for_memory_logs" >> $GITHUB_STEP_SUMMARY
+          # echo "Selected python versions for memory logs: $python_for_memory_logs" >> $GITHUB_STEP_SUMMARY
 
   test_with_tls:
     name: Test with TLS

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -118,25 +118,9 @@ jobs:
       - name: Print output values
         id: print_output_values
         run: |
-          # ---------------------------------------------------------------
-          # Print the selected values as a summary for better visibility
-          # ---------------------------------------------------------------
           echo "Selected jobs: ${{ steps.input_selection.outputs.jobs_to_run }}" >> $GITHUB_STEP_SUMMARY
-          # echo ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} >> $GITHUB_STEP_SUMMARY
           echo "| Job | Model | Python Version |" >> $GITHUB_STEP_SUMMARY
           echo "| ---- | ---- | ---- |" >> $GITHUB_STEP_SUMMARY
-          # if [ ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'all' || ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'test_with_tls' ]; then
-          #   echo "| Test with TLS | ${{ steps.input_selection.outputs.models_for_tls }} | ${{ steps.input_selection.outputs.python_for_tls }} |" >> $GITHUB_STEP_SUMMARY
-          #   fi
-          # if [ ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'all' || ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'test_with_non_tls' ]; then
-          #   echo "| Test without TLS | ${{ steps.input_selection.outputs.models_for_non_tls }} | ${{ steps.input_selection.outputs.python_for_non_tls }} |" >> $GITHUB_STEP_SUMMARY
-          # fi
-          # if [ ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'all' || ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'test_with_no_client_auth' ]; then
-          #   echo "| Test without client auth | ${{ steps.input_selection.outputs.models_for_no_client_auth }} | ${{ steps.input_selection.outputs.python_for_no_client_auth }} |" >> $GITHUB_STEP_SUMMARY
-          # fi
-          # if [ ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'all' || ${{ fromJson(steps.input_selection.outputs.jobs_to_run) }} == 'test_memory_logs' ]; then
-          #   echo "| Test memory logs | ${{ steps.input_selection.outputs.models_for_memory_logs }} | ${{ steps.input_selection.outputs.python_for_memory_logs }} |" >> $GITHUB_STEP_SUMMARY
-          # fi
           echo "" >> $GITHUB_STEP_SUMMARY
 
   test_with_tls:

--- a/tests/end_to_end/utils/summary_helper.py
+++ b/tests/end_to_end/utils/summary_helper.py
@@ -42,7 +42,6 @@ def get_aggregated_accuracy(agg_log_file):
         return agg_accuracy
 
     agg_accuracy_dict = convert_to_json(agg_log_file)
-    print(f"agg_accuracy_dict is: {agg_accuracy_dict}")
 
     if not agg_accuracy_dict:
         print(f"Aggregator log file {agg_log_file} is empty. Cannot get aggregated accuracy, returning 'Not Found'")

--- a/tests/end_to_end/utils/summary_helper.py
+++ b/tests/end_to_end/utils/summary_helper.py
@@ -225,7 +225,7 @@ def _get_summary_file():
     Returns:
         summary_file: Path to the summary file
     """
-    summary_file = Path(os.getenv("GITHUB_STEP_SUMMARY"))
+    summary_file = os.getenv("GITHUB_STEP_SUMMARY")
     print(f"Summary file: {summary_file}")
     if "step_summary" not in summary_file.name or ".env" not in summary_file.name:
         print("Invalid summary file. Exiting...")

--- a/tests/end_to_end/utils/summary_helper.py
+++ b/tests/end_to_end/utils/summary_helper.py
@@ -227,7 +227,10 @@ def _get_summary_file():
     """
     summary_file = os.getenv("GITHUB_STEP_SUMMARY")
     print(f"Summary file: {summary_file}")
-    if "step_summary" not in summary_file.name or ".env" not in summary_file.name:
+    # For local runs, the summary file can be .env file.
+    # For GitHub actions, the summary file name should start with prefix "step_summary".
+    # For e.g. /home/runner/work/_temp/_runner_file_commands/step_summary_ea653f69-bf1c-4a83-a115-c801b1d312a7
+    if "step_summary" not in summary_file or ".env" not in summary_file:
         print("Invalid summary file. Exiting...")
         exit(1)
     return summary_file

--- a/tests/end_to_end/utils/summary_helper.py
+++ b/tests/end_to_end/utils/summary_helper.py
@@ -226,13 +226,13 @@ def _get_summary_file():
     """
     summary_file = os.getenv("GITHUB_STEP_SUMMARY")
     print(f"Summary file: {summary_file}")
-    # For local runs, the summary file can be .env file.
-    # For GitHub actions, the summary file name should start with prefix "step_summary".
-    # For e.g. /home/runner/work/_temp/_runner_file_commands/step_summary_ea653f69-bf1c-4a83-a115-c801b1d312a7
-    if "step_summary" not in summary_file and ".env" not in summary_file:
+
+    # Check if the fetched summary file is valid
+    if summary_file and os.path.isfile(summary_file):
+        return summary_file
+    else:
         print("Invalid summary file. Exiting...")
         exit(1)
-    return summary_file
 
 
 def fetch_args():

--- a/tests/end_to_end/utils/summary_helper.py
+++ b/tests/end_to_end/utils/summary_helper.py
@@ -104,7 +104,7 @@ def get_testcase_result():
 
 def print_task_runner_score():
     """
-    Main function to get the test case results and aggregator logs
+    Function to get the test case results and aggregator logs
     And write the results to GitHub step summary
     IMP: Do not fail the test in any scenario
     """
@@ -130,6 +130,8 @@ def print_task_runner_score():
     num_rounds = os.getenv("NUM_ROUNDS")
     model_name = os.getenv("MODEL_NAME")
     summary_file = os.getenv("GITHUB_STEP_SUMMARY")
+
+    print(f"Summary file: {summary_file}")
 
     # Validate the model name and create the workspace name
     if not model_name.upper() in constants.ModelName._member_names_:
@@ -169,8 +171,13 @@ def print_task_runner_score():
 
 
 def print_federated_runtime_score():
+    """
+    Function to get the federated runtime score from the director log file
+    And write the results to GitHub step summary
+    IMP: Do not fail the test in any scenario
+    """
     summary_file = os.getenv("GITHUB_STEP_SUMMARY")
-
+    print(f"Summary file: {summary_file}")
     search_string = "Aggregated model validation score"
 
     last_occurrence = aggregated_model_score = None

--- a/tests/end_to_end/utils/summary_helper.py
+++ b/tests/end_to_end/utils/summary_helper.py
@@ -230,7 +230,7 @@ def _get_summary_file():
     # For local runs, the summary file can be .env file.
     # For GitHub actions, the summary file name should start with prefix "step_summary".
     # For e.g. /home/runner/work/_temp/_runner_file_commands/step_summary_ea653f69-bf1c-4a83-a115-c801b1d312a7
-    if "step_summary" not in summary_file or ".env" not in summary_file:
+    if "step_summary" not in summary_file and ".env" not in summary_file:
         print("Invalid summary file. Exiting...")
         exit(1)
     return summary_file

--- a/tests/end_to_end/utils/summary_helper.py
+++ b/tests/end_to_end/utils/summary_helper.py
@@ -42,9 +42,14 @@ def get_aggregated_accuracy(agg_log_file):
         return agg_accuracy
 
     agg_accuracy_dict = convert_to_json(agg_log_file)
-    agg_accuracy = agg_accuracy_dict[-1].get(
-        "aggregator/aggregated_model_validation/accuracy", "Not Found"
-    )
+    print(f"agg_accuracy_dict is: {agg_accuracy_dict}")
+
+    if not agg_accuracy_dict:
+        print(f"Aggregator log file {agg_log_file} is empty. Cannot get aggregated accuracy, returning 'Not Found'")
+    else:
+        agg_accuracy = agg_accuracy_dict[-1].get(
+            "aggregator/aggregated_model_validation/accuracy", "Not Found"
+        )
     return agg_accuracy
 
 
@@ -129,9 +134,7 @@ def print_task_runner_score():
     num_cols = os.getenv("NUM_COLLABORATORS")
     num_rounds = os.getenv("NUM_ROUNDS")
     model_name = os.getenv("MODEL_NAME")
-    summary_file = os.getenv("GITHUB_STEP_SUMMARY")
-
-    print(f"Summary file: {summary_file}")
+    summary_file = _get_summary_file()
 
     # Validate the model name and create the workspace name
     if not model_name.upper() in constants.ModelName._member_names_:
@@ -176,8 +179,7 @@ def print_federated_runtime_score():
     And write the results to GitHub step summary
     IMP: Do not fail the test in any scenario
     """
-    summary_file = os.getenv("GITHUB_STEP_SUMMARY")
-    print(f"Summary file: {summary_file}")
+    summary_file = _get_summary_file()
     search_string = "Aggregated model validation score"
 
     last_occurrence = aggregated_model_score = None
@@ -215,6 +217,20 @@ def print_federated_runtime_score():
         print("| Aggregated model validation score |", file=fh)
         print("| ------------- |", file=fh)
         print(f"| {aggregated_model_score} |", file=fh)
+
+
+def _get_summary_file():
+    """
+    Function to get the summary file path
+    Returns:
+        summary_file: Path to the summary file
+    """
+    summary_file = Path(os.getenv("GITHUB_STEP_SUMMARY"))
+    print(f"Summary file: {summary_file}")
+    if "step_summary" not in summary_file.name or ".env" not in summary_file.name:
+        print("Invalid summary file. Exiting...")
+        exit(1)
+    return summary_file
 
 
 def fetch_args():


### PR DESCRIPTION
Parameterised the input for job, model and python version in `TaskRunner E2E` for better manual triggers.

<img width="339" alt="image" src="https://github.com/user-attachments/assets/7480b001-1508-49b4-bf02-cb9863ce7372" />

Also, added a check on the fetched value of `GITHUB_STEP_SUMMARY` before using it - as part of Coverity fix.

Successful E2E job runs:

1. All tests + keras_cnn_mnist + python 3.12 -> https://github.com/noopurintel/openfl/actions/runs/12922201062
2. Test without TLS + torch_cnn_mnist+ python 3.11 -> https://github.com/noopurintel/openfl/actions/runs/12922184838
3. All tests + models + python versions (just like existing flow) -> https://github.com/noopurintel/openfl/actions/runs/12922444478