### PR TITLE
Fix Aggregator / Assigner leaky abstraction

### DIFF
--- a/openfl-workspace/workspace/plan/defaults/aggregator.yaml
+++ b/openfl-workspace/workspace/plan/defaults/aggregator.yaml
@@ -3,4 +3,3 @@ settings :
     db_store_rounds : 2
     persist_checkpoint: True
     persistent_db_path: local_state/tensor.db
-

--- a/openfl/component/assigner/assigner.py
+++ b/openfl/component/assigner/assigner.py
@@ -81,6 +81,16 @@ class Assigner:
         """Abstract method."""
         raise NotImplementedError
 
+    def is_task_group_evaluation(self):
+        """Check if the selected task group is for 'evaluation' run.
+
+        Returns:
+            bool: True if the selected task group is 'evaluation', False otherwise.
+        """
+        if hasattr(self, "selected_task_group"):
+            return self.selected_task_group == "evaluation"
+        return False
+
     def get_all_tasks_for_round(self, round_number):
         """Return tasks for the current round.
 

--- a/openfl/interface/aggregator.py
+++ b/openfl/interface/aggregator.py
@@ -93,11 +93,10 @@ def start_(plan, authorized_cols, task_group):
         cols_config_path=Path(authorized_cols).absolute(),
     )
 
-    # Set task_group in aggregator and assigner settings if provided
+    # Set task_group in assigner settings if provided
     if task_group:
-        if "settings" not in parsed_plan.config["aggregator"]:
-            parsed_plan.config["aggregator"]["settings"] = {}
-        parsed_plan.config["aggregator"]["settings"]["task_group"] = task_group
+        if "settings" not in parsed_plan.config["assigner"]:
+            parsed_plan.config["assigner"]["settings"] = {}
         parsed_plan.config["assigner"]["settings"]["selected_task_group"] = task_group
         logger.info(f"Setting aggregator to assign: {task_group} task_group")
 

--- a/tests/openfl/component/aggregator/test_aggregator.py
+++ b/tests/openfl/component/aggregator/test_aggregator.py
@@ -48,15 +48,12 @@ def agg(mocker, model, assigner):
         'some_uuid',
         'federation_uuid',
         ['col1', 'col2'],
-
         'init_state_path',
         'best_state_path',
         'last_state_path',
-
         assigner,
-    )
+        )
     return agg
-
 
 @pytest.mark.parametrize(
     'cert_common_name,collaborator_common_name,authorized_cols,single_cccn,expected_is_valid', [

--- a/tests/openfl/interface/test_aggregator_api.py
+++ b/tests/openfl/interface/test_aggregator_api.py
@@ -23,11 +23,6 @@ def test_aggregator_start(mock_parse):
     mock_plan.get = {'task_group': 'learning'}.get
     # Add the config attribute with proper nesting
     mock_plan.config = {
-        'aggregator': {
-            'settings': {
-                'task_group': 'learning'
-            }
-        },
         'assigner': {
             'settings': {
                 'selected_task_group': 'learning'
@@ -55,11 +50,6 @@ def test_aggregator_start_illegal_plan(mock_parse, mock_is_directory_traversal):
     mock_plan.get = {'task_group': 'learning'}.get
     # Add the config attribute with proper nesting
     mock_plan.config = {
-        'aggregator': {
-            'settings': {
-                'task_group': 'learning'
-            }
-        },
         'assigner': {
             'settings': {
                 'selected_task_group': 'learning'
@@ -89,11 +79,6 @@ def test_aggregator_start_illegal_cols(mock_parse, mock_is_directory_traversal):
     mock_plan.get = {'task_group': 'learning'}.get
     # Add the config attribute with proper nesting
     mock_plan.config = {
-        'aggregator': {
-            'settings': {
-                'task_group': 'learning'
-            }
-        },
         'assigner': {
             'settings': {
                 'selected_task_group': 'learning'


### PR DESCRIPTION
In PR #1226 task_group is passed to Aggregator and awareness of task_group name is leaked b/w Assigner and Aggregator, to fix this Aggregator should rely on Assigner instead of hardcoding task_group names across multiple classes

- [x] Realign this with final changes in #1226 
 
