### PR TITLE
Security TLS certificate report tests

### DIFF
--- a/.github/workflows/pq_pipeline.yml
+++ b/.github/workflows/pq_pipeline.yml
@@ -88,3 +88,11 @@ jobs:
     name: TaskRunner Dockerized E2E
     needs: task_runner_straggler_e2e
     uses: ./.github/workflows/task_runner_dockerized_ws_e2e.yml
+
+  # run testssl for task runner
+  task_runner_secret_ssl_e2e:
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
+    name: TaskRunner Secret SSL E2E
+    uses: ./.github/workflows/task_runner_secret_tls_e2e.yml

--- a/.github/workflows/task_runner_secret_tls_e2e.yml
+++ b/.github/workflows/task_runner_secret_tls_e2e.yml
@@ -1,7 +1,7 @@
 ---
-# Task Runner E2E tests with Secure aggregation with bare metal approach
+# Task Runner E2E tests with Secret SSL check
 
-name: Task_Runner_Secure_Agg_E2E  # Please do not modify the name as it is used in the composite action
+name: Task_Runner_Secret_SSL_E2E  # Please do not modify the name as it is used in the composite action
 
 on:
   workflow_call:
@@ -11,8 +11,8 @@ permissions:
   contents: read
 
 jobs:
-  test_secure_aggregation:
-    name: Secure Aggregation (torch/mnist, 3.10)
+  test_secret_ssl:
+    name: Secret SSL Check (torch/mnist, 3.10)
     if: |
       (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
       (github.event_name == 'workflow_dispatch') ||
@@ -33,24 +33,24 @@ jobs:
           submodules: "true"
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Secure Aggregation dependencies
+      - name: Install Secret SSL dependencies
         run: |
-          python -m pip install pycryptodome
+          sudo apt install testssl.sh
           
       - name: Pre test run
         uses: ./.github/actions/tr_pre_test_run
         if: ${{ always() }}
 
-      - name: Run Task Runner with secure aggregation
+      - name: Run Task Runner with Secret SSL check
         id: run_tests
         run: |
-          python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+          python -m pytest -s tests/end_to_end/test_suites/tr_security_testssl.py \
           -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
-          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --secure_agg
+          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
           echo "Task runner end to end test run completed"
 
       - name: Post test run
         uses: ./.github/actions/tr_post_test_run
         if: ${{ always() }}
         with:
-          test_type: "With_Secure_Agg"
+          test_type: "With_Secret_SSL"

--- a/.github/workflows/task_runner_secret_tls_e2e.yml
+++ b/.github/workflows/task_runner_secret_tls_e2e.yml
@@ -22,7 +22,7 @@ jobs:
     env:
       MODEL_NAME: 'torch/mnist'
       PYTHON_VERSION: '3.10'
-      NUM_ROUNDS: 5
+      NUM_ROUNDS: 10
       NUM_COLLABORATORS: 2
     steps:
       - name: Checkout OpenFL repository

--- a/openfl-tutorials/experimental/workflow/workflow_interface_requirements.txt
+++ b/openfl-tutorials/experimental/workflow/workflow_interface_requirements.txt
@@ -3,7 +3,7 @@ charset-normalizer
 dill==0.3.6
 matplotlib>=2.0.0
 metaflow==2.7.15
-nbdev==2.3.12
+nbdev==2.3.37
 nbformat==5.10.4
 ray==2.9.2
 tabulate==0.9.0

--- a/openfl-workspace/flower-app-pytorch/src/connector_flower.py
+++ b/openfl-workspace/flower-app-pytorch/src/connector_flower.py
@@ -56,7 +56,7 @@ class ConnectorFlower:
         """
         connector_address = self.superlink_params.get("fleet-api-address", "0.0.0.0:9092")
         self.interop_client = FlowerInteropClient(connector_address, self.automatic_shutdown)
-        return self.interop_client 
+        return self.interop_client
 
     def _build_flwr_superlink_command(self) -> list[str]:
         """

--- a/openfl-workspace/flower-app-pytorch/src/setup_data.py
+++ b/openfl-workspace/flower-app-pytorch/src/setup_data.py
@@ -7,7 +7,7 @@ from PIL import Image
 import numpy as np
 from tqdm import tqdm
 
-EXPECTED_DATASET_HASH = 'ee5342b063299eda95304b0e0388e403a3c65ce5a07cabea4c62a3efdb419a5983c7bb204e55d771ae643642ed440182'  
+EXPECTED_DATASET_HASH = 'ee5342b063299eda95304b0e0388e403a3c65ce5a07cabea4c62a3efdb419a5983c7bb204e55d771ae643642ed440182'
 
 def verify_data_hash(dataset, expected_hash):
     """Verify the hash of the entire dataset."""

--- a/tests/end_to_end/conftest.py
+++ b/tests/end_to_end/conftest.py
@@ -73,7 +73,7 @@ def setup_e2e_logging(pytestconfig):
 
     # Setup a global logger to ensure logging works before any test-specific logs are set
     logger = setup_logger(log_level=log_level, log_file=f"{results_dir}/deployment.log")
-    
+
     # Remove any existing RichHandler instances
     logger.handlers = [h for h in logger.handlers if not isinstance(h, RichHandler)]
 

--- a/tests/end_to_end/test_suites/tr_security_testssl.py
+++ b/tests/end_to_end/test_suites/tr_security_testssl.py
@@ -9,7 +9,6 @@ import json
 
 from tests.end_to_end.utils.tr_common_fixtures import (
     fx_federation_tr,
-    fx_federation_tr_dws,
 )
 from tests.end_to_end.utils import federation_helper as fed_helper
 from tests.end_to_end.utils import constants
@@ -27,11 +26,14 @@ def test_federation_via_native(request, fx_federation_tr):
     """
     # Start the federation
     assert fed_helper.run_federation(fx_federation_tr)
-    # Run testssl.sh on the aggregator port
-    output_path = os.path.join(fx_federation_tr.workspace_path, "testssl_output.json")
+
+    # Get aggregator address and port from plan.yaml
     plan_dir = constants.AGG_PLAN_PATH.format(fx_federation_tr.local_bind_path)
     plan_file = os.path.join(plan_dir, "plan.yaml")
     aggreagtor_addr, aggregator_port = fed_helper.get_agg_addr_port(plan_file)
+
+    # Run testssl.sh on the aggregator port
+    output_path = os.path.join(fx_federation_tr.workspace_path, "testssl_output.json")
     run_testssl_sh(aggreagtor_addr, aggregator_port, output_path)
 
     # Verify the completion of the federation run
@@ -53,16 +55,17 @@ def run_testssl_sh(aggregator_host, aggregator_port, output_path):
     Args:
         aggregator_host (str): Aggregator host
         aggregator_port (int): Aggregator port
+        output_path (str): Path to store the testssl.sh output
     """
     # Use testssl.sh to scan the aggregator port using subprocess and store the output in json file
     command = f"testssl --full --jsonfile {output_path} {aggregator_host}:{aggregator_port}"
-    log.info(f"============== TestSSL.sh output for Aggregator - {aggregator_host}:{aggregator_port} ==============")
+    log.info(f"============== testssl.sh output for Aggregator - {aggregator_host}:{aggregator_port} ==============")
     subprocess.run(command, shell=True)
 
 
 def verify_testssl_report(output_path):
     """
-    Verify the testssl.sh report.
+    Verify the testssl.sh report for security risks. If severity is HIGH, log the issue.
     Args:
         output_path (str): Path to testssl.sh output file
     """
@@ -70,7 +73,7 @@ def verify_testssl_report(output_path):
     log.info("Verifying testssl.sh report")
 
     # Check if the testssl.sh output file exists
-    assert os.path.exists(output_path), "Testssl.sh output file not found"
+    assert os.path.exists(output_path), "testssl.sh output file not found"
 
     # Load the JSON output file
     with open(output_path, "r") as file:
@@ -91,4 +94,4 @@ def verify_testssl_report(output_path):
                 log.error(f"Security risk found in testssl.sh report: {item}")
 
     # Assert that no security risks were found
-    assert not security_risk, "Testssl.sh report shows security risk"
+    assert not security_risk, "testssl.sh report shows security risk"

--- a/tests/end_to_end/test_suites/tr_security_testssl.py
+++ b/tests/end_to_end/test_suites/tr_security_testssl.py
@@ -33,7 +33,7 @@ def test_federation_via_native(request, fx_federation_tr):
     plan_file = os.path.join(plan_dir, "plan.yaml")
     aggreagtor_addr, aggregator_port = fed_helper.get_agg_addr_port(plan_file)
     run_testssl_sh(aggreagtor_addr, aggregator_port, output_path)
-    
+
     # Verify the completion of the federation run
     assert fed_helper.verify_federation_run_completion(
         fx_federation_tr,
@@ -45,7 +45,7 @@ def test_federation_via_native(request, fx_federation_tr):
     log.info(f"Model best aggregated score post {request.config.num_rounds} is {best_agg_score}")
     # Verify the testssl.sh report
     verify_testssl_report(output_path)
-    
+
 
 def run_testssl_sh(aggregator_host, aggregator_port, output_path):
     """
@@ -58,7 +58,7 @@ def run_testssl_sh(aggregator_host, aggregator_port, output_path):
     command = f"testssl --full --jsonfile {output_path} {aggregator_host}:{aggregator_port}"
     subprocess.run(command, shell=True)
     log.info(f"Testssl.sh output is stored in {output_path}")
-    
+
 
 def verify_testssl_report(output_path):
     """
@@ -68,16 +68,16 @@ def verify_testssl_report(output_path):
     """
     # Verify the testssl.sh report
     log.info("Verifying testssl.sh report")
-    
+
     # Check if the testssl.sh output file exists
     assert os.path.exists(output_path), "Testssl.sh output file not found"
-    
+
     # Load the JSON output file
     with open(output_path, "r") as file:
         testssl_output = json.load(file)
-    
+
     security_risk = False
-    
+
     # Iterate through the testssl output items
     for item in testssl_output:
         # Check for high severity issues
@@ -89,6 +89,6 @@ def verify_testssl_report(output_path):
                 # Mark as security risk and log the issue
                 security_risk = True
                 log.error(f"Security risk found in testssl.sh report: {item}")
-    
+
     # Assert that no security risks were found
     assert not security_risk, "Testssl.sh report shows security risk"

--- a/tests/end_to_end/test_suites/tr_security_testssl.py
+++ b/tests/end_to_end/test_suites/tr_security_testssl.py
@@ -1,0 +1,94 @@
+# Copyright 2020-2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import logging
+import subprocess
+import os
+import json
+
+from tests.end_to_end.utils.tr_common_fixtures import (
+    fx_federation_tr,
+    fx_federation_tr_dws,
+)
+from tests.end_to_end.utils import federation_helper as fed_helper
+from tests.end_to_end.utils import constants
+
+log = logging.getLogger(__name__)
+
+
+@pytest.mark.task_runner_basic
+def test_federation_via_native(request, fx_federation_tr):
+    """
+    Test federation via native task runner.
+    Args:
+        request (Fixture): Pytest fixture
+        fx_federation_tr (Fixture): Pytest fixture for native task runner
+    """
+    # Start the federation
+    assert fed_helper.run_federation(fx_federation_tr)
+    # Run testssl.sh on the aggregator port
+    output_path = os.path.join(fx_federation_tr.workspace_path, "testssl_output.json")
+    plan_dir = constants.AGG_PLAN_PATH.format(fx_federation_tr.local_bind_path)
+    plan_file = os.path.join(plan_dir, "plan.yaml")
+    aggreagtor_addr, aggregator_port = fed_helper.get_agg_addr_port(plan_file)
+    run_testssl_sh(aggreagtor_addr, aggregator_port, output_path)
+    
+    # Verify the completion of the federation run
+    assert fed_helper.verify_federation_run_completion(
+        fx_federation_tr,
+        test_env=request.config.test_env,
+        num_rounds=request.config.num_rounds,
+    ), "Federation completion failed"
+
+    best_agg_score = fed_helper.get_best_agg_score(fx_federation_tr.aggregator.tensor_db_file)
+    log.info(f"Model best aggregated score post {request.config.num_rounds} is {best_agg_score}")
+    # Verify the testssl.sh report
+    verify_testssl_report(output_path)
+    
+
+def run_testssl_sh(aggregator_host, aggregator_port, output_path):
+    """
+    Run testssl.sh on the aggregator port.
+    Args:
+        aggregator_host (str): Aggregator host
+        aggregator_port (int): Aggregator port
+    """
+    # Use testssl.sh to scan the aggregator port using subprocess and store the output in json file
+    command = f"testssl --full --jsonfile {output_path} {aggregator_host}:{aggregator_port}"
+    subprocess.run(command, shell=True)
+    log.info(f"Testssl.sh output is stored in {output_path}")
+    
+
+def verify_testssl_report(output_path):
+    """
+    Verify the testssl.sh report.
+    Args:
+        output_path (str): Path to testssl.sh output file
+    """
+    # Verify the testssl.sh report
+    log.info("Verifying testssl.sh report")
+    
+    # Check if the testssl.sh output file exists
+    assert os.path.exists(output_path), "Testssl.sh output file not found"
+    
+    # Load the JSON output file
+    with open(output_path, "r") as file:
+        testssl_output = json.load(file)
+    
+    security_risk = False
+    
+    # Iterate through the testssl output items
+    for item in testssl_output:
+        # Check for high severity issues
+        if item['severity'] == 'HIGH':
+            # Skip certain checks that are not relevant due to internal CA usage
+            if 'cipher_order' in item['id'] or 'cert_revocation' in item['id']:
+                continue
+            else:
+                # Mark as security risk and log the issue
+                security_risk = True
+                log.error(f"Security risk found in testssl.sh report: {item}")
+    
+    # Assert that no security risks were found
+    assert not security_risk, "Testssl.sh report shows security risk"

--- a/tests/end_to_end/test_suites/tr_security_testssl.py
+++ b/tests/end_to_end/test_suites/tr_security_testssl.py
@@ -56,8 +56,8 @@ def run_testssl_sh(aggregator_host, aggregator_port, output_path):
     """
     # Use testssl.sh to scan the aggregator port using subprocess and store the output in json file
     command = f"testssl --full --jsonfile {output_path} {aggregator_host}:{aggregator_port}"
+    log.info(f"============== TestSSL.sh output for Aggregator - {aggregator_host}:{aggregator_port} ==============")
     subprocess.run(command, shell=True)
-    log.info(f"Testssl.sh output is stored in {output_path}")
 
 
 def verify_testssl_report(output_path):

--- a/tests/end_to_end/utils/exceptions.py
+++ b/tests/end_to_end/utils/exceptions.py
@@ -17,6 +17,9 @@ class PlanModificationException(Exception):
     """Exception for plan modification"""
     pass
 
+class PlanReadException(Exception):
+    """Exception for plan read"""
+    pass
 
 class WorkspaceCertificationException(Exception):
     """Exception for workspace certification"""

--- a/tests/end_to_end/utils/federation_helper.py
+++ b/tests/end_to_end/utils/federation_helper.py
@@ -396,7 +396,7 @@ def _verify_completion_for_participant(
             log.info(f"Process is yet to complete for {participant.name}")
 
     # Read tensor.db file for aggregator to check if the process is completed
-    if participant.name == "aggregator":
+    if participant.name == "aggregator" and num_rounds > 1:
         current_round = get_current_round(participant.tensor_db_file)
         if (current_round + 1) != num_rounds:
             raise Exception(f"Process completed but only till round {current_round}")

--- a/tests/end_to_end/utils/federation_helper.py
+++ b/tests/end_to_end/utils/federation_helper.py
@@ -4,6 +4,7 @@
 import time
 import concurrent.futures
 import logging
+import yaml
 import os
 import json
 import re
@@ -1163,3 +1164,20 @@ def remove_workspace(path):
         for entry in os.scandir(path):
             remove_workspace(entry.path)
         subprocess.run(['sudo', 'rmdir', path], check=True)
+
+
+def get_agg_addr_port(plan_file):
+    """
+    Get the aggregator address and port
+    Returns:
+        tuple: Aggregator address and port
+    """
+    try:
+        with open(plan_file) as fp:
+            data = yaml.safe_load(fp)
+        
+        agg_addr = data["network"]["settings"]["agg_addr"]
+        agg_port = data["network"]["settings"]["agg_port"]
+        return agg_addr, agg_port
+    except Exception as e:
+        raise ex.PlanReadException(f"Failed to get aggregator address and port: {e}")

--- a/tests/end_to_end/utils/federation_helper.py
+++ b/tests/end_to_end/utils/federation_helper.py
@@ -1175,7 +1175,7 @@ def get_agg_addr_port(plan_file):
     try:
         with open(plan_file) as fp:
             data = yaml.safe_load(fp)
-        
+
         agg_addr = data["network"]["settings"]["agg_addr"]
         agg_port = data["network"]["settings"]["agg_port"]
         return agg_addr, agg_port

--- a/tests/github/experimental/workflow/LocalRuntime/requirements_experimental_localruntime_tests.txt
+++ b/tests/github/experimental/workflow/LocalRuntime/requirements_experimental_localruntime_tests.txt
@@ -5,5 +5,5 @@ torch
 tabulate==0.9.0
 torchvision
 nbformat==5.10.4
-nbdev==2.3.12
+nbdev==2.3.37
 tensorboard


### PR DESCRIPTION
## Summary
Generate report for TLS certificates using testssl.sh

## Type of Change (Mandatory)
Specify the type of change being made. 
- Others [Please specify] - Security tests to verify SSL connection

## Description (Mandatory)
TestSSL report for task runner ssl certificate verification
Flower workspaces gets included due to format script.
**Testssl.sh Vulnerability Scan Integration**

Testssl.sh is an open-source tool designed to detect vulnerabilities in SSL/TLS configurations by performing thorough assessments of server security. It helps identify a wide range of issues, including:

- **Weak Ciphers & Protocols**: Identifies weak ciphers, outdated protocols (SSLv2, SSLv3, TLS 1.0/1.1), and supports modern, secure ones (TLS 1.2, TLS 1.3).
- **Cipher Suite Strength**: Detects insecure or deprecated cipher suites that can be exploited for attacks.
- **Certificate Issues**: Flags problems with expired certificates, improper chain of trust, missing intermediate certificates, or misconfigurations.
- **Known Vulnerabilities**: Identifies known vulnerabilities like Heartbleed, POODLE, BEAST, and DROWN, which can be exploited by attackers.
- **Forward Secrecy**: Checks whether the server supports forward secrecy, ensuring encryption keys cannot be retroactively decrypted.
- **TLS/SSL Configuration Weaknesses**: Identifies misconfigurations that could lead to insecure communication.

Including Testssl.sh in the security scan is critical for proactively detecting these vulnerabilities, ensuring secure communication, compliance with best practices, and enhancing the overall security posture of the product.

## Testing
[Describe the testing done for this PR. If applicable include screenshots.]
https://github.com/payalcha/openfl/actions/runs/13962018825/job/39084960564 
https://github.com/payalcha/openfl/actions/runs/13962018825/job/39084960564#step:5:178 


```
###########################################################
    testssl       3.0.7 from https://testssl.sh/
    (2ec186b 2025-03-20 10:00:53)

      This program is free software. Distribution and
             modification under GPLv2 permitted.
      USAGE w/o ANY WARRANTY. USE IT AT YOUR OWN RISK!
       Please file bugs @ https://testssl.sh/bugs/

###########################################################
 Using "OpenSSL 3.0.2 15 Mar 2022 (Library: OpenSSL 3.0.2 15 Mar 2022)" [~76 ciphers]
 on fv-az891-418:/usr/bin/openssl
 (built: "Feb  5 13:19:41 2025", platform: "debian-amd64")
 Start 2025-03-20 04:36:58        -->> 127.0.0.1:50096 (localhost) <<--
 Further IP addresses:   ::1 
 A record via:           /etc/hosts 
 rDNS (127.0.0.1):       localhost.
 Service detected:       certificate-based authentication => skipping all HTTP checks
 Testing protocols via sockets except NPN+ALPN 
 SSLv2      not offered (OK)
 SSLv3      not offered (OK)
 TLS 1      not offered
 TLS 1.1    not offered
 TLS 1.2    offered (OK)
 TLS 1.3    offered (OK): final
 NPN/SPDY   not offered
 ALPN/HTTP2 h2 (offered)
 Testing for server implementation bugs 
 No bugs found.
 Testing cipher categories 
 NULL ciphers (no encryption)                  not offered (OK)
 Anonymous NULL Ciphers (no authentication)    not offered (OK)
 Export ciphers (w/o ADH+NULL)                 not offered (OK)
 LOW: 64 Bit + DES, RC[2,4] (w/o export)       not offered (OK)
 Triple DES Ciphers / IDEA                     not offered
 Obsolete CBC ciphers (AES, ARIA etc.)         not offered
 Strong encryption (AEAD ciphers)              offered (OK)
 Testing robust (perfect) forward secrecy, (P)FS -- omitting Null Authentication/Encryption, 3DES, RC4 
 PFS is offered (OK)          TLS_AES_256_GCM_SHA384
                              TLS_CHACHA20_POLY1305_SHA256
                              ECDHE-RSA-AES256-GCM-SHA384
                              TLS_AES_128_GCM_SHA256
                              ECDHE-RSA-AES128-GCM-SHA256 
 Elliptic curves offered:     prime256v1 
 Testing server preferences 
 Has server cipher order?     no (NOT ok)
 Negotiated protocol          TLSv1.3
 Negotiated cipher            TLS_AES_256_GCM_SHA384, 256 bit ECDH (P-256) (limited sense as client will pick)
 Negotiated cipher per proto  (limited sense as client will pick)
     ECDHE-RSA-AES256-GCM-SHA384:   TLSv1.2
     TLS_AES_256_GCM_SHA384:        TLSv1.3
 No further cipher order check has been done as order is determined by the client
 Testing server defaults (Server Hello) 
 TLS extensions (standard)    "server name/#0" "renegotiation info/#65281"
                              "EC point formats/#11" "session ticket/#35"
                              "next protocol/#13172" "supported versions/#43"
                              "key share/#51" "signature algorithms/#13"
                              "certificate authorities/#47"
                              "extended master secret/#23"
                              "application layer protocol negotiation/#16"
 Session Ticket RFC 5077 hint no -- no lifetime advertised
 SSL Session ID support       no
 Session Resumption           Tickets no, ID: no
 TLS clock skew               -1 sec from localtime
 Signature Algorithm          SHA384 with RSA
 Server key size              RSA 3072 bits
 Server key usage             --
 Server extended key usage    --
 Serial                       805843F12FAF4464B321F4C4745C0E04 (OK: length 16)
 Fingerprints                 SHA1 sha1 8383C1339FB58EFF2B4A8F6092845245397C7B5D
                              SHA256 sha256 52A3805C6695C6669EC20C8574245F43AFB96E34B36ED2A2B03131546ED1D788
 Common Name (CN)             localhost 
 subjectAltName (SAN)         localhost 
 Issuer                       Simple Signing CA (Simple Inc)
 Trust (hostname)             Ok via SAN (same w/o SNI)
 Chain of trust               NOT ok (chain incomplete)
 EV cert (experimental)       no 
 ETS/"eTLS", visibility info  not present
 Certificate Validity (UTC)   364 >= 60 days (2025-03-20 04:35 --> 2026-03-20 04:35)
 # of certificates provided   1
 Certificate Revocation List  --
 OCSP URI                     --
                              NOT ok -- neither CRL nor OCSP URI provided
 OCSP stapling                not offered
 OCSP must staple extension   --
 DNS CAA RR (experimental)    not offered
 Certificate Transparency     --
 Testing vulnerabilities 
 Heartbleed (CVE-2014-0160)                not vulnerable (OK), no heartbeat extension
 CCS (CVE-2014-0224)                       not vulnerable (OK)
 Ticketbleed (CVE-2016-9244), experiment.  not vulnerable (OK), no session tickets
 ROBOT                                     Server does not support any cipher suites that use RSA key transport
 Secure Renegotiation (RFC 5746)           supported (OK)
 Secure Client-Initiated Renegotiation     client x509-based authentication prevents this from being tested
 CRIME, TLS (CVE-2012-4929)                not vulnerable (OK)
 BREACH (CVE-2013-3587)                    client x509-based authentication prevents this from being tested
 POODLE, SSL (CVE-2014-3566)               not vulnerable (OK), no SSLv3 support
 TLS_FALLBACK_SCSV (RFC 7507)              No fallback possible (OK), no protocol below TLS 1.2 offered
 SWEET32 (CVE-2016-2[183](https://github.com/payalcha/openfl/actions/runs/13962018825/job/39084960564#step:5:184), CVE-2016-6329)    not vulnerable (OK)
 FREAK (CVE-2015-0204)                     not vulnerable (OK)
 DROWN (CVE-2016-0800, CVE-2016-0703)      not vulnerable on this host and port (OK)
                                           make sure you don't use this certificate elsewhere with SSLv2 enabled services
                                           https://censys.io/ipv4?q=sha256 52A3805C6695C6669EC20C8574245F43AFB96E34B36ED2A2B03131546ED1D788 could help you to find out
 LOGJAM (CVE-2015-4000), experimental      not vulnerable (OK): no DH EXPORT ciphers, no DH key detected with <= TLS 1.2
 BEAST (CVE-2011-3389)                     not vulnerable (OK), no SSL3 or TLS1
 LUCKY13 (CVE-2013-0169), experimental     not vulnerable (OK)
 RC4 (CVE-2013-2566, CVE-2015-2808)        no RC4 ciphers detected (OK)
 Testing ciphers per protocol via OpenSSL plus sockets against the server, ordered by encryption strength 
Hexcode  Cipher Suite Name (OpenSSL)       KeyExch.   Encryption  Bits     Cipher Suite Name (IANA/RFC)
-----------------------------------------------------------------------------------------------------------------------------
SSLv2  
SSLv3  
TLS 1  
TLS 1.1  
TLS 1.2  
 xc030   ECDHE-RSA-AES256-GCM-SHA384       ECDH 256   AESGCM      256      TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384              
 xc02f   ECDHE-RSA-AES128-GCM-SHA256       ECDH 256   AESGCM      128      TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256              
TLS 1.3  
 x1302   TLS_AES_256_GCM_SHA384            ECDH 256   AESGCM      256      TLS_AES_256_GCM_SHA384                             
 x1303   TLS_CHACHA20_POLY1305_SHA256      ECDH 256   ChaCha20    256      TLS_CHACHA20_POLY1305_SHA256                       
 x1301   TLS_AES_128_GCM_SHA256            ECDH 256   AESGCM      128      TLS_AES_128_GCM_SHA256                             
Could not determine the protocol, only simulating generic clients.
 Running client simulations via sockets 
 Android 4.4.2                TLSv1.2 ECDHE-RSA-AES256-GCM-SHA384, 256 bit ECDH (P-256)
 Android 5.0.0                TLSv1.2 ECDHE-RSA-AES128-GCM-SHA256, 256 bit ECDH (P-256)
 Android 6.0                  TLSv1.2 ECDHE-RSA-AES128-GCM-SHA[256](https://github.com/payalcha/openfl/actions/runs/13962018825/job/39084960564#step:5:257), 256 bit ECDH (P-256)
 Android 7.0 (native)         TLSv1.2 ECDHE-RSA-AES128-GCM-SHA256, 256 bit ECDH (P-256)
 Android 8.1 (native)         TLSv1.2 ECDHE-RSA-AES128-GCM-SHA256, 256 bit ECDH (P-256)
 Android 9.0 (native)         TLSv1.3 TLS_AES_128_GCM_SHA256, 256 bit ECDH (P-256)
 Android 10.0 (native)        TLSv1.3 TLS_AES_128_GCM_SHA256, 256 bit ECDH (P-256)
 Chrome 74 (Win 10)           TLSv1.3 TLS_AES_128_GCM_SHA256, 256 bit ECDH (P-256)
 Chrome 79 (Win 10)           TLSv1.3 TLS_AES_128_GCM_SHA256, 256 bit ECDH (P-256)
 Firefox 66 (Win 8.1/10)      TLSv1.3 TLS_AES_128_GCM_SHA256, 256 bit ECDH (P-256)
 Firefox 71 (Win 10)          TLSv1.3 TLS_AES_128_GCM_SHA256, 256 bit ECDH (P-256)
```

<!-- ## Additional Information
This is to verify the TLS connection of aggregator in task runner.