### PR TITLE
fix(plan reading): use yaml safe_load

### DIFF
--- a/openfl/experimental/workflow/interface/cli/aggregator.py
+++ b/openfl/experimental/workflow/interface/cli/aggregator.py
@@ -12,7 +12,6 @@ from pathlib import Path
 import yaml
 from click import Path as ClickPath
 from click import confirm, echo, group, option, pass_context, style
-from yaml.loader import SafeLoader
 
 from openfl.cryptography.ca import sign_certificate
 from openfl.cryptography.io import get_csr_hash, read_crt, read_csr, read_key, write_crt, write_key
@@ -80,7 +79,7 @@ def start_(plan, authorized_cols, secure):
         )
     else:
         with open("plan/data.yaml", "r") as f:
-            data = yaml.load(f, Loader=SafeLoader)
+            data = yaml.safe_load(f)
             if data.get("aggregator", None) is None:
                 logger.warning(
                     "Aggregator private attributes are set to None as no aggregator"

--- a/openfl/experimental/workflow/interface/cli/collaborator.py
+++ b/openfl/experimental/workflow/interface/cli/collaborator.py
@@ -18,7 +18,6 @@ import yaml
 from click import Path as ClickPath
 from click import confirm, echo, group, option, pass_context, style
 from yaml import FullLoader, dump, load
-from yaml.loader import SafeLoader
 
 from openfl.cryptography.ca import sign_certificate
 from openfl.cryptography.io import get_csr_hash, read_crt, read_csr, read_key, write_crt, write_key
@@ -83,7 +82,7 @@ def start_(plan, collaborator_name, secure, data_config="plan/data.yaml"):
         )
     else:
         with open(data_config, "r") as f:
-            data = yaml.load(f, Loader=SafeLoader)
+            data = yaml.safe_load(f)
             if data.get(collaborator_name, None) is None:
                 logger.warning(
                     f"Collaborator private attributes are set to None as no attributes"


### PR DESCRIPTION
## Summary
Use `yaml.safe_load` instead of `yaml.load`.

## Type of Change (Mandatory)
Specify the type of change being made. 
- Security improvement

## Description (Mandatory)
Bandit suggests using
```
yaml.safe_loader
```
From `pyyaml` docs, both, `yaml.load` (with `SafeLoader`) and `yaml.safe_load`  are equivalent
- `SafeLoader(stream)` supports only standard YAML tags and thus it does not construct class instances and probably safe to use with documents received from an untrusted source. The functions `safe_load` and `safe_load_all` use `SafeLoader` to parse a stream.
- recommend that people choose SafeLoader for untrusted data, but aribitrary code execution will no longer be possible using `yaml.load()` with the default loader (`FullLoader`).

References:
- https://pyyaml.org/wiki/PyYAMLDocumentation#LoadingYAML
- https://github.com/yaml/pyyaml/pull/257
- https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation


## Testing
CI pipeline