### PR TITLE
Fix: Secure Aggregation masking and weighted average

### DIFF
--- a/openfl-tutorials/experimental/workflow/SecAgg/workspace/MNIST_SecAgg.ipynb
+++ b/openfl-tutorials/experimental/workflow/SecAgg/workspace/MNIST_SecAgg.ipynb
@@ -531,7 +531,7 @@
     "        self._private_keys = {}\n",
     "        print(seed_shares, key_shares)\n",
     "        for source_id in seed_shares:\n",
-    "            self._private_seeds[source_id] = reconstruct_secret(seed_shares[source_id])\n",
+    "            self._private_seeds[source_id] = struct.unpack(\"d\", reconstruct_secret(seed_shares[source_id]))[0]\n",
     "            self._private_keys[source_id] = reconstruct_secret(key_shares[source_id])\n",
     "\n",
     "        # Generate all agreed keys.\n",

--- a/openfl/component/collaborator/collaborator.py
+++ b/openfl/component/collaborator/collaborator.py
@@ -344,8 +344,11 @@ class Collaborator:
         )
         # If secure aggregation is enabled, add masks to the dict to be shared
         # with the aggregator.
+        unmasked_metrics = {}
         if self._secure_aggregation_enabled:
-            self._secure_aggregation_masking(global_output_tensor_dict)
+            unmasked_metrics = self._secure_aggregation_masking(
+                global_output_tensor_dict, task_name
+            )
 
         # Save global and local output_tensor_dicts to TensorDB
         self.tensor_db.cache_tensor(global_output_tensor_dict)
@@ -354,6 +357,8 @@ class Collaborator:
         # send the results for this tasks; delta and compression will occur in
         # this function
         metrics = self.send_task_results(global_output_tensor_dict, round_number, task_name)
+        # Add unmasked metrics to the metrics that are logged, if any.
+        metrics.update(unmasked_metrics)
         return metrics
 
     def get_numpy_dict_for_tensorkeys(self, tensor_keys):
@@ -649,7 +654,7 @@ class Collaborator:
 
         return decompressed_nparray
 
-    def _secure_aggregation_masking(self, global_output_tensor_dict):
+    def _secure_aggregation_masking(self, global_output_tensor_dict, task_name):
         """
         Apply secure aggregation masking to the global output tensor
         dictionary.
@@ -682,8 +687,17 @@ class Collaborator:
                 TensorKey("shared_mask", self.collaborator_name, -1, False, ("secagg",))
             )[0]
 
+        metrics = {}
         for tensor_key in global_output_tensor_dict:
-            _, _, _, _, tags = tensor_key
+            tensor_name, _, _, report, tags = tensor_key
             if "metric" in tags:
+                if report:
+                    # Reportable metric must be a scalar
+                    value = float(global_output_tensor_dict[tensor_key])
+                    metrics.update(
+                        {f"{self.collaborator_name}/{task_name}/{tensor_name}/unmasked": value}
+                    )
                 masked_metric = np.add(self._private_mask, global_output_tensor_dict[tensor_key])
                 global_output_tensor_dict[tensor_key] = np.add(masked_metric, self._shared_mask)
+
+        return metrics

--- a/openfl/interface/aggregation_functions/secure_weighted_average.py
+++ b/openfl/interface/aggregation_functions/secure_weighted_average.py
@@ -20,6 +20,7 @@ class SecureWeightedAverage(WeightedAverage):
     def __init__(self):
         super().__init__()
         self._private_masks, self._shared_masks = None, None
+        self.private_seeds, self.agreed_keys, self.col_indices = None, None, None
 
     def call(self, local_tensors, db_iterator, *_) -> np.ndarray:
         """Aggregate tensors.
@@ -88,33 +89,27 @@ class SecureWeightedAverage(WeightedAverage):
         if self._shared_masks and self._private_masks:
             return
 
-        private_seeds = []
-        agreed_keys = []
-        col_indices = []
         # Get all required values from tensor db.
-        private_seeds, agreed_keys, col_indices = self._get_secagg_items_from_db(db_iterator)
+        self._get_secagg_items_from_db(db_iterator)
         if not self._shared_masks:
             # Calculate shared mask
-            self._shared_masks = calculate_shared_mask(agreed_keys)
+            self._shared_masks = calculate_shared_mask(self.agreed_keys)
 
         if not self._private_masks:
             # Create a dict with collaborator index and their name.
             # This dict is used to map private masks to the collaborator name
             # as they are stored with collaborator index in the db.
             col_idx = {}
-            for col in col_indices:
+            for col in self.col_indices:
                 col_idx[col[1]] = col[0]
-
-            del col_indices
 
             # Generate private masks for each collaborator.
             self._private_masks = {}
-            for seed in private_seeds:
+            for seed in self.private_seeds:
                 # col_name: col_private_mask
                 self._private_masks[col_idx[seed[0]]] = pseudo_random_generator(seed[1])
 
             del col_idx
-            del private_seeds
 
     def _calculcate_weighted_mask_average(
         self, private_masks: dict, local_tensors: list[LocalTensor]
@@ -163,12 +158,6 @@ class SecureWeightedAverage(WeightedAverage):
                 Each item is expected to be a dictionary with keys "tags",
                 "tensor_name", and "nparray".
 
-        Returns:
-            tuple: A tuple containing three elements:
-                - private_seeds (numpy.ndarray): The private seeds array.
-                - agreed_keys (numpy.ndarray): The agreed keys array.
-                - col_indices (numpy.ndarray): The column indices array.
-
         Raises:
             KeyError: If any of the required keys ("tags", "tensor_name",
                 "nparray") are missing in an item.
@@ -176,10 +165,8 @@ class SecureWeightedAverage(WeightedAverage):
         for item in db_iterator:
             if "tags" in item and item["tags"] == ("secagg",):
                 if item["tensor_name"] == "private_seeds":
-                    private_seeds = item["nparray"]
+                    self.private_seeds = item["nparray"]
                 elif item["tensor_name"] == "agreed_keys":
-                    agreed_keys = item["nparray"]
+                    self.agreed_keys = item["nparray"]
                 elif item["tensor_name"] == "indices":
-                    col_indices = item["nparray"]
-
-        return private_seeds, agreed_keys, col_indices
+                    self.col_indices = item["nparray"]

--- a/openfl/utilities/secagg/crypto.py
+++ b/openfl/utilities/secagg/crypto.py
@@ -163,6 +163,8 @@ def calculate_shared_mask(agreed_keys: list) -> float:
         agreed_key = key[2]
         if source_index > dest_index:
             total_mask += pseudo_random_generator(agreed_key)
+        elif source_index == dest_index:
+            continue
         else:
             total_mask -= pseudo_random_generator(agreed_key)
 

--- a/openfl/utilities/secagg/key.py
+++ b/openfl/utilities/secagg/key.py
@@ -9,7 +9,7 @@ This file contains utility functions for Secure Aggregation for key operations.
 from Crypto.PublicKey import ECC
 
 
-def generate_key_pair(curve: str = "ed25519") -> tuple[bytes, bytes]:
+def generate_key_pair(curve: str = "ed25519") -> tuple[str, str]:
     """
     Generates a public-private key pair for a specific curve.
 
@@ -18,8 +18,8 @@ def generate_key_pair(curve: str = "ed25519") -> tuple[bytes, bytes]:
             Defaults to 'ed25519'
 
     Returns:
-        bytes: Private key in bytes.
-        bytes: Public key in bytes.
+        str: Private key in string.
+        str: Public key in string.
     """
     # Generate private key.
     private_key = ECC.generate(curve=curve)

--- a/openfl/utilities/secagg/setup.py
+++ b/openfl/utilities/secagg/setup.py
@@ -6,6 +6,7 @@ aggregation setup.
 """
 
 import logging
+import struct
 
 from openfl.utilities import TensorKey
 from openfl.utilities.secagg import (
@@ -214,9 +215,9 @@ class Setup:
         self._results["private_keys"] = {}
 
         for source_id in self._results["seed_shares"]:
-            self._results["private_seeds"][source_id] = reconstruct_secret(
-                self._results["seed_shares"][source_id]
-            )
+            self._results["private_seeds"][source_id] = struct.unpack(
+                "d", reconstruct_secret(self._results["seed_shares"][source_id])
+            )[0]
             self._results["private_keys"][source_id] = reconstruct_secret(
                 self._results["key_shares"][source_id]
             )


### PR DESCRIPTION
## Summary
This PR aims to fix the masking and aggregation issues when using secure aggregation.

## Type of Change (Mandatory)
Specify the type of change being made. 
- Bug fix  

## Description (Mandatory)
- The weighted average calculated was not accurate as the mask calculation was incorrect. 
- Collaborator did not log unmasked metrics making it harder to verify the accuracy of the aggregation and the performance of training. 
- Seed calculation fix in Workflow API example notebook. 

## Testing
- [aggregator.log](https://github.com/user-attachments/files/19008316/aggregator.log)
- [bob.log](https://github.com/user-attachments/files/19008317/bob.log)
- [charlie.log](https://github.com/user-attachments/files/19008319/charlie.log)
- Reported metrics
    ```
    {"aggregator/train/loss": 0.24208595607665756, "aggregator/locally_tuned_model_validation/accuracy": 0.9621000215807316, "aggregator/aggregated_model_validation/accuracy": 0.07499999556926468}
    {"aggregator/train/loss": 0.08519018445399978, "aggregator/locally_tuned_model_validation/accuracy": 0.9739999995031712, "aggregator/aggregated_model_validation/accuracy": 0.9618000016012547}
    {"aggregator/train/loss": 0.05764483664420822, "aggregator/locally_tuned_model_validation/accuracy": 0.9770000204840061, "aggregator/aggregated_model_validation/accuracy": 0.9807999656000492}
    {"aggregator/train/loss": 0.04555738721278885, "aggregator/locally_tuned_model_validation/accuracy": 0.9816000089445469, "aggregator/aggregated_model_validation/accuracy": 0.9857000038423893}
    {"aggregator/train/loss": 0.03624368462947586, "aggregator/locally_tuned_model_validation/accuracy": 0.9801000282564518, "aggregator/aggregated_model_validation/accuracy": 0.9875000343122837}

    {"bob/aggregated_model_validation/accuracy": -0.47684156492425234, "bob/aggregated_model_validation/accuracy/unmasked": 0.0674000009894371, "bob/train/loss": -0.2559740130610588, "bob/train/loss/unmasked": 0.2882675528526306, "bob/locally_tuned_model_validation/accuracy": 0.4219584281735298, "bob/locally_tuned_model_validation/accuracy/unmasked": 0.9661999940872192}
    {"bob/aggregated_model_validation/accuracy": 0.4179584200672981, "bob/aggregated_model_validation/accuracy/unmasked": 0.9621999859809875, "bob/train/loss": -0.42838490352107317, "bob/train/loss/unmasked": 0.11585666239261627, "bob/locally_tuned_model_validation/accuracy": 0.42795841053055494, "bob/locally_tuned_model_validation/accuracy/unmasked": 0.9721999764442444}
    {"bob/aggregated_model_validation/accuracy": 0.4347584064297554, "bob/aggregated_model_validation/accuracy/unmasked": 0.9789999723434448, "bob/train/loss": -0.4633952637024048, "bob/train/loss/unmasked": 0.08084630221128464, "bob/locally_tuned_model_validation/accuracy": 0.4375584538273689, "bob/locally_tuned_model_validation/accuracy/unmasked": 0.9818000197410583}
    {"bob/aggregated_model_validation/accuracy": 0.4415584619336006, "bob/aggregated_model_validation/accuracy/unmasked": 0.98580002784729, "bob/train/loss": -0.47939341858102114, "bob/train/loss/unmasked": 0.0648481473326683, "bob/locally_tuned_model_validation/accuracy": 0.43955842807816237, "bob/locally_tuned_model_validation/accuracy/unmasked": 0.9837999939918518}
    {"bob/aggregated_model_validation/accuracy": 0.4453584368519661, "bob/aggregated_model_validation/accuracy/unmasked": 0.9896000027656555, "bob/train/loss": -0.4919670146710995, "bob/train/loss/unmasked": 0.05227455124258995, "bob/locally_tuned_model_validation/accuracy": 0.43995843484925, "bob/locally_tuned_model_validation/accuracy/unmasked": 0.9842000007629395}

    {"charlie/aggregated_model_validation/accuracy": 1.0397003922571546, "charlie/aggregated_model_validation/accuracy/unmasked": 0.08259999752044678, "charlie/train/loss": 1.1530047092546827, "charlie/train/loss/unmasked": 0.19590431451797485, "charlie/locally_tuned_model_validation/accuracy": 1.9151003990282423, "charlie/locally_tuned_model_validation/accuracy/unmasked": 0.9580000042915344}
    {"charlie/aggregated_model_validation/accuracy": 1.91850036717552, "charlie/aggregated_model_validation/accuracy/unmasked": 0.9613999724388123, "charlie/train/loss": 1.0116241309751874, "charlie/train/loss/unmasked": 0.054523736238479614, "charlie/locally_tuned_model_validation/accuracy": 1.9329003725160963, "charlie/locally_tuned_model_validation/accuracy/unmasked": 0.9757999777793884}
    {"charlie/aggregated_model_validation/accuracy": 1.9397003684152967, "charlie/aggregated_model_validation/accuracy/unmasked": 0.9825999736785889, "charlie/train/loss": 0.9915437433828719, "charlie/train/loss/unmasked": 0.03444334864616394, "charlie/locally_tuned_model_validation/accuracy": 1.9293003711809522, "charlie/locally_tuned_model_validation/accuracy/unmasked": 0.9721999764442444}
    {"charlie/aggregated_model_validation/accuracy": 1.9427003893961317, "charlie/aggregated_model_validation/accuracy/unmasked": 0.9855999946594238, "charlie/train/loss": 0.9833670254756816, "charlie/train/loss/unmasked": 0.026266630738973618, "charlie/locally_tuned_model_validation/accuracy": 1.9365003738512403, "charlie/locally_tuned_model_validation/accuracy/unmasked": 0.9793999791145325}
    {"charlie/aggregated_model_validation/accuracy": 1.9425004158129102, "charlie/aggregated_model_validation/accuracy/unmasked": 0.9854000210762024, "charlie/train/loss": 0.9773132238497145, "charlie/train/loss/unmasked": 0.020212829113006592, "charlie/locally_tuned_model_validation/accuracy": 1.9331004057039625, "charlie/locally_tuned_model_validation/accuracy/unmasked": 0.9760000109672546}
    ```