### PR TITLE
Fix doc URL

### DIFF
--- a/docs/about/features_index/fed_eval.rst
+++ b/docs/about/features_index/fed_eval.rst
@@ -12,7 +12,7 @@ Model evaluation is an essential part of the machine learning development cycle.
 OpenFL's Support for Federated Evaluation
 ------------------------------------------
 
-OpenFL, a flexible framework for Federated Learning, has the capability to perform federated evaluation by modifying the federation plan. In this document, we will show how OpenFL can facilitate this process through its `TaskRunner API <https://openfl.readthedocs.io/en/latest/about/features_index/taskrunner.html>`_, where the model evaluation is distributed across various collaborators before being sent to the aggregator. For the task runner API, this involves minor modifications to the ``plan.yaml`` file, which defines the workflow and tasks for the federation. In particular, the federation plan should be defined to run for one forward pass and perform only aggregated model validation.
+OpenFL, a flexible framework for Federated Learning, has the capability to perform federated evaluation by modifying the federation plan. In this document, we will show how OpenFL can facilitate this process through its :doc:`taskrunner`, where the model evaluation is distributed across various collaborators before being sent to the aggregator. For the task runner API, this involves minor modifications to the ``plan.yaml`` file, which defines the workflow and tasks for the federation. In particular, the federation plan should be defined to run for one forward pass and perform only aggregated model validation.
 
 In general a Federated Evaluation pipeline is as follows:
 


### PR DESCRIPTION
Current FedEval document source code directly refers to the TaskRunner API global URL in ReadTheDoc, this renders local hosting of document to navigate out of the local version of the doc. We should do relative referencing so that documents even when hosted locally are navigable without global context, wherever applicable.

Local doc build steps / verification:

```
pip install -r docs/requirements.txt
```

```
pip install sphinx-autobuild
sphinx-autobuild . _build/html
```
This will serve the docs locally (usually at http://localhost:8000/)

Validated the changes in local build:
![image](https://github.com/user-attachments/assets/3f555933-8ef4-43fe-846d-e4056dfd84f4)

