### PR TITLE
Add pre-requisites in the FederatedRuntime notebooks

### DIFF
--- a/openfl-tutorials/experimental/workflow/FederatedRuntime/101_MNIST/workspace/101_MNIST_FederatedRuntime.ipynb
+++ b/openfl-tutorials/experimental/workflow/FederatedRuntime/101_MNIST/workspace/101_MNIST_FederatedRuntime.ipynb
@@ -24,7 +24,8 @@
     "**Key Features covered**:  \n",
     "1. **Simulate** Federated Learning experiment using `LocalRuntime`. Explore [101 MNIST](https://github.com/securefederatedai/openfl/blob/develop/openfl-tutorials/experimental/workflow/101_MNIST.ipynb) for insights\n",
     "2. Enable creation of workspace content by annotating Jupyter notebook with export directives. Explore [1001 Workspace Creation from JupyterNotebook](https://github.com/securefederatedai/openfl/blob/develop/openfl-tutorials/experimental/workflow/1001_Workspace_Creation_from_JupyterNotebook.ipynb) for insights\n",
-    "3. **Deploy** the experiment on Federated infrastructure (Director and Envoy nodes) using `FederatedRuntime`\n",
+    "3. **Deploy** the experiment on Federated infrastructure (Director and Envoy nodes) using `FederatedRuntime`.\n",
+    "   NOTE: Participants in the Federation should be launched using the steps described in [README.md](https://github.com/securefederatedai/openfl/blob/develop/openfl-tutorials/experimental/workflow/FederatedRuntime/101_MNIST/README.md) before deploying the experiment.\n",
     "\n",
     "Let's get started !\n"
    ]
@@ -70,7 +71,7 @@
    "id": "d109332c",
    "metadata": {},
    "source": [
-    "### Installing Pre-requisties\n",
+    "### Installing Pre-requisites\n",
     "We start by installing OpenFL and dependencies of the workflow interface. These dependencies are exported and become requirements for the Federated Learning Environment "
    ]
   },

--- a/openfl-tutorials/experimental/workflow/FederatedRuntime/301_MNIST_Watermarking/workspace/MNIST_Watermarking.ipynb
+++ b/openfl-tutorials/experimental/workflow/FederatedRuntime/301_MNIST_Watermarking/workspace/MNIST_Watermarking.ipynb
@@ -14,7 +14,7 @@
    "id": "3b7357ef",
    "metadata": {},
    "source": [
-    "This tutorial is based on the LocalRuntime example [301_MNIST_Watermarking](https://github.com/securefederatedai/openfl/blob/develop/openfl-tutorials/experimental/workflow/301_MNIST_Watermarking.ipynb). It has been adapted to demonstrate the FederatedRuntime version of the watermarking workflow. In this tutorial, we will guide you through the process of deploying the watermarking example within a federation, showcasing how to transition from a local setup to a federated environment effectively."
+    "This tutorial is based on the LocalRuntime example [301_MNIST_Watermarking](https://github.com/securefederatedai/openfl/blob/develop/openfl-tutorials/experimental/workflow/301_MNIST_Watermarking.ipynb). It has been adapted to demonstrate the FederatedRuntime version of the watermarking workflow. In this tutorial, we will guide you through the process of deploying the watermarking example within a federation, showcasing how to transition from a local setup to a federated environment effectively. User should follow the steps described in [README.md](https://github.com/securefederatedai/openfl/blob/develop/openfl-tutorials/experimental/workflow/FederatedRuntime/301_MNIST_Watermarking/README.md) to ensure that participants in federation are launched before the experiment is deployed to federated environment.\n"
    ]
   },
   {


### PR DESCRIPTION
To prevent confusion, include a backward reference to the README file within the notebook.