### PR TITLE
Changes to reduce memory footprint in Aggregator

### DIFF
--- a/openfl/component/aggregator/aggregator.py
+++ b/openfl/component/aggregator/aggregator.py
@@ -3,10 +3,12 @@
 
 """Aggregator module."""
 
+import ctypes
+import gc
 import logging
+import os
 import queue
 import time
-import gc
 from threading import Lock
 from typing import List, Optional
 
@@ -20,6 +22,7 @@ from openfl.protocols.base_pb2 import NamedTensor
 from openfl.utilities import TaskResultKey, TensorKey, change_tags
 
 logger = logging.getLogger(__name__)
+
 
 class Aggregator:
     """An Aggregator is the central node in federated learning.
@@ -62,6 +65,7 @@ class Aggregator:
     .. note::
         - plan setting
     """
+
     def __init__(
         self,
         aggregator_uuid,
@@ -802,7 +806,6 @@ class Aggregator:
 
             self._end_of_round_with_stragglers_check()
 
-
     def _end_of_round_with_stragglers_check(self):
         """
         Checks if the minimum required collaborators have reported their results,
@@ -1120,6 +1123,13 @@ class Aggregator:
         self.stragglers = []
         # resetting collaborators_done for next round
         self.collaborators_done = []
+        self.tensor_db.clean_up(self.db_store_rounds)
+        self.release_memory()
+        # End of round callbacks.
+        self.callbacks.on_round_end(self.round_number, logs)
+
+        # Reset straggler handling policy for the next round.
+        self.straggler_handling_policy.reset_policy_for_round()
 
         # TODO This needs to be fixed!
         if self._time_to_quit():
@@ -1128,15 +1138,6 @@ class Aggregator:
             logger.info("Starting round %s...", self.round_number)
             # https://github.com/securefederatedai/openfl/pull/1195#discussion_r1879479537
             self.callbacks.on_round_begin(self.round_number)
-
-        self.tensor_db.clean_up(self.db_store_rounds)
-        gc.collect()
-
-        # End of round callbacks.
-        self.callbacks.on_round_end(self.round_number, logs)
-
-        # Reset straggler handling policy for the next round.
-        self.straggler_handling_policy.reset_policy_for_round()
 
     def _is_collaborator_done(self, collaborator_name: str, round_number: int) -> None:
         """
@@ -1202,3 +1203,10 @@ class Aggregator:
                 collaborator_name,
             )
             self.quit_job_sent_to.append(collaborator_name)
+
+    def release_memory():
+        """Release memory back to the operating system."""
+        gc.collect()
+        if os.name == "posix":
+            libc = ctypes.CDLL("libc.so.6")
+            libc.malloc_trim(0)

--- a/openfl/component/aggregator/aggregator.py
+++ b/openfl/component/aggregator/aggregator.py
@@ -6,6 +6,7 @@
 import logging
 import queue
 import time
+import gc
 from threading import Lock
 from typing import List, Optional
 
@@ -19,7 +20,6 @@ from openfl.protocols.base_pb2 import NamedTensor
 from openfl.utilities import TaskResultKey, TensorKey, change_tags
 
 logger = logging.getLogger(__name__)
-
 
 class Aggregator:
     """An Aggregator is the central node in federated learning.
@@ -62,7 +62,6 @@ class Aggregator:
     .. note::
         - plan setting
     """
-
     def __init__(
         self,
         aggregator_uuid,
@@ -381,6 +380,7 @@ class Aggregator:
         self.model = utils.construct_model_proto(
             tensor_dict, round_number, self.compression_pipeline
         )
+        del og_tensor_dict, tensor_keys, tensor_dict
         utils.dump_proto(self.model, file_path)
 
     def valid_collaborator_cn_and_id(self, cert_common_name, collaborator_common_name):
@@ -613,7 +613,7 @@ class Aggregator:
         named_tensor = self._nparray_to_named_tensor(
             agg_tensor_key, nparray, send_model_deltas=True, compress_lossless=compress_lossless
         )
-
+        del nparray
         return named_tensor
 
     def _nparray_to_named_tensor(self, tensor_key, nparray, send_model_deltas, compress_lossless):
@@ -658,6 +658,7 @@ class Aggregator:
                 metadata,
                 lossless=compress_lossless,
             )
+            del model_nparray, delta_comp_tensor_key, delta_comp_nparray, metadata
 
         else:
             # Assume every other tensor requires lossless compression
@@ -670,7 +671,7 @@ class Aggregator:
                 metadata,
                 lossless=compress_lossless,
             )
-
+            del compressed_tensor_key, compressed_nparray, metadata
         return named_tensor
 
     def _collaborator_task_completed(self, collaborator, task_name, round_num):
@@ -800,6 +801,7 @@ class Aggregator:
             self._is_collaborator_done(collaborator_name, round_number)
 
             self._end_of_round_with_stragglers_check()
+
 
     def _end_of_round_with_stragglers_check(self):
         """
@@ -1083,7 +1085,6 @@ class Aggregator:
                         self._save_model(round_number, self.best_state_path)
             if "trained" in tags:
                 self._prepare_trained(tensor_name, origin, round_number, report, agg_results)
-
         return metrics
 
     def _end_of_round_check(self):
@@ -1107,9 +1108,6 @@ class Aggregator:
         for task_name in self.assigner.get_all_tasks_for_round(self.round_number):
             logs.update(self._compute_validation_related_task_metrics(task_name))
 
-        # End of round callbacks.
-        self.callbacks.on_round_end(self.round_number, logs)
-
         # Once all of the task results have been processed
         self._end_of_round_check_done[self.round_number] = True
 
@@ -1131,8 +1129,12 @@ class Aggregator:
             # https://github.com/securefederatedai/openfl/pull/1195#discussion_r1879479537
             self.callbacks.on_round_begin(self.round_number)
 
-        # Cleaning tensor db
         self.tensor_db.clean_up(self.db_store_rounds)
+        gc.collect()
+
+        # End of round callbacks.
+        self.callbacks.on_round_end(self.round_number, logs)
+
         # Reset straggler handling policy for the next round.
         self.straggler_handling_policy.reset_policy_for_round()
 

--- a/openfl/databases/tensor_db.py
+++ b/openfl/databases/tensor_db.py
@@ -15,7 +15,6 @@ from openfl.databases.utilities import ROUND_PLACEHOLDER, _retrieve, _search, _s
 from openfl.interface.aggregation_functions import AggregationFunction
 from openfl.utilities import LocalTensor, TensorKey, change_tags
 
-
 class TensorDB:
     """The TensorDB stores a tensor key and the data that it corresponds to.
 
@@ -29,7 +28,6 @@ class TensorDB:
         mutex: A threading Lock object used to ensure thread-safe operations
             on the tensor_db Dataframe.
     """
-
     def __init__(self) -> None:
         """Initializes a new instance of the TensorDB class."""
         types_dict = {
@@ -83,16 +81,25 @@ class TensorDB:
             remove_older_than (int, optional): Entries older than this number
                 of rounds are removed. Defaults to 1.
         """
+
         if remove_older_than < 0:
             # Getting a negative argument calls off cleaning
             return
         current_round = self.tensor_db["round"].astype(int).max()
         if current_round == ROUND_PLACEHOLDER:
             current_round = np.sort(self.tensor_db["round"].astype(int).unique())[-2]
+        # Keep only recent records
+        old_tensor_db = self.tensor_db
         self.tensor_db = self.tensor_db[
             (self.tensor_db["round"].astype(int) > current_round - remove_older_than)
             | self.tensor_db["report"]
-        ].reset_index(drop=True)
+        ].copy()  # Avoid unnecessary memory retention
+
+        self.tensor_db.reset_index(drop=True, inplace=True)
+
+        # Delete old DataFrame and force garbage collection
+        del old_tensor_db
+
 
     def cache_tensor(self, tensor_key_dict: Dict[TensorKey, np.ndarray]) -> None:
         """Insert a tensor into TensorDB (dataframe).
@@ -106,25 +113,28 @@ class TensorDB:
         """
         entries_to_add = []
         with self.mutex:
+            old_tensor_db = self.tensor_db
             for tensor_key, nparray in tensor_key_dict.items():
                 tensor_name, origin, fl_round, report, tags = tensor_key
-                entries_to_add.append(
-                    pd.DataFrame(
+                new_entry = pd.DataFrame(
+                    [
                         [
-                            [
-                                tensor_name,
-                                origin,
-                                fl_round,
-                                report,
-                                tags,
-                                nparray,
-                            ]
-                        ],
-                        columns=list(self.tensor_db.columns),
-                    )
+                            tensor_name,
+                            origin,
+                            fl_round,
+                            report,
+                            tags,
+                            nparray,
+                        ]
+                    ],
+                    columns=list(self.tensor_db.columns),
                 )
+                entries_to_add.append(new_entry)
 
-            self.tensor_db = pd.concat([self.tensor_db, *entries_to_add], ignore_index=True)
+            self.tensor_db = pd.concat([self.tensor_db, *entries_to_add], ignore_index=True, copy=True)
+
+            del old_tensor_db
+            entries_to_add.clear()
 
     def get_tensor_from_cache(self, tensor_key: TensorKey) -> Optional[np.ndarray]:
         """Perform a lookup of the tensor_key in the TensorDB.
@@ -149,6 +159,8 @@ class TensorDB:
 
         if len(df) == 0:
             return None
+
+
         return np.array(df["nparray"].iloc[0])
 
     def get_tensors_by_round_and_tags(self, fl_round: int, tags: tuple) -> dict:
@@ -249,6 +261,7 @@ class TensorDB:
             else:
                 agg_tensor_dict[col] = raw_df.iloc[0]
 
+        del raw_df
         local_tensors = [
             LocalTensor(
                 col_name=col_name,
@@ -276,6 +289,7 @@ class TensorDB:
         db_iterator = self._iterate()
         agg_nparray = aggregation_function(local_tensors, db_iterator, tensor_name, fl_round, tags)
         self.cache_tensor({tensor_key: agg_nparray})
+
 
         return np.array(agg_nparray)
 

--- a/openfl/databases/tensor_db.py
+++ b/openfl/databases/tensor_db.py
@@ -15,6 +15,7 @@ from openfl.databases.utilities import ROUND_PLACEHOLDER, _retrieve, _search, _s
 from openfl.interface.aggregation_functions import AggregationFunction
 from openfl.utilities import LocalTensor, TensorKey, change_tags
 
+
 class TensorDB:
     """The TensorDB stores a tensor key and the data that it corresponds to.
 
@@ -28,6 +29,7 @@ class TensorDB:
         mutex: A threading Lock object used to ensure thread-safe operations
             on the tensor_db Dataframe.
     """
+
     def __init__(self) -> None:
         """Initializes a new instance of the TensorDB class."""
         types_dict = {
@@ -100,7 +102,6 @@ class TensorDB:
         # Delete old DataFrame and force garbage collection
         del old_tensor_db
 
-
     def cache_tensor(self, tensor_key_dict: Dict[TensorKey, np.ndarray]) -> None:
         """Insert a tensor into TensorDB (dataframe).
 
@@ -131,7 +132,9 @@ class TensorDB:
                 )
                 entries_to_add.append(new_entry)
 
-            self.tensor_db = pd.concat([self.tensor_db, *entries_to_add], ignore_index=True, copy=True)
+            self.tensor_db = pd.concat(
+                [self.tensor_db, *entries_to_add], ignore_index=True, copy=True
+            )
 
             del old_tensor_db
             entries_to_add.clear()
@@ -159,7 +162,6 @@ class TensorDB:
 
         if len(df) == 0:
             return None
-
 
         return np.array(df["nparray"].iloc[0])
 
@@ -289,7 +291,6 @@ class TensorDB:
         db_iterator = self._iterate()
         agg_nparray = aggregation_function(local_tensors, db_iterator, tensor_name, fl_round, tags)
         self.cache_tensor({tensor_key: agg_nparray})
-
 
         return np.array(agg_nparray)
 

--- a/openfl/protocols/utils.py
+++ b/openfl/protocols/utils.py
@@ -6,7 +6,6 @@
 from openfl.protocols import base_pb2
 from openfl.utilities import TensorKey
 
-
 def model_proto_to_bytes_and_metadata(model_proto):
     """Convert the model protobuf to bytes and metadata.
 
@@ -235,6 +234,9 @@ def deconstruct_model_proto(model_proto, compression_pipeline):
         tensor_dict[key] = compression_pipeline.backward(
             data=bytes_dict[key], transformer_metadata=metadata_dict[key]
         )
+    del bytes_dict
+    del metadata_dict
+
     return tensor_dict, round_number
 
 
@@ -288,10 +290,8 @@ def dump_proto(model_proto, fpath):
         model_proto: The protobuf of the model.
         fpath: The file path to dump the protobuf.
     """
-    s = model_proto.SerializeToString()
     with open(fpath, "wb") as f:
-        f.write(s)
-
+        f.write(model_proto.SerializeToString())
 
 def datastream_to_proto(proto, stream, logger=None):
     """Convert the datastream to the protobuf.
@@ -312,6 +312,7 @@ def datastream_to_proto(proto, stream, logger=None):
         proto.ParseFromString(npbytes)
         if logger is not None:
             logger.debug("datastream_to_proto parsed a %s.", type(proto))
+        del npbytes
         return proto
     else:
         raise RuntimeError(f"Received empty stream message of type {type(proto)}")

--- a/openfl/protocols/utils.py
+++ b/openfl/protocols/utils.py
@@ -6,6 +6,7 @@
 from openfl.protocols import base_pb2
 from openfl.utilities import TensorKey
 
+
 def model_proto_to_bytes_and_metadata(model_proto):
     """Convert the model protobuf to bytes and metadata.
 
@@ -292,6 +293,7 @@ def dump_proto(model_proto, fpath):
     """
     with open(fpath, "wb") as f:
         f.write(model_proto.SerializeToString())
+
 
 def datastream_to_proto(proto, stream, logger=None):
     """Convert the datastream to the protobuf.

--- a/openfl/transport/grpc/aggregator_server.py
+++ b/openfl/transport/grpc/aggregator_server.py
@@ -258,12 +258,17 @@ class AggregatorGRPCServer(aggregator_pb2_grpc.AggregatorServicer):
             tags,
             require_lossless,
         )
-
-        return aggregator_pb2.GetAggregatedTensorResponse(
+        try:
+            response = aggregator_pb2.GetAggregatedTensorResponse(
             header=self.get_header(collaborator_name),
             round_number=round_number,
             tensor=named_tensor,
-        )
+            )
+        finally:
+            # Ensure any resources used by named_tensor are released
+            del named_tensor
+
+        return response
 
     def SendLocalTaskResults(self, request, context):  # NOQA:N802
         """Request a model download from aggregator.

--- a/openfl/transport/grpc/aggregator_server.py
+++ b/openfl/transport/grpc/aggregator_server.py
@@ -260,9 +260,9 @@ class AggregatorGRPCServer(aggregator_pb2_grpc.AggregatorServicer):
         )
         try:
             response = aggregator_pb2.GetAggregatedTensorResponse(
-            header=self.get_header(collaborator_name),
-            round_number=round_number,
-            tensor=named_tensor,
+                header=self.get_header(collaborator_name),
+                round_number=round_number,
+                tensor=named_tensor,
             )
         finally:
             # Ensure any resources used by named_tensor are released


### PR DESCRIPTION
Changes made:

- Explicit deletion of local variables reduces the run-time footprint as the garbage collector
- Moved the measurement of memory to after tensor_db::clean_up() to get a clearer picture of memory usage.
- Added garbage collection at the end of round post db clean_up to free up unused memory.