### PR TITLE
List FedEval notebook in the openfl-tutorial/readme

### DIFF
--- a/openfl-tutorials/README.md
+++ b/openfl-tutorials/README.md
@@ -29,6 +29,7 @@ fx experimental activate
 - [MNIST Aggregator Validation Ray Watermarking](https://github.com/securefederatedai/openfl/tree/develop/openfl-tutorials/experimental/workflow/402_MNIST_Aggregator_Validation_Ray_Watermarking.ipynb): Combines aggregator validation, watermarking, and multi-GPU training using Ray Backend in OpenFL.
 - [Federated FedProx PyTorch MNIST Workflow Tutorial](https://github.com/securefederatedai/openfl/tree/develop/openfl-tutorials/experimental/workflow/403_Federated_FedProx_PyTorch_MNIST_Workflow_Tutorial.ipynb): Implements FedProx algorithm for distributed training on MNIST using PyTorch and Workflow API.
 - [Keras MNIST with FedProx](https://github.com/securefederatedai/openfl/tree/develop/openfl-tutorials/experimental/workflow/404_Keras_MNIST_with_FedProx.ipynb): Trains a TensorFlow Keras model on MNIST using OpenFL Workflow Interface with FedProx optimization.
+- [Federated Evaluation MNIST Workflow Tutorial](https://github.com/securefederatedai/openfl/tree/develop/openfl-tutorials/experimental/workflow/405_MNIST_FederatedEvaluation.ipynb): Shows how to implement Federated Evaluation using Workflow API.
 - [Workspace Creation from JupyterNotebook](https://github.com/securefederatedai/openfl/tree/develop/openfl-tutorials/experimental/workflow/1001_Workspace_Creation_from_JupyterNotebook.ipynb): Demonstrates converting a Jupyter Notebook Federated Learning experiment into an OpenFL workspace.
 
 ### Advanced

--- a/openfl-tutorials/experimental/workflow/405_MNIST_FederatedEvaluation.ipynb
+++ b/openfl-tutorials/experimental/workflow/405_MNIST_FederatedEvaluation.ipynb
@@ -72,13 +72,15 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "id": "3a4a7108",
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd108b5a",
    "metadata": {
     "vscode": {
-     "languageId": "raw"
+     "languageId": "code-text-binary"
     }
    },
+   "outputs": [],
    "source": [
     "Sample of the final model weights: tensor([[[ 0.1221, -0.0846, -0.0635,  0.0590, -0.2059],\n",
     "         [ 0.1558, -0.0202,  0.1005,  0.0272, -0.0148],\n",


### PR DESCRIPTION
This PR implements following changes:

- updates the openfl-tutorial/README file with link to FedEval notebook
- Fix a minor issue with sample output being hidden in notebook
Before
![Screenshot 2025-02-12 145744](https://github.com/user-attachments/assets/38d201b8-0b37-43f2-96e3-f756a8649189)
After
![Screenshot 2025-02-12 150029](https://github.com/user-attachments/assets/cd6022a6-668e-43e1-a86d-7a190d601966)
