### PR TITLE
CodeQL Action v2 to v3 & Upload Artifact v3 to v4

### DIFF
--- a/.github/workflows/docker-bench-security.yml
+++ b/.github/workflows/docker-bench-security.yml
@@ -51,7 +51,7 @@ jobs:
           docker-bench-security | tee results/docker_bench_security_report.txt
 
     - name: Upload Security Bench Report
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: docker_bench_security-report
         path: results/docker_bench_security_report.txt

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -31,7 +31,7 @@ jobs:
         docker run -v ${PWD}/openfl-docker:/openfl-docker --rm -i hadolint/hadolint hadolint -t error /openfl-docker/Dockerfile.base
         docker run -v ${PWD}/openfl-docker:/openfl-docker --rm -i hadolint/hadolint hadolint -t error -f json /openfl-docker/Dockerfile.base > hadolint_output.json
     - name: Upload Hadolint JSON Report
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: hadolint-report
         path: hadolint_output.json

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -35,7 +35,7 @@ jobs:
           TRIVY_DB_REPOSITORY: 'ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'
 

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -55,7 +55,7 @@ jobs:
           .
 
       - name: Upload Code Vulnerability Scan Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: trivy-code-report-json
           path: trivy-code-results.json
@@ -74,7 +74,7 @@ jobs:
           TRIVY_DB_REPOSITORY: 'ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db'
   
       - name: Upload Docker Vulnerability Scan
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: trivy-docker-report-json
           path: trivy-docker-results.json
@@ -91,7 +91,7 @@ jobs:
           .
   
       - name: Upload Code Vulnerability Scan Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: trivy-code-spdx-report-json
           path: trivy-code-spdx-results.json
@@ -110,7 +110,7 @@ jobs:
           TRIVY_DB_REPOSITORY: 'ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db'
     
       - name: Upload Docker Vulnerability Scan
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: trivy-docker-spdx-report-json
           path: trivy-docker-spdx-results.json


### PR DESCRIPTION
To fix below warning in case of `codeql-action` and ensure ongoing support for `upload-artifact`

<img width="1282" alt="image" src="https://github.com/user-attachments/assets/ad7d373b-130e-417c-8d43-9033c2ea2a9f" />

References - 
https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/