### PR TITLE
Return non-zero exit code should any lint check fail

### DIFF
--- a/openfl/interface/cli.py
+++ b/openfl/interface/cli.py
@@ -10,9 +10,9 @@ import sys
 import time
 import warnings
 from importlib import import_module
+from sys import argv, path
 from logging import basicConfig
 from pathlib import Path
-from sys import argv, path
 
 from click import (
     Group,

--- a/openfl/interface/cli.py
+++ b/openfl/interface/cli.py
@@ -10,9 +10,9 @@ import sys
 import time
 import warnings
 from importlib import import_module
-from sys import argv, path
 from logging import basicConfig
 from pathlib import Path
+from sys import argv, path
 
 from click import (
     Group,

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -7,5 +7,9 @@ base_dir=$(dirname $(dirname $0))
 SKIP=bandit pre-commit run --all-files
 
 ruff check --config "${base_dir}/pyproject.toml" openfl/
+exitcode=$?
 
 ruff format --check --config "${base_dir}/pyproject.toml" openfl/
+exitcode=$(($exitcode + $?))
+
+exit $exitcode


### PR DESCRIPTION
I did not realize that removing `e` flag from #1345 would default to zero exit code even when lint check fails. This PR fixes it.