### PR TITLE
Skip push event trigger for PR specific workflows

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -1,10 +1,6 @@
 name: Bandit Code Scan
 
 on:
-  push:
-    branches: 
-      - develop
-      - v1.7.x
   workflow_call:
   workflow_dispatch:
 

--- a/.github/workflows/experimental_workflow_tests.yml
+++ b/.github/workflows/experimental_workflow_tests.yml
@@ -1,10 +1,6 @@
 name: Workflow Interface Tests
 
 on:
-  push:
-    branches: 
-      - develop
-      - v1.7.x
   workflow_call:
   workflow_dispatch:
 

--- a/.github/workflows/federated_runtime.yml
+++ b/.github/workflows/federated_runtime.yml
@@ -1,7 +1,7 @@
 #---------------------------------------------------------------------------
 # Workflow to run 301_MNIST_Watermarking notebook
 #---------------------------------------------------------------------------
-name: Federated Runtime 301 MNIST Watermarking
+name: Federated Runtime Watermarking E2E
 
 on:
   workflow_call:

--- a/.github/workflows/openfl-docker-build.yml
+++ b/.github/workflows/openfl-docker-build.yml
@@ -1,10 +1,6 @@
 name: Build and Push Openfl Docker Image
 
 on:
-  push:
-    branches: 
-      - develop
-      - v1.7.x
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/pr_pipeline.yml
+++ b/.github/workflows/pr_pipeline.yml
@@ -36,7 +36,7 @@ jobs:
     uses: ./.github/workflows/docker-bench-security.yml
 
   fr_301_watermark_nb_run:
-    name: Federated Runtime 301 MNIST Watermarking
+    name: Federated Runtime Watermarking E2E
     uses: ./.github/workflows/federated_runtime.yml
 
   gandlf_taskrunner:
@@ -85,7 +85,7 @@ jobs:
     uses: ./.github/workflows/wf_functional_e2e.yml
 
   workflow_interface_101_mnist:
-    name: Federated Runtime Watermarking E2E
+    name: Workflow Interface 101 MNIST Notebook
     uses: ./.github/workflows/workflow_interface_101_mnist.yml
 
   workflow_interface_tests:

--- a/.github/workflows/pr_pipeline.yml
+++ b/.github/workflows/pr_pipeline.yml
@@ -85,7 +85,7 @@ jobs:
     uses: ./.github/workflows/wf_functional_e2e.yml
 
   workflow_interface_101_mnist:
-    name: Workflow Interface 101 MNIST Notebook
+    name: Federated Runtime Watermarking E2E
     uses: ./.github/workflows/workflow_interface_101_mnist.yml
 
   workflow_interface_tests:

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -6,9 +6,6 @@ name: Task_Runner_E2E  # Please do not modify the name as it is used in the comp
 on:
   schedule:
     - cron: "0 0 * * *" # Run every day at midnight
-  push:
-    branches: 
-      - develop
   workflow_call:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/task_runner_e2e_resiliency.yml
+++ b/.github/workflows/task_runner_e2e_resiliency.yml
@@ -6,9 +6,6 @@ name: Task_Runner_E2E_Resiliency  # Please do not modify the name as it is used 
 on:
   schedule:
     - cron: "0 5 * * *" # Run every day at 5 am UTC
-  push:
-    branches:
-      - develop
   workflow_call:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,9 +1,5 @@
 name: Trivy
 on:
-  push:
-    branches: 
-      - develop
-      - v1.7.x
   workflow_call:
   workflow_dispatch:
 

--- a/.github/workflows/wf_functional_e2e.yml
+++ b/.github/workflows/wf_functional_e2e.yml
@@ -5,7 +5,6 @@ name: Workflow_Functional_E2E
 
 on:
   workflow_call:
-
   workflow_dispatch:
     inputs:
       num_rounds:

--- a/.github/workflows/wf_functional_e2e.yml
+++ b/.github/workflows/wf_functional_e2e.yml
@@ -1,7 +1,7 @@
 ---
 # Workflow functional E2E tests
 
-name: Workflow Functional E2E
+name: Workflow_Functional_E2E
 
 on:
   workflow_call:

--- a/.github/workflows/wf_functional_e2e.yml
+++ b/.github/workflows/wf_functional_e2e.yml
@@ -1,7 +1,7 @@
 ---
 # Workflow functional E2E tests
 
-name: Workflow_Functional_E2E
+name: Workflow Functional E2E
 
 on:
   workflow_call:


### PR DESCRIPTION
## Description
Right now, multiple workflows that are part of PR pipeline calls as well are getting triggered on "push" event. This is not required, as the PR pipeline is already taking care of the pushed changes.

## Type of Change

1. Removed push event for all the workflows which are called from PR pipeline - to avoid such runs on forked repo/branches unnecessarily.
2. (Unrelated change) Added E2E tag to Federated Runtime 301 notebook run - which is being called from pytest framework.

## Testing

PR pipeline is already triggering the jobs as and when commits are pushed. Regarding skip of "push" event, those changes would reflect only once this PR gets mergd.