### PR TITLE
Fix `fx --version`

### DIFF
--- a/openfl/interface/cli.py
+++ b/openfl/interface/cli.py
@@ -14,7 +14,6 @@ from logging import basicConfig
 from pathlib import Path
 from sys import argv, path
 
-import pkg_resources
 from click import (
     Group,
     argument,
@@ -30,6 +29,7 @@ from click import (
 from rich.console import Console
 from rich.logging import RichHandler
 
+import openfl
 from openfl.utilities import add_log_level
 
 
@@ -157,21 +157,14 @@ class CLI(Group):
                     f"  {style('*', fg='green')} {style(name, fg='cyan'):<21} {help_str}" + "\n"
                 )
 
-
-def get_version():
-    """Get the version of the openfl module.
-
-    Returns:
-        str: Version of the openfl module.
-    """
-    try:
-        version = pkg_resources.get_distribution("openfl").version
-        return version
-    except pkg_resources.DistributionNotFound:
-        return "openfl is not installed"
+    def invoke(self, ctx):
+        if ctx.params.get("version"):
+            echo(f"OpenFL version: {openfl.__version__}")
+            ctx.exit()
+        super().invoke(ctx)
 
 
-@group(cls=CLI, invoke_without_command=True)
+@group(cls=CLI)
 @option("-l", "--log-level", default="info", help="Logging verbosity level.")
 @option("--no-warnings", is_flag=True, help="Disable third-party warnings.")
 @option("-v", "--version", is_flag=True, help="Show version")
@@ -186,9 +179,6 @@ def cli(context, log_level, no_warnings, version):
         no_warnings (bool): Flag to disable third-party warnings.
         version (bool): Flag to show version.
     """
-    if version:
-        echo(f"OpenFL version: {get_version()}")
-        context.exit()
 
     context.ensure_object(dict)
     context.obj["log_level"] = log_level


### PR DESCRIPTION
Re-enables list commands when issuing fx without any args or commands by removing the use of `invoke_without_commands`, introduced for invoking `fx --version`.