### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,30 @@
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     open-pull-requests-limit: 3
+
   # Don't update these directories.
   - package-ecosystem: pip
     directory: /tests
     schedule:
-      interval: "daily"
+      interval: "monthly"
     ignore:
       - dependency-name: "*"
   - package-ecosystem: pip
     directory: /openfl-workspace
     schedule:
-      interval: "daily"
+      interval: "monthly"
     ignore:
       - dependency-name: "*"


### PR DESCRIPTION
Given the multi-framework nature of OpenFL. This repository relies on a proportionately large number of packages, which increases the frequency of package updates globally, with minimally useful returns on frequent bumps.

This PR lets dependabot raise updates monthly instead of daily, in line with open source best practices. In addition, this PR also asks dependabot to propose updates to `github-actions` automatically.