### PR TITLE
Introduce a default `WaitForAllPolicy` for straggler handling

### DIFF
--- a/openfl-workspace/workspace/plan/defaults/straggler_handling_policy.yaml
+++ b/openfl-workspace/workspace/plan/defaults/straggler_handling_policy.yaml
@@ -1,1 +1,1 @@
-template : openfl.component.NoPolicy
+template : openfl.component.WaitForAllPolicy

--- a/openfl-workspace/workspace/plan/defaults/straggler_handling_policy.yaml
+++ b/openfl-workspace/workspace/plan/defaults/straggler_handling_policy.yaml
@@ -1,0 +1,1 @@
+template : openfl.component.NoPolicy

--- a/openfl/component/__init__.py
+++ b/openfl/component/__init__.py
@@ -6,9 +6,9 @@
 from openfl.component.aggregator.aggregator import Aggregator
 from openfl.component.aggregator.straggler_handling import (
     CutoffTimePolicy,
-    NoPolicy,
     PercentagePolicy,
     StragglerPolicy,
+    WaitForAllPolicy,
 )
 from openfl.component.assigner.assigner import Assigner
 from openfl.component.assigner.random_grouped_assigner import RandomGroupedAssigner

--- a/openfl/component/__init__.py
+++ b/openfl/component/__init__.py
@@ -6,6 +6,7 @@
 from openfl.component.aggregator.aggregator import Aggregator
 from openfl.component.aggregator.straggler_handling import (
     CutoffTimePolicy,
+    NoPolicy,
     PercentagePolicy,
     StragglerPolicy,
 )

--- a/openfl/component/aggregator/__init__.py
+++ b/openfl/component/aggregator/__init__.py
@@ -5,6 +5,7 @@
 from openfl.component.aggregator.aggregator import Aggregator
 from openfl.component.aggregator.straggler_handling import (
     CutoffTimePolicy,
+    NoPolicy,
     PercentagePolicy,
     StragglerPolicy,
 )

--- a/openfl/component/aggregator/__init__.py
+++ b/openfl/component/aggregator/__init__.py
@@ -5,7 +5,7 @@
 from openfl.component.aggregator.aggregator import Aggregator
 from openfl.component.aggregator.straggler_handling import (
     CutoffTimePolicy,
-    NoPolicy,
     PercentagePolicy,
     StragglerPolicy,
+    WaitForAllPolicy,
 )

--- a/openfl/component/aggregator/aggregator.py
+++ b/openfl/component/aggregator/aggregator.py
@@ -11,7 +11,7 @@ from threading import Lock
 from typing import List, Optional
 
 import openfl.callbacks as callbacks_module
-from openfl.component.aggregator.straggler_handling import NoPolicy, StragglerPolicy
+from openfl.component.aggregator.straggler_handling import StragglerPolicy, WaitForAllPolicy
 from openfl.databases import PersistentTensorDB, TensorDB
 from openfl.interface.aggregation_functions import SecureWeightedAverage, WeightedAverage
 from openfl.pipelines import NoCompressionPipeline, TensorCodec
@@ -75,7 +75,7 @@ class Aggregator:
         last_state_path,
         assigner,
         use_delta_updates=True,
-        straggler_handling_policy: StragglerPolicy = NoPolicy,
+        straggler_handling_policy: StragglerPolicy = WaitForAllPolicy,
         rounds_to_train=256,
         single_col_cert_common_name=None,
         compression_pipeline=None,

--- a/openfl/component/aggregator/aggregator.py
+++ b/openfl/component/aggregator/aggregator.py
@@ -11,7 +11,7 @@ from threading import Lock
 from typing import List, Optional
 
 import openfl.callbacks as callbacks_module
-from openfl.component.aggregator.straggler_handling import CutoffTimePolicy, StragglerPolicy
+from openfl.component.aggregator.straggler_handling import NoPolicy, StragglerPolicy
 from openfl.databases import PersistentTensorDB, TensorDB
 from openfl.interface.aggregation_functions import SecureWeightedAverage, WeightedAverage
 from openfl.pipelines import NoCompressionPipeline, TensorCodec
@@ -75,7 +75,7 @@ class Aggregator:
         last_state_path,
         assigner,
         use_delta_updates=True,
-        straggler_handling_policy: StragglerPolicy = CutoffTimePolicy,
+        straggler_handling_policy: StragglerPolicy = NoPolicy,
         rounds_to_train=256,
         single_col_cert_common_name=None,
         compression_pipeline=None,

--- a/openfl/component/aggregator/straggler_handling.py
+++ b/openfl/component/aggregator/straggler_handling.py
@@ -56,6 +56,32 @@ class StragglerPolicy(ABC):
         raise NotImplementedError
 
 
+class NoPolicy(StragglerPolicy):
+    """
+    This policy waits for all collaborators.
+    """
+
+    def start_policy(self, **kwargs) -> None:
+        """
+        Nothing needed.
+        """
+        pass
+
+    def reset_policy_for_round(self) -> None:
+        """
+        Nothing needed.
+        """
+        pass
+
+    def straggler_cutoff_check(
+        self, num_collaborators_done: int, num_all_collaborators: int, **kwargs
+    ) -> bool:
+        """
+        Checks if all collaborators have sent task results for the round.
+        """
+        return num_all_collaborators == num_collaborators_done
+
+
 class CutoffTimePolicy(StragglerPolicy):
     """Cutoff time based Straggler Handling function."""
 

--- a/openfl/component/aggregator/straggler_handling.py
+++ b/openfl/component/aggregator/straggler_handling.py
@@ -56,7 +56,7 @@ class StragglerPolicy(ABC):
         raise NotImplementedError
 
 
-class NoPolicy(StragglerPolicy):
+class WaitForAllPolicy(StragglerPolicy):
     """
     This policy waits for all collaborators.
     """

--- a/openfl/federated/plan/plan.py
+++ b/openfl/federated/plan/plan.py
@@ -418,8 +418,10 @@ class Plan:
 
     def get_straggler_handling_policy(self):
         """Get straggler handling policy."""
-        template = "openfl.component.aggregator.straggler_handling.CutoffTimePolicy"
-        defaults = self.config.get("straggler_handling_policy", {TEMPLATE: template, SETTINGS: {}})
+        defaults = self.config.get(
+            "straggler_handling_policy",
+            {TEMPLATE: "openfl.component.aggregator.straggler_handling.NoPolicy", SETTINGS: {}},
+        )
 
         if self.straggler_policy_ is None:
             # Prepare a partial function for the straggler policy

--- a/openfl/federated/plan/plan.py
+++ b/openfl/federated/plan/plan.py
@@ -420,7 +420,10 @@ class Plan:
         """Get straggler handling policy."""
         defaults = self.config.get(
             "straggler_handling_policy",
-            {TEMPLATE: "openfl.component.aggregator.straggler_handling.NoPolicy", SETTINGS: {}},
+            {
+                TEMPLATE: "openfl.component.aggregator.straggler_handling.WaitForAllPolicy",
+                SETTINGS: {},
+            },
         )
 
         if self.straggler_policy_ is None:


### PR DESCRIPTION
## Summary
Introduce a default `NoPolicy` straggler handling policy. 

## Type of Change (Mandatory)
Specify the type of change being made. 
- Feature enhancement  

## Description (Mandatory)
- The default `straggler_handling_policy` currently is `CutOfTimePolicy` with infinite waiting time. This can also be mimicked with `PercentagePolicy` with 100% collaborators needed.
- This PR introduces a clearer default straggler handling policy where openfl waits for all collaborators' results to be sent. 

## Testing
[CI](https://github.com/securefederatedai/openfl/actions/runs/13962224046/job/39085526216?pr=1461)
![Screenshot 2025-03-20 at 10 29 29 AM](https://github.com/user-attachments/assets/f30b2079-ee55-453f-b840-2586b62f2cc5)
