### PR TITLE
E2E Testing: Register collaborators before exporting workspace

### DIFF
--- a/tests/end_to_end/conftest.py
+++ b/tests/end_to_end/conftest.py
@@ -193,7 +193,10 @@ def pytest_sessionfinish(session, exitstatus):
         shutil.rmtree(cache_dir, ignore_errors=False)
         log.debug(f"Cleared .pytest_cache directory at {cache_dir}")
 
-    # Cleanup docker containers related to aggregator and collaborators, if any.
-    dh.cleanup_docker_containers(list_of_containers=["aggregator", "collaborator*"])
-    # Cleanup docker network created for openfl, if any.
-    dh.remove_docker_network(["openfl"])
+    if dh.is_docker_running():
+        # Cleanup docker containers related to aggregator and collaborators, if any.
+        dh.cleanup_docker_containers(list_of_containers=["aggregator", "collaborator*"])
+        # Cleanup docker network created for openfl, if any.
+        dh.remove_docker_network(["openfl"])
+    else:
+        log.warning("Docker is not running or not accessible. Skipping Docker cleanup steps.")

--- a/tests/end_to_end/conftest.py
+++ b/tests/end_to_end/conftest.py
@@ -199,4 +199,4 @@ def pytest_sessionfinish(session, exitstatus):
         # Cleanup docker network created for openfl, if any.
         dh.remove_docker_network(["openfl"])
     else:
-        log.warning("Docker is not running or not accessible. Skipping Docker cleanup steps.")
+        log.info("Docker is not running or not accessible. Skipping Docker cleanup steps.")

--- a/tests/end_to_end/utils/docker_helper.py
+++ b/tests/end_to_end/utils/docker_helper.py
@@ -233,3 +233,13 @@ def build_docker_image(image_name, dockerfile_path):
         )
     except Exception as e:
         raise ex.DockerException(f"Error building docker image: {e}")
+
+
+def is_docker_running():
+    try:
+        subprocess.run(["docker", "info"], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        return True
+    except subprocess.CalledProcessError:
+        return False
+    except FileNotFoundError:
+        return False

--- a/tests/end_to_end/utils/federation_helper.py
+++ b/tests/end_to_end/utils/federation_helper.py
@@ -192,28 +192,6 @@ def import_pki_for_collaborators(collaborators, local_bind_path):
     except Exception as e:
         raise e
 
-    # Copy the cols.yaml file from aggregator to all the collaborators
-    # File cols.yaml is updated after PKI setup
-    try:
-        results = [
-            executor.submit(
-                copy_file_between_participants,
-                local_src_path=os.path.join(local_agg_ws_path, "plan"),
-                local_dest_path=constants.COL_PLAN_PATH.format(
-                    local_bind_path, collaborator.name
-                ),
-                file_name="cols.yaml",
-                run_with_sudo=True,
-            )
-            for collaborator in collaborators
-        ]
-        if not all([f.result() for f in results]):
-            raise Exception(
-                "Failed to copy cols.yaml file from aggregator to one or more collaborators"
-            )
-    except Exception as e:
-        raise e
-
     return True
 
 

--- a/tests/end_to_end/utils/tr_workspace.py
+++ b/tests/end_to_end/utils/tr_workspace.py
@@ -100,11 +100,11 @@ def create_tr_workspace(request, eval_scope=False):
     workspace_path, local_bind_path, agg_domain_name, model_owner, plan_path, agg_workspace_path = common_workspace_creation(request, eval_scope)
     model_name = request.config.model_name
     # Certify the workspace in case of TLS
-    # Register the collaborators in case of non-TLS
     if request.config.use_tls:
         model_owner.certify_workspace()
-    else:
-        model_owner.register_collaborators(plan_path, request.config.num_collaborators)
+
+    # Register the collaborators. It will also update plan/cols.yaml file with the collaborator names.
+    model_owner.register_collaborators(plan_path, request.config.num_collaborators)
 
     # Create the objects for aggregator and collaborators
     # Workspace path for aggregator is uniform in case of docker or task_runner
@@ -188,11 +188,11 @@ def create_tr_dws_workspace(request, eval_scope=False):
     image_name = constants.DFLT_DOCKERIZE_IMAGE_NAME
 
     # Certify the workspace in case of TLS
-    # Register the collaborators in case of non-TLS
     if request.config.use_tls:
         model_owner.certify_workspace()
-    else:
-        model_owner.register_collaborators(plan_path, request.config.num_collaborators)
+
+    # Register the collaborators. It will also update plan/cols.yaml file with the collaborator names.
+    model_owner.register_collaborators(plan_path, request.config.num_collaborators)
 
     # Create the objects for aggregator and collaborators
     # Workspace path for aggregator is uniform in case of docker or task_runner


### PR DESCRIPTION
## Type of Change (Mandatory)
Specify the type of change being made. 
- Test code automation improvement 

## Description (Mandatory)
Earlier, in the E2E testing automation code, the export of workspace was happening before registration of collaborators, due to which we had to explicitly copy the up-to-date cols.yaml from aggregator to collaborator workspaces.

In this PR, we ensured collaborator registration before workspace export and removed the logic of explicit copy later.

Also, added if/else condition to delete docker containers/network etc. only when docker is running (in `conftest.py`).
This is to help in local machine testing without having a dependency on docker. 

## Testing
The code change impacts Task Runner jobs which are already part of PR pipeline. So a successful pipeline means the fix was rightly implemented.
