### PR TITLE
Bump keras from 3.8.0 to 3.9.0 in /openfl-workspace/keras/torch/mnist

### DIFF
--- a/openfl-workspace/keras/torch/mnist/requirements.txt
+++ b/openfl-workspace/keras/torch/mnist/requirements.txt
@@ -1,4 +1,4 @@
-keras==3.8.0
+keras==3.9.0
 torch==2.6.0
 torch-xla==2.6.0
 torchvision==0.21.0


### PR DESCRIPTION
## Summary
Bump keras from 3.8.0 to 3.9.0 in /openfl-workspace/keras/torch/mnist
https://github.com/securefederatedai/openfl/security/dependabot/1920

## Type of Change (Mandatory)
Specify the type of change being made. 
- Security improvement

## Description (Mandatory)
This PR resolves https://github.com/securefederatedai/openfl/security/dependabot/1920.