### PR TITLE
A callback for re-fetching the root ca in the aggregator 

### DIFF
--- a/openfl/transport/grpc/aggregator_server.py
+++ b/openfl/transport/grpc/aggregator_server.py
@@ -10,9 +10,12 @@ from multiprocessing import cpu_count
 from random import random
 from time import sleep
 
-from grpc import StatusCode, server
-from grpc import dynamic_ssl_server_credentials
-from grpc import ssl_server_certificate_configuration
+from grpc import (
+    StatusCode,
+    dynamic_ssl_server_credentials,
+    server,
+    ssl_server_certificate_configuration,
+)
 
 from openfl.protocols import aggregator_pb2, aggregator_pb2_grpc, utils
 from openfl.transport.grpc.grpc_channel_options import channel_options
@@ -52,7 +55,7 @@ class AggregatorGRPCServer(aggregator_pb2_grpc.AggregatorServicer):
         root_certificate=None,
         certificate=None,
         private_key=None,
-        clients_certs_refresher_cb=None,
+        root_certificate_refresher_cb=None,
         **kwargs,
     ):
         """
@@ -71,6 +74,8 @@ class AggregatorGRPCServer(aggregator_pb2_grpc.AggregatorServicer):
                 TLS connection.
             private_key (str): The path to the server's private key for the
                 TLS connection.
+            root_certificate_refresher_cb (Callable): A callback function
+                that receive no arguments and return the current root certificate.
             **kwargs: Additional keyword arguments.
         """
         self.aggregator = aggregator
@@ -84,7 +89,7 @@ class AggregatorGRPCServer(aggregator_pb2_grpc.AggregatorServicer):
         self.server_credentials = None
 
         self.logger = logging.getLogger(__name__)
-        self.clients_certs_refresher_cb = clients_certs_refresher_cb
+        self.root_certificate_refresher_cb = root_certificate_refresher_cb
 
     def validate_collaborator(self, request, context):
         """Validate the collaborator.
@@ -335,8 +340,8 @@ class AggregatorGRPCServer(aggregator_pb2_grpc.AggregatorServicer):
 
             def certificate_configuration_fetcher():
                 root_cert = root_certificate_b
-                if self.clients_certs_refresher_cb is not None:
-                    root_cert = self.clients_certs_refresher_cb()
+                if self.root_certificate_refresher_cb is not None:
+                    root_cert = self.root_certificate_refresher_cb()
                 return ssl_server_certificate_configuration(
                     ((private_key_b, certificate_b),), root_certificates=root_cert
                 )

--- a/openfl/transport/grpc/aggregator_server.py
+++ b/openfl/transport/grpc/aggregator_server.py
@@ -10,12 +10,9 @@ from multiprocessing import cpu_count
 from random import random
 from time import sleep
 
-from grpc import (
-    StatusCode,
-    server,
-    dynamic_ssl_server_credentials,
-    ssl_server_certificate_configuration,
-)
+from grpc import StatusCode, server
+from grpc import dynamic_ssl_server_credentials
+from grpc import ssl_server_certificate_configuration
 
 from openfl.protocols import aggregator_pb2, aggregator_pb2_grpc, utils
 from openfl.transport.grpc.grpc_channel_options import channel_options


### PR DESCRIPTION
A collaborator may exchange its root ca during a restart, especially if the collaborator is enclavized and uses a self-signed certificate. In this case, we need to provide a mechanism for the aggregator to fetch the client's root ca (the self-signer certificate) (in practice, it can be fetched from some 3rd trusted certificates store or governor).

In this implementation, the aggregator fetches the new root ca only when a TLS handshake starts, but it's ok as the collaborators start new connection for every new request (see https://github.com/securefederatedai/openfl/blob/develop/openfl/transport/grpc/aggregator_client.py#L136)

The change was tested by restarting the custom collaborator and creating a new self-signed cert on every restart. 