### PR TITLE
Bump keras from 3.8.0 to 3.9.0 in /openfl-workspace/keras/jax/mnist

### DIFF
--- a/openfl-workspace/keras/jax/mnist/requirements.txt
+++ b/openfl-workspace/keras/jax/mnist/requirements.txt
@@ -1,3 +1,3 @@
 jax==0.5.0
-keras==3.8.0
+keras==3.9.0
 tensorflow==2.18.0


### PR DESCRIPTION
## Summary
Bump keras from 3.8.0 to 3.9.0 in /openfl-workspace/keras/jax/mnist

## Type of Change (Mandatory)
- Security improvement

## Description (Mandatory)
This PR resolves https://github.com/securefederatedai/openfl/security/dependabot/1919