### PR TITLE
TaskRunner E2E - Fix artifact issue for nested model structure

### DIFF
--- a/.github/actions/tr_post_test_run/action.yml
+++ b/.github/actions/tr_post_test_run/action.yml
@@ -25,6 +25,9 @@ runs:
       if: ${{ always() }}
       run: |
         tar -cvf result.tar --exclude="cert" --exclude="data" --exclude="__pycache__" $HOME/results
+        # Model name might contain forward slashes, convert them to underscore. 
+        tmp=${{ env.MODEL_NAME }}
+        echo "MODEL_NAME_MODIFIED=${tmp/\//_}" >> $GITHUB_ENV
       shell: bash
 
     - name: Upload Artifacts
@@ -32,5 +35,5 @@ runs:
       uses: actions/upload-artifact@v4
       if: ${{ always() }}
       with:
-        name: ${{ inputs.test_type }}_${{ env.MODEL_NAME }}_python${{ env.PYTHON_VERSION }}_${{ github.run_id }}
+        name: ${{ inputs.test_type }}_${{ env.MODEL_NAME_MODIFIED }}_python${{ env.PYTHON_VERSION }}_${{ github.run_id }}
         path: result.tar

--- a/.github/workflows/task_runner_fedeval_e2e.yml
+++ b/.github/workflows/task_runner_fedeval_e2e.yml
@@ -30,6 +30,9 @@ env:
 jobs:
   test_with_tls:
     name: tr_tls
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
@@ -73,6 +76,9 @@ jobs:
 
   test_with_non_tls:
     name: tr_non_tls
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
@@ -116,6 +122,9 @@ jobs:
 
   test_with_no_client_auth:
     name: tr_no_client_auth
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:


### PR DESCRIPTION
**Problem** - With nested model structure implemented recently, the Task Runner workflows are failing when artifacts are collected.

**Reason** - The artifact name is set as below without handling the forward slash which is expected in the model name.

`name: ${{ inputs.test_type }}_${{ env.MODEL_NAME }}_python${{ env.PYTHON_VERSION }}_${{ github.run_id }}`

**Solution** - To create an environment variable `MODEL_NAME_MODIFIED` with `/` replaced with `_` and use the same during artifact naming.

```
tmp=${{ env.MODEL_NAME }}
echo "MODEL_NAME_MODIFIED=${tmp/\//_}" >> $GITHUB_ENV
```

`name: ${{ inputs.test_type }}_${{ env.MODEL_NAME_MODIFIED }}_python${{ env.PYTHON_VERSION }}_${{ github.run_id }}`

**Additional** - Workflow `Task_Runner_FedEval_E2E` didn't have a check to skip the nightly run on the forked repo, added the same.


Successful run - [Task Runner Basic E2E](https://github.com/noopurintel/openfl/actions/runs/13112631077)

