### PR TITLE
Make GRPC transport decorators configurable & disable atomic decorator by default

### DIFF
--- a/openfl-workspace/workspace/plan/defaults/network.yaml
+++ b/openfl-workspace/workspace/plan/defaults/network.yaml
@@ -7,3 +7,4 @@ settings:
     client_reconnect_interval  : 5
     require_client_auth        : True
     cert_folder                : cert
+    enable_atomic_connections  : False

--- a/openfl/transport/grpc/aggregator_client.py
+++ b/openfl/transport/grpc/aggregator_client.py
@@ -96,7 +96,10 @@ class RetryOnRpcErrorClientInterceptor(
             if isinstance(response, grpc.RpcError):
                 # If status code is not in retryable status codes
                 self.sleeping_policy.logger.info("Response code: %s", response.code())
-                if self.status_for_retry and response.code() not in self.status_for_retry:
+                if (
+                    self.status_for_retry
+                    and response.code() not in self.status_for_retry
+                ):
                     return response
 
                 self.sleeping_policy.sleep()
@@ -117,7 +120,9 @@ class RetryOnRpcErrorClientInterceptor(
         """
         return self._intercept_call(continuation, client_call_details, request)
 
-    def intercept_stream_unary(self, continuation, client_call_details, request_iterator):
+    def intercept_stream_unary(
+        self, continuation, client_call_details, request_iterator
+    ):
         """
         Wrap intercept call for stream->unary RPC.
 
@@ -135,6 +140,8 @@ class RetryOnRpcErrorClientInterceptor(
 
 def _atomic_connection(func):
     def wrapper(self, *args, **kwargs):
+        if not self.enable_atomic_connections:
+            return func(self, *args, **kwargs)
         self.reconnect()
         response = func(self, *args, **kwargs)
         self.disconnect()
@@ -145,6 +152,8 @@ def _atomic_connection(func):
 
 def _resend_data_on_reconnection(func):
     def wrapper(self, *args, **kwargs):
+        if not self.resend_data_on_reconnection:
+            return func(self, *args, **kwargs)
         while True:
             try:
                 response = func(self, *args, **kwargs)
@@ -198,6 +207,8 @@ class AggregatorGRPCClient:
         federation_uuid=None,
         single_col_cert_common_name=None,
         refetch_server_cert_callback=None,
+        enable_atomic_connections=False,
+        resend_data_on_reconnection=True,
         **kwargs,
     ):
         """
@@ -228,12 +239,18 @@ class AggregatorGRPCClient:
         self.certificate = certificate
         self.private_key = private_key
         self.sleeping_policy = ConstantBackoff(
-            int(kwargs.get("client_reconnect_interval", 1)), getLogger(__name__), self.uri
+            int(kwargs.get("client_reconnect_interval", 1)),
+            getLogger(__name__),
+            self.uri,
         )
         self.logger = getLogger(__name__)
+        self.enable_atomic_connections = enable_atomic_connections
+        self.resend_data_on_reconnection = resend_data_on_reconnection
 
         if not self.use_tls:
-            self.logger.warning("gRPC is running on insecure channel with TLS disabled.")
+            self.logger.warning(
+                "gRPC is running on insecure channel with TLS disabled."
+            )
             self.channel = self.create_insecure_channel(self.uri)
         else:
             self.channel = self.create_tls_channel(
@@ -345,7 +362,7 @@ class AggregatorGRPCClient:
 
     def disconnect(self):
         """Close the gRPC channel."""
-        self.logger.debug("Disconnecting from gRPC server at %s", self.uri)
+        self.logger.info("Disconnecting from gRPC server at %s", self.uri)
         self.channel.close()
 
     def reconnect(self):
@@ -365,7 +382,7 @@ class AggregatorGRPCClient:
                 self.private_key,
             )
 
-        self.logger.debug("Connecting to gRPC at %s", self.uri)
+        self.logger.info("Connecting to gRPC at %s", self.uri)
 
         self.stub = aggregator_pb2_grpc.AggregatorStub(self.channel)
 

--- a/openfl/transport/grpc/aggregator_client.py
+++ b/openfl/transport/grpc/aggregator_client.py
@@ -160,6 +160,9 @@ def _resend_data_on_reconnection(func):
                 if self.refetch_server_cert_callback is not None:
                     self.logger.info("Refetching server certificate")
                     self.root_certificate = self.refetch_server_cert_callback()
+                if not self.enable_atomic_connections:
+                    self.logger.info("Reconnecting to aggregator")
+                    self.reconnect()
                 self.sleeping_policy.sleep()
         return response
 

--- a/openfl/transport/grpc/aggregator_client.py
+++ b/openfl/transport/grpc/aggregator_client.py
@@ -96,10 +96,7 @@ class RetryOnRpcErrorClientInterceptor(
             if isinstance(response, grpc.RpcError):
                 # If status code is not in retryable status codes
                 self.sleeping_policy.logger.info("Response code: %s", response.code())
-                if (
-                    self.status_for_retry
-                    and response.code() not in self.status_for_retry
-                ):
+                if self.status_for_retry and response.code() not in self.status_for_retry:
                     return response
 
                 self.sleeping_policy.sleep()
@@ -120,9 +117,7 @@ class RetryOnRpcErrorClientInterceptor(
         """
         return self._intercept_call(continuation, client_call_details, request)
 
-    def intercept_stream_unary(
-        self, continuation, client_call_details, request_iterator
-    ):
+    def intercept_stream_unary(self, continuation, client_call_details, request_iterator):
         """
         Wrap intercept call for stream->unary RPC.
 
@@ -248,9 +243,7 @@ class AggregatorGRPCClient:
         self.resend_data_on_reconnection = resend_data_on_reconnection
 
         if not self.use_tls:
-            self.logger.warning(
-                "gRPC is running on insecure channel with TLS disabled."
-            )
+            self.logger.warning("gRPC is running on insecure channel with TLS disabled.")
             self.channel = self.create_insecure_channel(self.uri)
         else:
             self.channel = self.create_tls_channel(


### PR DESCRIPTION
### Problem statement
The atomic connection decorators always reestablish connections on transport IO. This is not a desired IO characteristic especially due to penalty of reconnecting.
This PR proposes configuration to make these decorators option. By default atomic connections are disabled and can be provisioned when required.

### Background information on atomic connections (from @psfoley)
The background of reestablishing a connection for every request was due to early issues. There were problems resulting from long established connections when there was any kind of network instability. This started happening more with certain releases of gRPC around that time (1.32?). 
The atomic connection decorator, and establishing the connection only when communication was needed, was the solution for that. 
As long as the retry logic is left intact, I don't expect there would be problems making the change back to long standing connections (as long as this is thoroughly tested) 

### Summary of changes
- Add knobs to provision these decorators optionally when required.
- Log connection points since this is critical for debugging and tuning other attributes of service such as rate limiting etc.,

### Testing done
- Verified federation run with atomic connectivity disabled hence eliminating service level reconnects.
- Verified federation run with atomic connectivity enabled and correlating reconnects with logs.
