### PR TITLE
Fix `KeyError: 'w_old'`

### DIFF
--- a/openfl-tutorials/experimental/workflow/403_Federated_FedProx_PyTorch_MNIST_Workflow_Tutorial.ipynb
+++ b/openfl-tutorials/experimental/workflow/403_Federated_FedProx_PyTorch_MNIST_Workflow_Tutorial.ipynb
@@ -278,6 +278,8 @@
     "            output = self.model(data)\n",
     "            loss = F.cross_entropy(output, target)\n",
     "            loss.backward()\n",
+    "            \n",
+    "            self.optimizer.set_old_weights([p.clone().detach() for p in self.model.parameters()])\n",
     "            self.optimizer.step()\n",
     "\n",
     "            if (len(data) * batch_idx) / len(self.train_loader.dataset) >= log_threshold:\n",


### PR DESCRIPTION
## Summary
Fixed 403_Federated_FedProx_PyTorch_MNIST_Workflow_Tutorial

## Type of Change (Mandatory)
Specify the type of change being made. 
- Workflow tutorial fix

## Description (Mandatory)
Fixed workflow api 403_Federated_FedProx_PyTorch_MNIST_Workflow_Tutorial
Mentioned here too: https://wiki.ith.intel.com/display/TPE/OpenFL+cleanup
Issue:
```
File ~/situ_work/openfl-fedai/.venv/lib/python3.10/site-packages/openfl/experimental/workflow/interface/fl_spec.py:145, in FLSpec._run_local(self)
    139 self._setup_initial_state()
    140 try:
    141     # Execute all Participant (Aggregator & Collaborator) tasks and
...
--> 309         group["w_old"],
    310     )
    311 return loss

KeyError: 'w_old'
Output is truncated. View as a scrollable element or open in a text editor. Adjust cell output settings...
```

Fix:
The 'w_old' key was not found because old weights were not set. Therefore, we set global model parameters as old weights to enable the computation of the proximal term.

## Testing
Output:
```
Calling start
Performing initialization for model

Calling aggregated_model_validation
Performing aggregated model validation for collaborator collaborator0, model: 139688852352608

Test set: Avg. loss: 3.1648, Accuracy: 323/2500 (13%)


Calling train
Train Epoch: [4096/15000 (27%)]	Loss: 1.880076
Train Epoch: [8192/15000 (53%)]	Loss: 1.411064
Train Epoch: [11264/15000 (73%)]	Loss: 1.042751

Calling local_model_validation
Performing local model validation for collaborator collaborator0

Test set: Avg. loss: 0.8562, Accuracy: 1849/2500 (74%)

Done with local model validation for collaborator collaborator0, Accuracy: 0.7396000027656555
Should transfer from local_model_validation to join

Calling aggregated_model_validation
Performing aggregated model validation for collaborator collaborator1, model: 139688850330128
...
Average local model validation values = 0.9185000061988831

Calling end
Flow ended
```
<!-- ## Additional Information
[Any additional information that reviewers should be aware of.] -->