### PR TITLE
Add `--version` to fx CLI

### DIFF
--- a/openfl/interface/cli.py
+++ b/openfl/interface/cli.py
@@ -14,6 +14,7 @@ from logging import basicConfig
 from pathlib import Path
 from sys import argv, path
 
+import pkg_resources
 from click import (
     Group,
     argument,
@@ -157,11 +158,25 @@ class CLI(Group):
                 )
 
 
-@group(cls=CLI)
+def get_version():
+    """Get the version of the openfl module.
+
+    Returns:
+        str: Version of the openfl module.
+    """
+    try:
+        version = pkg_resources.get_distribution("openfl").version
+        return version
+    except pkg_resources.DistributionNotFound:
+        return "openfl is not installed"
+
+
+@group(cls=CLI, invoke_without_command=True)
 @option("-l", "--log-level", default="info", help="Logging verbosity level.")
 @option("--no-warnings", is_flag=True, help="Disable third-party warnings.")
+@option("-v", "--version", is_flag=True, help="Show version")
 @pass_context
-def cli(context, log_level, no_warnings):
+def cli(context, log_level, no_warnings, version):
     """
     Command-line Interface.
 
@@ -169,7 +184,11 @@ def cli(context, log_level, no_warnings):
         context (click.core.Context): Click context.
         log_level (str): Logging verbosity level.
         no_warnings (bool): Flag to disable third-party warnings.
+        version (bool): Flag to show version.
     """
+    if version:
+        echo(f"OpenFL version: {get_version()}")
+        context.exit()
 
     context.ensure_object(dict)
     context.obj["log_level"] = log_level


### PR DESCRIPTION
This PR adds support for `fx --version` to get the openfl version.