### PR TITLE
WIP: Use LOG_FILE for logging to the participant log files

### DIFF
--- a/openfl/utilities/logging.py
+++ b/openfl/utilities/logging.py
@@ -51,7 +51,7 @@ def setup_logger(log_level=logging.INFO, log_file=None):
     if log_file:
         file_formatter = logging.Formatter(
             "[%(asctime)s] [%(filename)s:%(lineno)d] %(levelname)s %(message)s",
-            datefmt="%Y-%m-%d %H:%M:%S",
+            datefmt="%H:%M:%S",
         )
         file_handler = logging.FileHandler(log_file)
         file_handler.setFormatter(file_formatter)

--- a/openfl/utilities/logging.py
+++ b/openfl/utilities/logging.py
@@ -23,26 +23,38 @@ def setup_logger(log_level=logging.INFO, log_file=None):
             Defaults to logging.INFO.
         log_file (str, optional): The file to which log messages should be written.
     """
+    # Create a logger instance
+    logger = logging.getLogger()
+
+    # Add a custom log level for METRIC
     metric = 25
     add_log_level("METRIC", metric)
 
     if isinstance(log_level, str):
         log_level = log_level.upper()
 
-    root = logging.getLogger()
-    root.setLevel(log_level)
+    # Set the log level for the logger
+    logger.setLevel(log_level)
 
-    formatter = logging.Formatter("%(message)s")
-    if log_file:
-        file_handler = logging.FileHandler(log_file)
-        file_handler.setFormatter(formatter)
-        root.addHandler(file_handler)
-
+    # Create a console handler with a specific format
     console = Console(width=160, force_terminal=True)
-    rich_handler = RichHandler(
+    console_handler = RichHandler(
         rich_tracebacks=True,
         markup=True,
         console=console,
     )
-    rich_handler.setFormatter(formatter)
-    root.addHandler(rich_handler)
+    # Console handler includes date and log level, do not add it again
+    console_handler.setFormatter(logging.Formatter("%(message)s"))
+    logger.addHandler(console_handler)
+
+    # Create a file handler if log_file is provided
+    if log_file:
+        file_formatter = logging.Formatter(
+            "[%(asctime)s] [%(filename)s:%(lineno)d] %(levelname)s %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setFormatter(file_formatter)
+        logger.addHandler(file_handler)
+
+    return logger

--- a/tests/end_to_end/models/aggregator.py
+++ b/tests/end_to_end/models/aggregator.py
@@ -64,13 +64,14 @@ class Aggregator():
         try:
             log.info(f"Starting {self.name}")
             error_msg = "Failed to start the aggregator"
+
             # Note: LOG_FILE does not take absolute path, hence using relative path
             log_file = os.path.join("logs", "aggregator.log")
-            command = f"LOG_FILE={log_file} {constants.AGG_START_CMD}"
+            self.res_file = os.path.join(self.workspace_path, log_file)
 
+            command = f"LOG_FILE={log_file} {constants.AGG_START_CMD}"
             if self.eval_scope:
                 command = f"{command} --task_group evaluation"
-
             fh.run_command(
                 command=command,
                 error_msg=error_msg,
@@ -78,7 +79,7 @@ class Aggregator():
                 workspace_path=self.workspace_path,
                 run_in_background=True,
             )
-            self.res_file = os.path.join(self.workspace_path, log_file)
+
             log.info(
                 f"Started {self.name} and tracking the logs in {self.res_file}."
             )

--- a/tests/end_to_end/models/aggregator.py
+++ b/tests/end_to_end/models/aggregator.py
@@ -55,36 +55,37 @@ class Aggregator():
         except Exception as e:
             raise ex.CSRGenerationException(f"Failed to generate sign request for {self.name}: {e}")
 
-    def start(self, res_file):
+    def start(self):
         """
         Start the aggregator
-        Args:
-            res_file (str): Result file to track the logs
         Returns:
-            str: Path to the log file
+            bool: True if successful, else raise exception
         """
         try:
             log.info(f"Starting {self.name}")
             error_msg = "Failed to start the aggregator"
-            command = constants.AGG_START_CMD
+            # Note: LOG_FILE does not take absolute path, hence using relative path
+            log_file = os.path.join("logs", "aggregator.log")
+            command = f"LOG_FILE={log_file} {constants.AGG_START_CMD}"
+
             if self.eval_scope:
                 command = f"{command} --task_group evaluation"
+
             fh.run_command(
                 command=command,
                 error_msg=error_msg,
                 container_id=self.container_id,
                 workspace_path=self.workspace_path,
                 run_in_background=True,
-                bg_file=res_file,
             )
+            self.res_file = os.path.join(self.workspace_path, log_file)
             log.info(
-                f"Started {self.name} and tracking the logs in {res_file}."
+                f"Started {self.name} and tracking the logs in {self.res_file}."
             )
-            self.res_file = res_file
         except Exception as e:
             log.error(f"{error_msg}: {e}")
             raise e
-        return res_file
+        return True
 
     def modify_data_file(self, data_file, col_name, index):
         """

--- a/tests/end_to_end/models/aggregator.py
+++ b/tests/end_to_end/models/aggregator.py
@@ -71,9 +71,9 @@ class Aggregator():
 
             command = f"LOG_FILE={log_file} {constants.AGG_START_CMD}"
             if self.eval_scope:
-                command = f"{command} --task_group evaluation"
+                command += " --task_group evaluation"
             fh.run_command(
-                command=command,
+                command=f"{command} &",
                 error_msg=error_msg,
                 container_id=self.container_id,
                 workspace_path=self.workspace_path,

--- a/tests/end_to_end/models/collaborator.py
+++ b/tests/end_to_end/models/collaborator.py
@@ -115,33 +115,34 @@ class Collaborator():
             raise e
         return True
 
-    def start(self, res_file):
+    def start(self):
         """
         Start the collaborator
-        Args:
-            res_file (str): Result file to track the logs
         Returns:
-            str: Path to the log file
+            bool: True if successful, else raise exception
         """
         try:
             log.info(f"Starting {self.collaborator_name}")
             error_msg = f"Failed to start {self.collaborator_name}"
+            # Note: LOG_FILE does not take absolute path, hence using relative path
+            log_file = os.path.join("logs", f"{self.collaborator_name}.log")
+            command = f"LOG_FILE={log_file} {constants.COL_START_CMD.format(self.collaborator_name)}"
+
             fh.run_command(
-                constants.COL_START_CMD.format(self.collaborator_name),
+                command,
                 error_msg=error_msg,
                 container_id=self.container_id,
                 workspace_path=self.workspace_path,
                 run_in_background=True,
-                bg_file=res_file,
             )
+            self.res_file = os.path.join(self.workspace_path, log_file)
             log.info(
-                f"Started {self.name} and tracking the logs in {res_file}."
+                f"Started {self.name} and tracking the logs in {self.res_file}."
             )
-            self.res_file = res_file
         except Exception as e:
             log.error(f"{error_msg}: {e}")
             raise e
-        return res_file
+        return True
 
     def install_dependencies(self):
         """

--- a/tests/end_to_end/models/collaborator.py
+++ b/tests/end_to_end/models/collaborator.py
@@ -124,18 +124,19 @@ class Collaborator():
         try:
             log.info(f"Starting {self.collaborator_name}")
             error_msg = f"Failed to start {self.collaborator_name}"
+
             # Note: LOG_FILE does not take absolute path, hence using relative path
             log_file = os.path.join("logs", f"{self.collaborator_name}.log")
-            command = f"LOG_FILE={log_file} {constants.COL_START_CMD.format(self.collaborator_name)}"
+            self.res_file = os.path.join(self.workspace_path, log_file)
 
             fh.run_command(
-                command,
+                f"LOG_FILE={log_file} {constants.COL_START_CMD.format(self.collaborator_name)}",
                 error_msg=error_msg,
                 container_id=self.container_id,
                 workspace_path=self.workspace_path,
                 run_in_background=True,
             )
-            self.res_file = os.path.join(self.workspace_path, log_file)
+
             log.info(
                 f"Started {self.name} and tracking the logs in {self.res_file}."
             )

--- a/tests/end_to_end/models/collaborator.py
+++ b/tests/end_to_end/models/collaborator.py
@@ -130,7 +130,7 @@ class Collaborator():
             self.res_file = os.path.join(self.workspace_path, log_file)
 
             fh.run_command(
-                f"LOG_FILE={log_file} {constants.COL_START_CMD.format(self.collaborator_name)}",
+                command=f"LOG_FILE={log_file} {constants.COL_START_CMD.format(self.collaborator_name)} &",
                 error_msg=error_msg,
                 container_id=self.container_id,
                 workspace_path=self.workspace_path,

--- a/tests/end_to_end/utils/constants.py
+++ b/tests/end_to_end/utils/constants.py
@@ -50,7 +50,9 @@ AGG_MEM_USAGE_JSON = "{}/aggregator/workspace/logs/aggregator_memory_usage.json"
 COL_MEM_USAGE_JSON = "{0}/{1}/workspace/logs/{1}_memory_usage.json"  # example - /tmp/my_federation/collaborator1/workspace/logs/collaborator1_memory_usage.json
 
 AGG_START_CMD = "fx aggregator start"
+AGG_END_MSG = "Experiment Completed"
 COL_START_CMD = "fx collaborator start -n {}"
+COL_END_MSG = "Received shutdown signal"
 
 COL_CERTIFY_CMD = "fx collaborator certify --import 'agg_to_col_{}_signed_cert.zip'"
 DFLT_DOCKERIZE_IMAGE_NAME = "workspace"

--- a/tests/end_to_end/utils/federation_helper.py
+++ b/tests/end_to_end/utils/federation_helper.py
@@ -569,7 +569,7 @@ def run_command(
         if bg_file:
             bg_file = open(bg_file, "a", buffering=1) # open file in append mode, so that restarting scenarios can be handled
         ssh.run_command_background(
-            command,
+            command=f"{command} &", # run in background using &
             work_dir=workspace_path,
             redirect_to_file=bg_file,
             check_sleep=60,

--- a/tests/end_to_end/utils/federation_helper.py
+++ b/tests/end_to_end/utils/federation_helper.py
@@ -237,10 +237,7 @@ def run_federation(fed_obj, install_dependencies=True):
     # As the collaborators will wait for aggregator to start, we need to start them in parallel.
     futures = [
         executor.submit(
-            participant.start,
-            constants.AGG_COL_RESULT_FILE.format(
-                fed_obj.workspace_path, participant.name
-            ),
+            participant.start
         )
         for participant in [fed_obj.aggregator] + fed_obj.collaborators
     ]
@@ -344,7 +341,12 @@ def _verify_completion_for_participant(
     Returns:
         bool: True if successful, else False
     """
-    time.sleep(20)  # Wait for some time before checking the log file
+    # Wait for a min so that log files are available
+    while not os.path.exists(participant.res_file):
+        if time.time() - start_time > 60:
+            raise Exception(f"Log file {participant.res_file} not found after 60 seconds")
+        time.sleep(10)
+
     # Set timeout based on the number of rounds and time for each round
     timeout = 600 + (time_for_each_round * num_rounds)  # in seconds
 
@@ -353,9 +355,7 @@ def _verify_completion_for_participant(
     content = [""]
 
     start_time = time.time()
-    while (
-        constants.SUCCESS_MARKER not in content and time.time() - start_time < timeout
-    ):
+    while time.time() - start_time < timeout:
         with open(participant.res_file, "r") as file:
             lines = [line.strip() for line in file.readlines()]
 
@@ -364,9 +364,7 @@ def _verify_completion_for_participant(
 
         # Print last line of the log file on screen to track the progress
         log.info(f"Last line in {participant.name} log: {lines[-1:]}")
-        if constants.SUCCESS_MARKER in content:
-            break
-        log.info(f"Process is yet to complete for {participant.name}")
+
         # If in logs Exception is encountered, throw Exception and stop the process
         if constants.EXCEPTION in content:
             log.error(
@@ -374,18 +372,36 @@ def _verify_completion_for_participant(
             )
             raise Exception(f"Process failed for {participant.name}")
 
+        msg_received = [line for line in content if constants.AGG_END_MSG in line or constants.COL_END_MSG in line]
+        if msg_received:
+            log.info(f"Process completed for {participant.name}")
+            break
+
+        # Verify that the process is completed successfully
+        get_process_id = constants.AGG_START_CMD if participant.name == "aggregator" else constants.COL_START_CMD.format(participant.name)
+
+        # Find the process ID
+        pids = []
+        for line in os.popen(f"ps ax | grep '{get_process_id}' | grep -v grep"):
+            fields = line.split()
+            pids.append(fields[0])
+
+        if not pids:
+            log.info(f"No processes found for participant {participant.name}")
+            break
+        else:
+            log.info(f"Process is yet to complete for {participant.name}. PIDs are {pids}")
+
         time.sleep(45)
 
-    if constants.SUCCESS_MARKER not in content:
-        log.error(
-            f"Process failed/is incomplete for {participant.name} after timeout of {timeout} seconds"
-        )
-        return False
-    else:
-        log.info(
-            f"Process completed for {participant.name} in {time.time() - start_time} seconds"
-        )
-        return True
+    # Read tensor.db file for aggregator to check if the process is completed
+    if participant.name == "aggregator":
+        current_round = get_current_round(participant.tensor_db_file)
+        log.info(f"Current round for {participant.name}: {current_round}")
+        if (current_round + 1) != num_rounds:
+            raise Exception(f"Process completed but only till round {current_round}")
+
+    return True
 
 
 def federation_env_setup_and_validate(request, eval_scope=False):
@@ -550,7 +566,8 @@ def run_command(
         log.info(f"Running command: {command}")
 
     if run_in_background and not with_docker:
-        bg_file = open(bg_file, "a", buffering=1) # open file in append mode, so that restarting scenarios can be handled
+        if bg_file:
+            bg_file = open(bg_file, "a", buffering=1) # open file in append mode, so that restarting scenarios can be handled
         ssh.run_command_background(
             command,
             work_dir=workspace_path,
@@ -1131,4 +1148,4 @@ def remove_stale_processes(num_collaborators=0, envoys=[], director=False):
                 )
             except subprocess.CalledProcessError as e:
                 log.warning(f"Failed to kill processes: {e}")
-    log.info("Stale processes removed successfully")
+    log.info("Stale processes (if any) removed successfully")

--- a/tests/end_to_end/utils/federation_helper.py
+++ b/tests/end_to_end/utils/federation_helper.py
@@ -569,7 +569,7 @@ def run_command(
         if bg_file:
             bg_file = open(bg_file, "a", buffering=1) # open file in append mode, so that restarting scenarios can be handled
         ssh.run_command_background(
-            cmd=f"{command} &", # run in background using &
+            command,
             work_dir=workspace_path,
             redirect_to_file=bg_file,
             check_sleep=60,
@@ -1069,7 +1069,7 @@ def validate_round_increment(inp_round, database_file, total_rounds, timeout=300
     start_time = time.time()
     while time.time() - start_time < timeout:
         current_round = get_current_round(database_file)
-# Sometimes round number is not updated immediately, thus checking for current_round > inp_round + 1
+        # Sometimes round number is not updated immediately, thus checking for current_round > inp_round + 1
         if current_round > inp_round + 1:
             log.info(f"Round number has increased from {inp_round} to {current_round}")
             return current_round

--- a/tests/end_to_end/utils/federation_helper.py
+++ b/tests/end_to_end/utils/federation_helper.py
@@ -569,7 +569,7 @@ def run_command(
         if bg_file:
             bg_file = open(bg_file, "a", buffering=1) # open file in append mode, so that restarting scenarios can be handled
         ssh.run_command_background(
-            command=f"{command} &", # run in background using &
+            cmd=f"{command} &", # run in background using &
             work_dir=workspace_path,
             redirect_to_file=bg_file,
             check_sleep=60,

--- a/tests/end_to_end/utils/interruption_helper.py
+++ b/tests/end_to_end/utils/interruption_helper.py
@@ -97,7 +97,7 @@ def stop_start_native_participant(participant, action):
     else:
         try:
             log.info(f"Starting participant {participant.name}")
-            participant.start(res_file=participant.res_file)
+            participant.start()
         except Exception as e:
             raise ex.ParticipantStartException(f"Error starting participant: {e}")
 

--- a/tests/end_to_end/utils/ssh_helper.py
+++ b/tests/end_to_end/utils/ssh_helper.py
@@ -63,15 +63,7 @@ def run_command_background(
             log.error(f"Error Traceback: {traceback.print_exc()}")
             raise subprocess.CalledProcessError(returncode=return_code, cmd=cmd)
     else:
-        log.warning("Process for Command completed instantly.")
-        if redirect_to_file:
-            log.info(
-                "The background process has been writing STDERR and STDOUT to a file passed in as 'redirect_to_file' arg"
-            )
-        else:
-            output = process.stdout.read().rstrip("\n").split("\n")
-            if print_stdout and output is not None:
-                log.info(f"Command to run - {cmd}  output - {output}")
+        log.info("Process triggered successfully in background.")
         return None
 
 

--- a/tests/end_to_end/utils/ssh_helper.py
+++ b/tests/end_to_end/utils/ssh_helper.py
@@ -50,6 +50,7 @@ def run_command_background(
     )
     time.sleep(check_sleep)
     return_code = process.poll()
+    log.info(f"Return code for background process [{cmd}] is: {return_code}")
     if return_code is None:
         return process
     elif return_code != 0:


### PR DESCRIPTION
## Summary
1. To make use of LOG_FILE environment variable for creating and logging into participant log files during Task Runner federation experiment (instead of redirecting the command output to a file).
2. To keep the participant log files inside `logs` folder present inside `workspace`.
3. To fix the problem of escape characters making it to the participant log files (in E2E test artifacts).

## Type of Change (Mandatory)
- Feature enhancement  
- Test framework improvement

## Description (Mandatory)
During Task Runner federation experiment, we were redirecting the command output of `fx start participant` to respective files which was an overhead (and we intended to remove it anyways).

Previously:
Run `fx aggregator start` (and pass the res_file to subprocess.Popen)

Now:
Run `LOG_FILE=logs/aggregator.log fx aggregator start` (no need to pass any file path/descriptor etc.)

Most of the changes are done around this. 

In `logging.py`, defined a separate formatter for file_handler to display time and filename:lineno details along with content.

## Testing
All the tests are part of PR pipeline.

## Additional Information
Sharing the aggregator and collaborator1 log files for reference (from one of PR pipeline jobs):

[aggregator.log](https://github.com/user-attachments/files/19289460/aggregator.log)
[collaborator1.log](https://github.com/user-attachments/files/19289482/collaborator1.log)
