### PR TITLE
Added notes for non-TLS in Quickstart documentation

### DIFF
--- a/docs/tutorials/taskrunner.ipynb
+++ b/docs/tutorials/taskrunner.ipynb
@@ -58,7 +58,16 @@
         "\n",
         "For a complete list of supported options, refer to [`fx plan initialize`](https://openfl.readthedocs.io/en/latest/reference/fx.plan.html#fx-plan-initialize).\n",
         "\n",
-        "Note: For `non-TLS` scenario - keep `use_tls` (under network/settings) as `false.`"
+        "Note: By default, this tutorial is based on the recommended mTLS communication setup. For local testing purposes, however, TLS can be disabled by:\n",
+        "\n",
+        "1. Setting `use_tls: false` in the FL plan\n",
+        "2. Manually populating the collaborator names in `cols.yaml`. For example:\n",
+        "    \n",
+        "    collaborators:\n",
+        "    - collaborator1\n",
+        "    - collaborator2\n",
+        "\n",
+        "3. Skipping all certificate-related commands (incl. CA setup) in the following steps of the tutorial"
       ]
     },
     {
@@ -89,9 +98,7 @@
         "\n",
         "OpenFL supports mTLS, which ensures secure communication between the collaborators and the aggregator. This step generates a certificate authority (CA) that will be used to sign the certificates of the collaborators. The CA is generated only once and can be reused for multiple experiments.\n",
         "\n",
-        "No additional arguments are required for this command.\n",
-        "\n",
-        "Note: For `non-TLS` scenario - skip all cert related steps and explicitly add the collaborators to `plan/cols.yaml`."
+        "No additional arguments are required for this command."
       ]
     },
     {

--- a/docs/tutorials/taskrunner.ipynb
+++ b/docs/tutorials/taskrunner.ipynb
@@ -52,7 +52,9 @@
         "This step builds an entire FL experiment plan, along with the initial set of parameters that will be used in the experiment.\n",
         "We supply `localhost` as the aggregator address, for simulation purposes. The command below supports models of arbitrary input shapes and initializations (e.g. when using pre-trained models).\n",
         "\n",
-        "For a complete list of supported options, refer to [`fx plan initialize`](https://openfl.readthedocs.io/en/latest/reference/fx.plan.html#fx-plan-initialize)."
+        "For a complete list of supported options, refer to [`fx plan initialize`](https://openfl.readthedocs.io/en/latest/reference/fx.plan.html#fx-plan-initialize).\n",
+        "\n",
+        "    For non-TLS scenario - keep use_tls (under network/settings) as false."
       ]
     },
     {
@@ -80,7 +82,9 @@
         "\n",
         "OpenFL supports mTLS, which ensures secure communication between the collaborators and the aggregator. This step generates a certificate authority (CA) that will be used to sign the certificates of the collaborators. The CA is generated only once and can be reused for multiple experiments.\n",
         "\n",
-        "No additional arguments are required for this command."
+        "No additional arguments are required for this command.\n",
+        "\n",
+        "    For non-TLS scenario - skip all cert related steps and explicitly add the collaborators to plan/cols.yaml."
       ]
     },
     {

--- a/docs/tutorials/taskrunner.ipynb
+++ b/docs/tutorials/taskrunner.ipynb
@@ -329,11 +329,7 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "tags": [
-          "hide-output"
-        ]
-      },
+      "metadata": {},
       "source": [
         "### Import CA signed certificates\n",
         "\n",
@@ -346,15 +342,11 @@
       "metadata": {
         "tags": [
           "hide-output"
-        ],
-        "vscode": {
-          "languageId": "shellscript"
-        }
+        ]
       },
-      "outputs": [],
       "source": [
-        "!fx collaborator certify --import agg_to_col_bob_signed_cert.zip\n",
-        "!fx collaborator certify --import agg_to_col_charlie_signed_cert.zip"
+        "!fx collaborator certify --import agg_to_col_bob_signed_cert.zip\\\n",
+        " fx collaborator certify --import agg_to_col_charlie_signed_cert.zip"
       ]
     },
     {

--- a/docs/tutorials/taskrunner.ipynb
+++ b/docs/tutorials/taskrunner.ipynb
@@ -351,6 +351,7 @@
           "languageId": "shellscript"
         }
       },
+      "outputs": [],
       "source": [
         "!fx collaborator certify --import agg_to_col_bob_signed_cert.zip\n",
         "!fx collaborator certify --import agg_to_col_charlie_signed_cert.zip"

--- a/docs/tutorials/taskrunner.ipynb
+++ b/docs/tutorials/taskrunner.ipynb
@@ -62,11 +62,9 @@
         "\n",
         "1. Setting `use_tls: false` in the FL plan\n",
         "2. Manually populating the collaborator names in `cols.yaml`. For example:\n",
-        "    \n",
-        "    collaborators:\n",
-        "    \\- collaborator1\n",
-        "    \\- collaborator2\n",
-        "\n",
+        "    collaborators:\\n\n",
+        "    \\- collaborator1\\n\n",
+        "    \\- collaborator2\\n\n",
         "3. Skipping all certificate-related commands (incl. CA setup) in the following steps of the tutorial"
       ]
     },

--- a/docs/tutorials/taskrunner.ipynb
+++ b/docs/tutorials/taskrunner.ipynb
@@ -329,7 +329,11 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "tags": [
+          "hide-output"
+        ]
+      },
       "source": [
         "### Import CA signed certificates\n",
         "\n",
@@ -342,11 +346,14 @@
       "metadata": {
         "tags": [
           "hide-output"
-        ]
+        ],
+        "vscode": {
+          "languageId": "shellscript"
+        }
       },
       "source": [
-        "!fx collaborator certify --import agg_to_col_bob_signed_cert.zip\\\n",
-        " fx collaborator certify --import agg_to_col_charlie_signed_cert.zip"
+        "!fx collaborator certify --import agg_to_col_bob_signed_cert.zip\n",
+        "!fx collaborator certify --import agg_to_col_charlie_signed_cert.zip"
       ]
     },
     {

--- a/docs/tutorials/taskrunner.ipynb
+++ b/docs/tutorials/taskrunner.ipynb
@@ -31,7 +31,11 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "tags": [
+          "hide-output"
+        ]
+      },
       "outputs": [],
       "source": [
         "!fx workspace create --prefix ./mnist_example --template keras/mnist\n",
@@ -61,6 +65,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "tags": [
+          "hide-output"
+        ],
         "vscode": {
           "languageId": "shellscript"
         }
@@ -91,6 +98,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "tags": [
+          "hide-output"
+        ],
         "vscode": {
           "languageId": "shellscript"
         }
@@ -121,6 +131,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "tags": [
+          "hide-output"
+        ],
         "vscode": {
           "languageId": "shellscript"
         }
@@ -161,6 +174,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "tags": [
+          "hide-output"
+        ],
         "vscode": {
           "languageId": "shellscript"
         }
@@ -185,6 +201,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "tags": [
+          "hide-output"
+        ],
         "vscode": {
           "languageId": "shellscript"
         }
@@ -211,6 +230,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "tags": [
+          "hide-output"
+        ],
         "vscode": {
           "languageId": "shellscript"
         }
@@ -237,6 +259,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "tags": [
+          "hide-output"
+        ],
         "vscode": {
           "languageId": "shellscript"
         }
@@ -261,6 +286,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "tags": [
+          "hide-output"
+        ],
         "vscode": {
           "languageId": "shellscript"
         }
@@ -287,6 +315,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "tags": [
+          "hide-output"
+        ],
         "vscode": {
           "languageId": "shellscript"
         }
@@ -313,6 +344,9 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "tags": [
+          "hide-output"
+        ],
         "vscode": {
           "languageId": "shellscript"
         }

--- a/docs/tutorials/taskrunner.ipynb
+++ b/docs/tutorials/taskrunner.ipynb
@@ -64,8 +64,8 @@
         "2. Manually populating the collaborator names in `cols.yaml`. For example:\n",
         "    \n",
         "    collaborators:\n",
-        "    - collaborator1\n",
-        "    - collaborator2\n",
+        "    \\- collaborator1\n",
+        "    \\- collaborator2\n",
         "\n",
         "3. Skipping all certificate-related commands (incl. CA setup) in the following steps of the tutorial"
       ]

--- a/docs/tutorials/taskrunner.ipynb
+++ b/docs/tutorials/taskrunner.ipynb
@@ -61,11 +61,17 @@
         "Note: By default, this tutorial is based on the recommended mTLS communication setup. For local testing purposes, however, TLS can be disabled by:\n",
         "\n",
         "1. Setting `use_tls: false` in the FL plan\n",
-        "2. Manually populating the collaborator names in `cols.yaml`. For example:\n",
-        "    collaborators:\\n\n",
-        "    \\- collaborator1\\n\n",
-        "    \\- collaborator2\\n\n",
-        "3. Skipping all certificate-related commands (incl. CA setup) in the following steps of the tutorial"
+        "2. Skipping all certificate-related commands (incl. CA setup) in the following steps of the tutorial\n",
+        "3. Manually populating the collaborator names in `cols.yaml`. For example:"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "        collaborators:\n",
+        "        - collaborator1\n",
+        "        - collaborator2"
       ]
     },
     {

--- a/docs/tutorials/taskrunner.ipynb
+++ b/docs/tutorials/taskrunner.ipynb
@@ -54,7 +54,7 @@
         "\n",
         "For a complete list of supported options, refer to [`fx plan initialize`](https://openfl.readthedocs.io/en/latest/reference/fx.plan.html#fx-plan-initialize).\n",
         "\n",
-        "    For non-TLS scenario - keep use_tls (under network/settings) as false."
+        "Note: For `non-TLS` scenario - keep `use_tls` (under network/settings) as `false.`"
       ]
     },
     {
@@ -84,7 +84,7 @@
         "\n",
         "No additional arguments are required for this command.\n",
         "\n",
-        "    For non-TLS scenario - skip all cert related steps and explicitly add the collaborators to plan/cols.yaml."
+        "Note: For `non-TLS` scenario - skip all cert related steps and explicitly add the collaborators to `plan/cols.yaml`."
       ]
     },
     {


### PR DESCRIPTION
## Summary
Fixes issue https://github.com/securefederatedai/openfl/issues/1412 using documentation update.

## Type of Change (Mandatory)
Specify the type of change being made. 
- Documentation update  

## Description (Mandatory)
For `non-TLS` scenario, collaborators registration need to be done separately which is otherwise included in the certify process for `TLS`. This wasn't documented anywhere.

In this PR:
1. Added Notes for `non-TLS` under `Initialize a Plan` and `Create a certificate authority (CA)`.
2. Made output section collapsible for all the steps (earlier it was present only for Simulation step).

## Testing
Changes are available here - https://noopurintel-openfl.readthedocs.io/en/latest/tutorials/taskrunner.html