### PR TITLE
Read tensor.db for bestscore

### DIFF
--- a/.github/workflows/task_runner_fedeval_e2e.yml
+++ b/.github/workflows/task_runner_fedeval_e2e.yml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         # Models like XGBoost (xgb_higgs) and torch/histology require runners with higher memory and CPU to run.
         # Thus these models are excluded from the matrix for now.
-        model_name: ["torch.mnist", "keras/mnist"]
+        model_name: ["torch/mnist", "keras/mnist"]
         python_version: ["3.10"]
       fail-fast: false # do not immediately fail if one of the combinations fail
 

--- a/docs/_templates/custom-exception-template.rst
+++ b/docs/_templates/custom-exception-template.rst
@@ -2,7 +2,7 @@
 {% if truncated_fullname | length < 4 %}
    {% set truncated_fullname = truncated_fullname.ljust(4) %}
 {% endif %}
-Exceptions - {{ truncated_fullname | escape | underline}}
+Exception - {{ truncated_fullname | escape | underline}}
  
  
 .. currentmodule:: {{ module }}

--- a/openfl-workspace/torch/mnist/plan/plan.yaml
+++ b/openfl-workspace/torch/mnist/plan/plan.yaml
@@ -10,6 +10,7 @@ aggregator:
     rounds_to_train: 2
     write_logs: false
   template: openfl.component.aggregator.Aggregator
+  defaults : plan/defaults/aggregator.yaml
 assigner :
   defaults : plan/defaults/assigner.yaml
 collaborator:

--- a/tests/end_to_end/test_suites/task_runner_tests.py
+++ b/tests/end_to_end/test_suites/task_runner_tests.py
@@ -10,7 +10,7 @@ from tests.end_to_end.utils.tr_common_fixtures import (
     fx_federation_tr_dws,
 )
 from tests.end_to_end.utils import federation_helper as fed_helper
-from tests.end_to_end.utils.summary_helper import get_best_accuracy
+from tests.end_to_end.utils.summary_helper import get_best_agg_score
 
 log = logging.getLogger(__name__)
 
@@ -35,8 +35,8 @@ def test_federation_via_native(request, fx_federation_tr):
     ), "Federation completion failed"
 
     tensor_db_file_path = os.path.join(fx_federation_tr.aggregator.workspace_path, "local_state", "tensor.db")
-    model_accuracy = get_best_accuracy(tensor_db_file_path)
-    log.info(f"Model accuracy post {request.config.num_rounds} rounds: {model_accuracy}")
+    best_agg_score = get_best_agg_score(tensor_db_file_path)
+    log.info(f"Model best aggregated score post {request.config.num_rounds} is {best_agg_score}")
 
 
 @pytest.mark.task_runner_dockerized_ws
@@ -61,5 +61,5 @@ def test_federation_via_dockerized_workspace(request, fx_federation_tr_dws):
     ), "Federation completion failed"
 
     tensor_db_file_path = os.path.join(fx_federation_tr_dws.aggregator.workspace_path, "local_state", "tensor.db")
-    model_accuracy = get_best_accuracy(tensor_db_file_path)
-    log.info(f"Model accuracy post {request.config.num_rounds} rounds: {model_accuracy}")
+    best_agg_score = get_best_agg_score(tensor_db_file_path)
+    log.info(f"Model best aggregated score post {request.config.num_rounds} is {best_agg_score}")

--- a/tests/end_to_end/test_suites/task_runner_tests.py
+++ b/tests/end_to_end/test_suites/task_runner_tests.py
@@ -10,7 +10,7 @@ from tests.end_to_end.utils.tr_common_fixtures import (
     fx_federation_tr_dws,
 )
 from tests.end_to_end.utils import federation_helper as fed_helper
-from tests.end_to_end.utils.summary_helper import get_aggregated_accuracy
+from tests.end_to_end.utils.summary_helper import get_best_accuracy
 
 log = logging.getLogger(__name__)
 
@@ -34,8 +34,8 @@ def test_federation_via_native(request, fx_federation_tr):
         num_rounds=request.config.num_rounds,
     ), "Federation completion failed"
 
-    metric_file_path = os.path.join(fx_federation_tr.aggregator.workspace_path, "logs", "aggregator_metrics.txt")
-    model_accuracy = get_aggregated_accuracy(metric_file_path)
+    tensor_db_file_path = os.path.join(fx_federation_tr.aggregator.workspace_path, "local_state", "tensor.db")
+    model_accuracy = get_best_accuracy(tensor_db_file_path)
     log.info(f"Model accuracy post {request.config.num_rounds} rounds: {model_accuracy}")
 
 
@@ -60,6 +60,6 @@ def test_federation_via_dockerized_workspace(request, fx_federation_tr_dws):
         num_rounds=request.config.num_rounds,
     ), "Federation completion failed"
 
-    metric_file_path = os.path.join(fx_federation_tr_dws.aggregator.workspace_path, "logs", "aggregator_metrics.txt")
-    model_accuracy = get_aggregated_accuracy(metric_file_path)
+    tensor_db_file_path = os.path.join(fx_federation_tr_dws.aggregator.workspace_path, "local_state", "tensor.db")
+    model_accuracy = get_best_accuracy(tensor_db_file_path)
     log.info(f"Model accuracy post {request.config.num_rounds} rounds: {model_accuracy}")

--- a/tests/end_to_end/test_suites/tr_with_fedeval_tests.py
+++ b/tests/end_to_end/test_suites/tr_with_fedeval_tests.py
@@ -11,7 +11,7 @@ from tests.end_to_end.utils.tr_common_fixtures import (
 )
 from tests.end_to_end.utils import federation_helper as fed_helper
 from tests.end_to_end.utils.tr_workspace import create_tr_workspace, create_tr_dws_workspace
-from tests.end_to_end.utils.summary_helper import get_aggregated_accuracy
+from tests.end_to_end.utils.summary_helper import get_best_accuracy
 
 log = logging.getLogger(__name__)
 
@@ -37,9 +37,9 @@ def test_eval_federation_via_native(request, fx_federation_tr):
 
     # Set the best model path in request. It is used during plan initialization for evaluation step
     request.config.best_model_path = os.path.join(fx_federation_tr.aggregator.workspace_path, "save", "best.pbuf")
-    metric_file_path = os.path.join(fx_federation_tr.aggregator.workspace_path, "logs", "aggregator_metrics.txt")
-    model_accuracy = get_aggregated_accuracy(metric_file_path)
-    log.info(f"Model accuracy post {request.config.num_rounds} rounds: {model_accuracy}")
+    tensor_db_file_path = os.path.join(fx_federation_tr.aggregator.workspace_path, "local_state", "tensor.db")
+    best_model_accuracy = get_best_accuracy(tensor_db_file_path)
+    log.info(f"Model accuracy post {request.config.num_rounds} rounds: {best_model_accuracy}")
     # Create new workspace with evaluation scope
     new_fed_obj = create_tr_workspace(request, eval_scope=True)
 
@@ -52,12 +52,12 @@ def test_eval_federation_via_native(request, fx_federation_tr):
         num_rounds=1,
     ), "Federation completion failed"
 
-    new_metric_file_path = os.path.join(new_fed_obj.aggregator.workspace_path, "logs", "aggregator_metrics.txt")
-    model_accuracy_eval = get_aggregated_accuracy(new_metric_file_path)
-    log.info(f"Model accuracy during evaluation only on prev trained model is : {model_accuracy_eval})")
+    tensor_db_file_path = os.path.join(new_fed_obj.aggregator.workspace_path, "local_state", "tensor.db")
+    best_model_accuracy_eval = get_best_accuracy(tensor_db_file_path)
+    log.info(f"Model accuracy post {request.config.num_rounds} rounds: {best_model_accuracy}")
 
     # verify that the model accuracy is similar to the previous model accuracy max of 1% difference
-    assert abs(model_accuracy - model_accuracy_eval) <= 0.01, "Model accuracy is not similar to the previous model accuracy"
+    assert abs(best_model_accuracy - best_model_accuracy_eval) <= 0.01, "Model accuracy is not similar to the previous model accuracy"
 
 
 @pytest.mark.task_runner_dockerized_ws
@@ -83,9 +83,10 @@ def test_eval_federation_via_dockerized_workspace(request, fx_federation_tr_dws)
 
     # Set the best model path in request. It is used during plan initialization for evaluation step
     request.config.best_model_path = os.path.join(fx_federation_tr_dws.aggregator.workspace_path, "save", "best.pbuf")
-    metric_file_path = os.path.join(fx_federation_tr_dws.aggregator.workspace_path, "logs", "aggregator_metrics.txt")
-    model_accuracy = get_aggregated_accuracy(metric_file_path)
-    log.info(f"Model accuracy post {request.config.num_rounds} rounds: {model_accuracy}")
+
+    tensor_db_file_path = os.path.join(fx_federation_tr_dws.aggregator.workspace_path, "local_state", "tensor.db")
+    best_model_accuracy = get_best_accuracy(tensor_db_file_path)
+    log.info(f"Model accuracy post {request.config.num_rounds} rounds: {best_model_accuracy}")
 
     # Create new workspace with evaluation scope
     new_fed_obj = create_tr_dws_workspace(request, eval_scope=True)
@@ -99,9 +100,9 @@ def test_eval_federation_via_dockerized_workspace(request, fx_federation_tr_dws)
         num_rounds=1,
     ), "Federation completion failed"
 
-    new_metric_file_path = os.path.join(new_fed_obj.aggregator.workspace_path, "logs", "aggregator_metrics.txt")
-    model_accuracy_eval = get_aggregated_accuracy(new_metric_file_path)
-    log.info(f"Model accuracy during evaluation only on prev trained model is : {model_accuracy_eval})")
+    tensor_db_file_path = os.path.join(new_fed_obj.aggregator.workspace_path, "local_state", "tensor.db")
+    best_model_accuracy_eval = get_best_accuracy(tensor_db_file_path)
+    log.info(f"Model accuracy post {request.config.num_rounds} rounds: {best_model_accuracy}")
 
     # verify that the model accuracy is similar to the previous model accuracy max of 1% difference
-    assert abs(model_accuracy - model_accuracy_eval) <= 0.01, "Model accuracy is not similar to the previous model accuracy"
+    assert abs(best_model_accuracy - best_model_accuracy_eval) <= 0.01, "Model accuracy is not similar to the previous model accuracy"

--- a/tests/end_to_end/test_suites/tr_with_fedeval_tests.py
+++ b/tests/end_to_end/test_suites/tr_with_fedeval_tests.py
@@ -11,10 +11,11 @@ from tests.end_to_end.utils.tr_common_fixtures import (
 )
 from tests.end_to_end.utils import federation_helper as fed_helper
 from tests.end_to_end.utils.tr_workspace import create_tr_workspace, create_tr_dws_workspace
-from tests.end_to_end.utils.summary_helper import get_best_accuracy
+from tests.end_to_end.utils.summary_helper import get_best_agg_score
 
 log = logging.getLogger(__name__)
 
+TOLERANCE = 0.00001
 
 @pytest.mark.task_runner_basic
 def test_eval_federation_via_native(request, fx_federation_tr):
@@ -38,8 +39,8 @@ def test_eval_federation_via_native(request, fx_federation_tr):
     # Set the best model path in request. It is used during plan initialization for evaluation step
     request.config.best_model_path = os.path.join(fx_federation_tr.aggregator.workspace_path, "save", "best.pbuf")
     tensor_db_file_path = os.path.join(fx_federation_tr.aggregator.workspace_path, "local_state", "tensor.db")
-    best_model_accuracy = get_best_accuracy(tensor_db_file_path)
-    log.info(f"Model accuracy post {request.config.num_rounds} rounds: {best_model_accuracy}")
+    best_model_score = get_best_agg_score(tensor_db_file_path)
+    log.info(f"Model score post {request.config.num_rounds} rounds: {best_model_score}")
     # Create new workspace with evaluation scope
     new_fed_obj = create_tr_workspace(request, eval_scope=True)
 
@@ -53,11 +54,11 @@ def test_eval_federation_via_native(request, fx_federation_tr):
     ), "Federation completion failed"
 
     tensor_db_file_path = os.path.join(new_fed_obj.aggregator.workspace_path, "local_state", "tensor.db")
-    best_model_accuracy_eval = get_best_accuracy(tensor_db_file_path)
-    log.info(f"Model accuracy post {request.config.num_rounds} rounds: {best_model_accuracy}")
+    best_model_score_eval = get_best_agg_score(tensor_db_file_path)
+    log.info(f"Model score post {request.config.num_rounds} rounds: {best_model_score}")
 
-    # verify that the model accuracy is similar to the previous model accuracy max of 1% difference
-    assert abs(best_model_accuracy - best_model_accuracy_eval) <= 0.01, "Model accuracy is not similar to the previous model accuracy"
+    # verify that the model score is similar to the previous model score max of 0.001% difference
+    assert abs(best_model_score - best_model_score_eval) <= TOLERANCE, "Model score is not similar to the previous score"
 
 
 @pytest.mark.task_runner_dockerized_ws
@@ -85,8 +86,8 @@ def test_eval_federation_via_dockerized_workspace(request, fx_federation_tr_dws)
     request.config.best_model_path = os.path.join(fx_federation_tr_dws.aggregator.workspace_path, "save", "best.pbuf")
 
     tensor_db_file_path = os.path.join(fx_federation_tr_dws.aggregator.workspace_path, "local_state", "tensor.db")
-    best_model_accuracy = get_best_accuracy(tensor_db_file_path)
-    log.info(f"Model accuracy post {request.config.num_rounds} rounds: {best_model_accuracy}")
+    best_model_score = get_best_agg_score(tensor_db_file_path)
+    log.info(f"Model score post {request.config.num_rounds} rounds: {best_model_score}")
 
     # Create new workspace with evaluation scope
     new_fed_obj = create_tr_dws_workspace(request, eval_scope=True)
@@ -101,8 +102,8 @@ def test_eval_federation_via_dockerized_workspace(request, fx_federation_tr_dws)
     ), "Federation completion failed"
 
     tensor_db_file_path = os.path.join(new_fed_obj.aggregator.workspace_path, "local_state", "tensor.db")
-    best_model_accuracy_eval = get_best_accuracy(tensor_db_file_path)
-    log.info(f"Model accuracy post {request.config.num_rounds} rounds: {best_model_accuracy}")
+    best_model_score_eval = get_best_agg_score(tensor_db_file_path)
+    log.info(f"Model score post {request.config.num_rounds} rounds: {best_model_score}")
 
-    # verify that the model accuracy is similar to the previous model accuracy max of 1% difference
-    assert abs(best_model_accuracy - best_model_accuracy_eval) <= 0.01, "Model accuracy is not similar to the previous model accuracy"
+    # verify that the model score is similar to the previous model score max of 0.001% difference
+    assert abs(best_model_score - best_model_score_eval) <= TOLERANCE, "Model score is not similar to the previous score"

--- a/tests/end_to_end/utils/db_helper.py
+++ b/tests/end_to_end/utils/db_helper.py
@@ -1,0 +1,49 @@
+import sqlite3
+
+# Database schema:
+# Table: key_value_store
+# Columns: key, value
+# Table: next_round_tensors
+# Columns: id, tensor_name, origin, round, report, tags, nparray
+# Table: tensors
+# Columns: id, tensor_name, origin, round, report, tags, nparray
+
+
+class DBHelper:
+    def __init__(self, db_name):
+        self.db_name = db_name
+        self.conn = None
+        self.cursor = None
+
+    def connect(self):
+        self.conn = sqlite3.connect(self.db_name)
+        self.cursor = self.conn.cursor()
+
+    def close(self):
+        if self.conn:
+            self.conn.close()
+
+    def read_key_value_store(self):
+        """
+        key_value_store - This table holds key-value pairs. It only holds best_score and round_number.
+                        This table holds which round had best score and what is best score until now in experiment.
+        Reads key-value pairs from the key_value_store table in the database.
+        This method connects to the database, executes a query to fetch all key-value pairs
+        from the key_value_store table, and then closes the connection. It returns the values
+        associated with the 'round_number' and 'best_score' keys.
+        Raises:
+            ValueError: If either 'round_number' or 'best_score' keys are not found in the key_value_store.
+        Returns:
+            tuple: A tuple containing the values of 'round_number' and 'best_score'.
+        """
+        self.connect()
+        self.cursor.execute("SELECT key, value FROM key_value_store")
+        rows = self.cursor.fetchall()
+        self.close()
+
+        key_value_dict = {row[0]: row[1] for row in rows}
+
+        if 'round_number' not in key_value_dict or 'best_score' not in key_value_dict:
+            raise ValueError("Required keys 'round_number' and 'best_score' not found in key_value_store")
+
+        return key_value_dict['round_number'], key_value_dict['best_score']

--- a/tests/end_to_end/utils/db_helper.py
+++ b/tests/end_to_end/utils/db_helper.py
@@ -1,3 +1,6 @@
+# Copyright 2020-2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import sqlite3
 
 # Database schema:

--- a/tests/end_to_end/utils/summary_helper.py
+++ b/tests/end_to_end/utils/summary_helper.py
@@ -48,7 +48,7 @@ def get_best_accuracy(database_file):
 
     db_helper = DBHelper(database_file)
     round_number, best_score = db_helper.read_key_value_store()
-    print(f"Round number: {round_number}, Best score: {best_score}")
+    print(f"Round number: {int(round_number)}, Best accuracy: {best_score}")
     return best_accuracy
 
 

--- a/tests/end_to_end/utils/summary_helper.py
+++ b/tests/end_to_end/utils/summary_helper.py
@@ -3,13 +3,14 @@
 
 import argparse
 from defusedxml.ElementTree import parse as defused_parse
-from lxml import etree
+import defusedxml.ElementTree as etree
 import os
 import re
 from pathlib import Path
 
 import tests.end_to_end.utils.constants as constants
 from tests.end_to_end.utils.generate_report import convert_to_json
+from tests.end_to_end.utils.db_helper import DBHelper
 
 result_path = os.path.join(Path().home(), "results")
 
@@ -30,6 +31,25 @@ def initialize_xml_parser():
     # Get the root element
     testsuites = tree.getroot()
     return testsuites
+
+
+def get_best_accuracy(database_file):
+    """
+    Get the best accuracy from the database
+    Args:
+        database_file: the database file
+    Returns:
+        best_accuracy: the best accuracy
+    """
+    best_accuracy = "Not Found"
+    if not os.path.exists(database_file):
+        print(f"Database file {database_file} not found. Cannot get best accuracy")
+        return best_accuracy
+
+    db_helper = DBHelper(database_file)
+    round_number, best_score = db_helper.read_key_value_store()
+    print(f"Round number: {round_number}, Best score: {best_score}")
+    return best_accuracy
 
 
 def get_aggregated_accuracy(agg_log_file):
@@ -156,10 +176,10 @@ def print_task_runner_score():
         model_name,
         "aggregator",
         "workspace",
-        "logs",
-        "aggregator_metrics.txt",
+        "local_state",
+        "tensor.db",
     )
-    agg_accuracy = get_aggregated_accuracy(agg_log_file)
+    agg_accuracy = get_best_accuracy(agg_log_file)
 
     # Write the results to GitHub step summary file
     # This file is created at runtime by the GitHub action, thus we cannot verify its existence beforehand

--- a/tests/end_to_end/utils/summary_helper.py
+++ b/tests/end_to_end/utils/summary_helper.py
@@ -3,7 +3,7 @@
 
 import argparse
 from defusedxml.ElementTree import parse as defused_parse
-import defusedxml.ElementTree as etree
+from lxml import etree
 import os
 import re
 from pathlib import Path
@@ -48,7 +48,7 @@ def get_best_accuracy(database_file):
 
     db_helper = DBHelper(database_file)
     round_number, best_score = db_helper.read_key_value_store()
-    print(f"Round number: {int(round_number)}, Best accuracy: {best_score}")
+    print(f"Best accuracy: {best_score} is in round_number {round_number} ")
     return best_accuracy
 
 
@@ -171,7 +171,7 @@ def print_task_runner_score():
         return
 
     # Assumption - result directory is present in the home directory
-    agg_log_file = os.path.join(
+    tensor_db_file = os.path.join(
         result_path,
         model_name,
         "aggregator",
@@ -179,7 +179,7 @@ def print_task_runner_score():
         "local_state",
         "tensor.db",
     )
-    agg_accuracy = get_best_accuracy(agg_log_file)
+    best_score = get_best_accuracy(tensor_db_file)
 
     # Write the results to GitHub step summary file
     # This file is created at runtime by the GitHub action, thus we cannot verify its existence beforehand
@@ -195,7 +195,7 @@ def print_task_runner_score():
         )
         for item in result:
             print(
-                f"| {item['name']} | {item['time']} | {item['result']} | {item['err_msg']} | {num_cols} | {num_rounds} | {agg_accuracy} |",
+                f"| {item['name']} | {item['time']} | {item['result']} | {item['err_msg']} | {num_cols} | {num_rounds} | {best_score} |",
                 file=fh,
             )
 

--- a/tests/end_to_end/utils/summary_helper.py
+++ b/tests/end_to_end/utils/summary_helper.py
@@ -46,8 +46,8 @@ def get_best_agg_score(database_file):
         return best_agg_score
 
     db_obj = DBHelper(database_file)
-    round_number, best_score = db_obj.read_key_value_store()
-    print(f"Best aggregated score: {best_score} is in round_number {round_number} ")
+    round_number, best_agg_score = db_obj.read_key_value_store()
+    print(f"Best aggregated score: {best_agg_score} is in round_number {round_number} ")
     return best_agg_score
 
 

--- a/tests/end_to_end/utils/summary_helper.py
+++ b/tests/end_to_end/utils/summary_helper.py
@@ -9,7 +9,6 @@ import re
 from pathlib import Path
 
 import tests.end_to_end.utils.constants as constants
-from tests.end_to_end.utils.generate_report import convert_to_json
 from tests.end_to_end.utils.db_helper import DBHelper
 
 result_path = os.path.join(Path().home(), "results")
@@ -33,49 +32,23 @@ def initialize_xml_parser():
     return testsuites
 
 
-def get_best_accuracy(database_file):
+def get_best_agg_score(database_file):
     """
-    Get the best accuracy from the database
+    Get the best_score from the database
     Args:
         database_file: the database file
     Returns:
-        best_accuracy: the best accuracy
+        best_agg_score: the best score
     """
-    best_accuracy = "Not Found"
+    best_agg_score = "Not Found"
     if not os.path.exists(database_file):
-        print(f"Database file {database_file} not found. Cannot get best accuracy")
-        return best_accuracy
+        print(f"Database file {database_file} not found. Cannot get best aggregated score")
+        return best_agg_score
 
-    db_helper = DBHelper(database_file)
-    round_number, best_score = db_helper.read_key_value_store()
-    print(f"Best accuracy: {best_score} is in round_number {round_number} ")
-    return best_accuracy
-
-
-def get_aggregated_accuracy(agg_log_file):
-    """
-    Get the aggregated accuracy from aggregator logs
-    Args:
-        agg_log_file: the aggregator log file
-    Returns:
-        agg_accuracy: the aggregated accuracy
-    """
-    agg_accuracy = "Not Found"
-    if not os.path.exists(agg_log_file):
-        print(
-            f"Aggregator log file {agg_log_file} not found. Cannot get aggregated accuracy"
-        )
-        return agg_accuracy
-
-    agg_accuracy_dict = convert_to_json(agg_log_file)
-
-    if not agg_accuracy_dict:
-        print(f"Aggregator log file {agg_log_file} is empty. Cannot get aggregated accuracy, returning 'Not Found'")
-    else:
-        agg_accuracy = agg_accuracy_dict[-1].get(
-            "aggregator/aggregated_model_validation/accuracy", "Not Found"
-        )
-    return agg_accuracy
+    db_obj = DBHelper(database_file)
+    round_number, best_score = db_obj.read_key_value_store()
+    print(f"Best aggregated score: {best_score} is in round_number {round_number} ")
+    return best_agg_score
 
 
 def get_test_status(result):
@@ -179,7 +152,7 @@ def print_task_runner_score():
         "local_state",
         "tensor.db",
     )
-    best_score = get_best_accuracy(tensor_db_file)
+    best_score = get_best_agg_score(tensor_db_file)
 
     # Write the results to GitHub step summary file
     # This file is created at runtime by the GitHub action, thus we cannot verify its existence beforehand


### PR DESCRIPTION
1. Change torch/mnist plan to get tensor.db in local_state.
This change is done in continuation of Eran's creation of tensor.db file. For keras/mnist it was creating in local_state and torch/mnist was getting created in workspace of aggregator.
3. Change summary_helper to get details from tensor.db instead of metrics.
4. Use defused etree for XMLParser.
5. **Documentation** change - Instead of Exceptions write Exception