### PR TITLE
Do not run windows workflow in draft stage

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,6 +14,10 @@ env:
 
 jobs:
   pytest-coverage: # from pytest_coverage.yml
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event.pull_request.draft == false)
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
@@ -38,6 +42,10 @@ jobs:
         coverage report
   
   keras_mnist: # from taskrunner.yml -  keras/mnist
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event.pull_request.draft == false)
     runs-on: windows-latest
     timeout-minutes: 15
     steps:
@@ -76,6 +84,10 @@ jobs:
           python -m tests.github.test_hello_federation --template torch/mnist_eden_compression --fed_workspace aggregator --col1 col1 --col2 col2  --rounds-to-train 3
 
   torch_mnist_straggler_check: # from straggler-handling.yml - torch/mnist_straggler_check
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event.pull_request.draft == false)
     runs-on: windows-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,6 +2,7 @@ name: Windows (latest)
 
 on:
   workflow_call:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
 


### PR DESCRIPTION
Condition to run the workflow in case of events like a scheduled run or a ready pull request was missed out earlier. Added the same.

Previously - https://github.com/securefederatedai/openfl/actions/runs/13367634548

Successful skip after code change (with this PR in draft stage) - https://github.com/securefederatedai/openfl/actions/runs/13382494757/job/37373380833?pr=1382


