### PR TITLE
Upgrading nbdev package version from 2.3.12 to 2.3.37 to fix ImportError

### DIFF
--- a/openfl-tutorials/experimental/workflow/workflow_interface_requirements.txt
+++ b/openfl-tutorials/experimental/workflow/workflow_interface_requirements.txt
@@ -3,7 +3,7 @@ charset-normalizer
 dill==0.3.6
 matplotlib>=2.0.0
 metaflow==2.7.15
-nbdev==2.3.12
+nbdev==2.3.37
 nbformat==5.10.4
 ray==2.9.2
 tabulate==0.9.0

--- a/tests/github/experimental/workflow/LocalRuntime/requirements_experimental_localruntime_tests.txt
+++ b/tests/github/experimental/workflow/LocalRuntime/requirements_experimental_localruntime_tests.txt
@@ -5,5 +5,5 @@ torch
 tabulate==0.9.0
 torchvision
 nbformat==5.10.4
-nbdev==2.3.12
+nbdev==2.3.37
 tensorboard


### PR DESCRIPTION
## Summary
Upgrade nbdev version in workflow requirements.

## Type of Change (Mandatory)
Specify the type of change being made. 
- Others - Pipeline failing post new release of nbdev

## Description (Mandatory)
Post new release of nbdev - https://github.com/AnswerDotAI/nbdev Workflow APIs started failing

## Testing
Pipeline run