### PR TITLE
Persist gRPC Connection

### DIFF
--- a/openfl/component/collaborator/collaborator.py
+++ b/openfl/component/collaborator/collaborator.py
@@ -196,6 +196,7 @@ class Collaborator:
 
         # Experiment end
         self.callbacks.on_experiment_end()
+        self.client.disconnect() # close gRPC connection after experiment
         logger.info("Received shutdown signal. Exiting...")
 
     def run_simulation(self):


### PR DESCRIPTION
The previous implementation of gRPC used an atomic connection, where a new connection was established for each call to the server and then disconnected upon completion.

The logic has now been modified to maintain a persistent gRPC connection throughout the entire experiment.
Additionally, checks have been added to ensure that the connection remains active before making a gRPC call, preventing unnecessary failures.