### PR TITLE
[Workflow Interface] Fix for FederatedRuntime bringup in distributed infrastructure (backport PR #1327 in OpenFL v1.7.x)

### DIFF
--- a/openfl-workspace/experimental/workflow/AggregatorBasedWorkflow/workspace/plan/defaults/network.yaml
+++ b/openfl-workspace/experimental/workflow/AggregatorBasedWorkflow/workspace/plan/defaults/network.yaml
@@ -2,8 +2,6 @@ template: openfl.federation.Network
 settings:
     agg_addr                   : auto
     agg_port                   : auto
-    hash_salt                  : auto
     tls                        : True
     client_reconnect_interval  : 5
     disable_client_auth        : False
-    cert_folder                : cert

--- a/openfl/experimental/workflow/federated/plan/plan.py
+++ b/openfl/experimental/workflow/federated/plan/plan.py
@@ -163,6 +163,7 @@ class Plan:
                     f"[blue]{plan_config_path}[/].",
                     extra={"markup": True},
                 )
+                Plan.dump(plan_config_path, plan.config)
                 Plan.logger.info(dump(plan.config))
 
             return plan
@@ -338,7 +339,7 @@ class Plan:
         private_key=None,
         certificate=None,
         client=None,
-        tls=False,
+        tls=True,
         envoy_config=None,
     ) -> "Collaborator":
         """Get collaborator.
@@ -406,7 +407,7 @@ class Plan:
         root_certificate=None,
         private_key=None,
         certificate=None,
-        tls=False,
+        tls=True,
     ) -> AggregatorGRPCClient:
         """Get gRPC client for the specified collaborator.
 
@@ -425,8 +426,8 @@ class Plan:
         Returns:
             AggregatorGRPCClient: gRPC client for the specified collaborator.
         """
-        common_name = collaborator_name
-        if not root_certificate or not private_key or not certificate:
+        if tls and not (root_certificate and private_key and certificate):
+            common_name = collaborator_name
             root_certificate = "cert/cert_chain.crt"
             certificate = f"cert/client/col_{common_name}.crt"
             private_key = f"cert/client/col_{common_name}.key"
@@ -438,7 +439,6 @@ class Plan:
         client_args["root_certificate"] = root_certificate
         client_args["certificate"] = certificate
         client_args["private_key"] = private_key
-        client_args["tls"] = tls
 
         client_args["aggregator_uuid"] = aggregator_uuid
         client_args["federation_uuid"] = federation_uuid
@@ -453,7 +453,7 @@ class Plan:
         root_certificate=None,
         private_key=None,
         certificate=None,
-        tls=False,
+        tls=True,
         director_config=None,
         **kwargs,
     ) -> AggregatorGRPCServer:
@@ -474,9 +474,8 @@ class Plan:
         Returns:
             AggregatorGRPCServer: gRPC server of the aggregator instance.
         """
-        common_name = self.config["network"][SETTINGS]["agg_addr"].lower()
-
-        if not root_certificate or not private_key or not certificate:
+        if tls and not (root_certificate and private_key and certificate):
+            common_name = self.config["network"][SETTINGS]["agg_addr"].lower()
             root_certificate = "cert/cert_chain.crt"
             certificate = f"cert/server/agg_{common_name}.crt"
             private_key = f"cert/server/agg_{common_name}.key"

--- a/openfl/experimental/workflow/runtime/federated_runtime.py
+++ b/openfl/experimental/workflow/runtime/federated_runtime.py
@@ -149,6 +149,8 @@ class FederatedRuntime(Runtime):
         archive_path, exp_name = WorkspaceExport.export_federated(
             notebook_path=self.notebook_path,
             output_workspace="./generated_workspace",
+            director_fqdn=self.director["director_node_fqdn"],
+            tls=self.tls,
         )
         return archive_path, exp_name
 

--- a/openfl/experimental/workflow/workspace_export/export.py
+++ b/openfl/experimental/workflow/workspace_export/export.py
@@ -19,6 +19,7 @@ import nbformat
 import yaml
 from nbdev.export import nb_export
 
+from openfl.experimental.workflow.federated.plan import Plan
 from openfl.experimental.workflow.interface.cli.cli_helper import print_tree
 
 logger = getLogger(__name__)
@@ -276,12 +277,16 @@ class WorkspaceExport:
             yaml.safe_dump(data, y)
 
     @classmethod
-    def export_federated(cls, notebook_path: str, output_workspace: str) -> Tuple[str, str]:
+    def export_federated(
+        cls, notebook_path: str, output_workspace: str, director_fqdn: str, tls: bool = False
+    ) -> Tuple[str, str]:
         """Exports workspace for FederatedRuntime.
 
         Args:
             notebook_path (str): Path to the Jupyter notebook.
             output_workspace (str): Path for the generated workspace directory.
+            director_fqdn (str): Fully qualified domain name of the director node.
+            tls (bool, optional): Whether to use TLS for the connection.
 
         Returns:
             Tuple[str, str]: A tuple containing:
@@ -289,7 +294,7 @@ class WorkspaceExport:
         """
         instance = cls(notebook_path, output_workspace)
         instance.generate_requirements()
-        instance.generate_plan_yaml()
+        instance.generate_plan_yaml(director_fqdn, tls)
         return instance.generate_experiment_archive()
 
     @classmethod
@@ -357,9 +362,13 @@ class WorkspaceExport:
                 if i not in line_nos:
                     f.write(line)
 
-    def generate_plan_yaml(self) -> None:
+    def generate_plan_yaml(self, director_fqdn: str = None, tls: bool = False) -> None:
         """
         Generates plan.yaml
+
+        Args:
+            director_fqdn (str): Fully qualified domain name of the director node.
+            tls (bool, optional): Whether to use TLS for the connection.
         """
         flspec = importlib.import_module("openfl.experimental.workflow.interface").FLSpec
         # Get flow classname
@@ -397,6 +406,13 @@ class WorkspaceExport:
         # Find kwargs of flow class and it's values
         kw_args = self.arguments_passed_to_initialize["kwargs"]
         update_dictionary(kw_args, data, dtype="kwargs")
+
+        # Updating the aggregator address with director's hostname and tls settings in plan.yaml
+        if director_fqdn:
+            network_settings = Plan.parse(plan).config["network"]
+            data["network"] = network_settings
+            data["network"]["settings"]["agg_addr"] = director_fqdn
+            data["network"]["settings"]["tls"] = tls
 
         self.__write_yaml(plan, data)
 


### PR DESCRIPTION
**Background:**
FederatedRuntime bringup is not successful in a distributed infrastructure setup when Director, Envoys and User are located on different machines. This PR is backporting the fix from openfl/develop branch to OpenFL v1.7.x release
Reference: Issue #1265.
Fix: #1327.
 
**Change Description & Modifications:**
 
- The `agg_addr` field in `plan.yaml` is now updated with the user-provided value in `FederatedRuntime` (`director_node_fqdn`).
- A detailed description of this change is provided in PR #1327
 
**Verification**
- [X] Confirmed that agg_addr is correctly updated with the Director's hostname in plan.yaml, preventing the issue from recurring.
- [X] Local infrastructure: Tested with & without TLS .
- [X]  Distributed infrastructure: Without TLS.
 
**Files modified**
- `openfl/experimental/workflow/federated/plan/plan.py`
- `openfl/experimental/workflow/runtime/federated_runtime.py`
- `openfl/experimental/workflow/workspace_export/export.py`
- `openfl-workspace/experimental/workflow/AggregatorBasedWorkflow/workspace/plan/defaults/network.yaml`
 
**Note:**
1. The Envoy admin and Experiment Manager must ensure they provide the correct Director IP to enable proper communication and prevent connectivity issues.
2. Admins and users must ensure that the same Python version is maintained across the infrastructure.