### PR TITLE
introduce a mechanism for relearning the aggregator certificate

### DIFF
--- a/openfl/transport/grpc/aggregator_client.py
+++ b/openfl/transport/grpc/aggregator_client.py
@@ -151,7 +151,7 @@ def _resend_data_on_reconnection(func):
                 break
             except grpc.RpcError as e:
                 self.logger.info(
-                    f"Failed to send data request to aggregator at {self.uri}, error code {e.code()}"
+                    f"Failed to send data request to aggregator {self.uri}, error code {e.code()}"
                 )
                 if self.refetch_server_cert_callback is not None:
                     self.logger.info("Refetching server certificate")

--- a/openfl/transport/grpc/aggregator_client.py
+++ b/openfl/transport/grpc/aggregator_client.py
@@ -227,7 +227,9 @@ class AggregatorGRPCClient:
         self.root_certificate = root_certificate
         self.certificate = certificate
         self.private_key = private_key
-        self.sleeping_policy = ConstantBackoff(int(kwargs.get("client_reconnect_interval", 1)), getLogger(__name__), self.uri)
+        self.sleeping_policy = ConstantBackoff(
+            int(kwargs.get("client_reconnect_interval", 1)), getLogger(__name__), self.uri
+        )
         self.logger = getLogger(__name__)
 
         if not self.use_tls:


### PR DESCRIPTION
In reality, the aggregator may restart and come up with new TLS certificate. For that, it is not enough to retry on the wrapper/interceptor level, but we also need to fetch the latest cert.
This PR introduces a mechanism for:
1. registering a callback for fetching the aggregator's latest cert
2. instead of intercepting and retrying on the channel itself (which prevents us from refreshing it), we retry on the wrapper level 