### PR TITLE
Added notes for non-TLS in Quickstart documentation

### DIFF
--- a/docs/tutorials/taskrunner.ipynb
+++ b/docs/tutorials/taskrunner.ipynb
@@ -14,7 +14,7 @@
         "\n",
         "OpenFL must be installed for this tutorial. Refer to the [installation](https://openfl.readthedocs.io/en/latest/installation.html) guide.\n",
         "\n",
-        "Note: For a simplified setup by disabling TLS, refer to the step below [(Optional) Disable TLS for a simplified setup](https://openfl.readthedocs.io/en/latest/tutorials/taskrunner.html)."
+        "Note: For a simplified setup by disabling TLS, refer to the step below [(Optional) Disable TLS for a simplified setup](https://noopurintel-openfl.readthedocs.io/en/latest/tutorials/taskrunner.html#optional-disable-tls-for-a-simplified-setup)."
       ]
     },
     {
@@ -366,14 +366,8 @@
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "vscode": {
-          "languageId": "shellscript"
-        }
-      },
-      "outputs": [],
+      "cell_type": "markdown",
+      "metadata": {},
       "source": [
         "collaborators:\n",
         "- collaborator1\n",
@@ -382,11 +376,7 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "tags": [
-          "hide-output"
-        ]
-      },
+      "metadata": {},
       "source": [
         "### Next steps\n",
         "\n",
@@ -396,15 +386,6 @@
         "\n",
         "For an in-depth understanding of the TaskRunner architecture, refer to the [TaskRunner API](https://openfl.readthedocs.io/en/latest/about/features_index/taskrunner.html)."
       ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "tags": [
-          "hide-output"
-        ]
-      },
-      "source": []
     }
   ],
   "metadata": {

--- a/docs/tutorials/taskrunner.ipynb
+++ b/docs/tutorials/taskrunner.ipynb
@@ -369,9 +369,9 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "collaborators:\n",
-        "- collaborator1\n",
-        "- collaborator2"
+        "        collaborators:\n",
+        "        - collaborator1\n",
+        "        - collaborator2"
       ]
     },
     {

--- a/docs/tutorials/taskrunner.ipynb
+++ b/docs/tutorials/taskrunner.ipynb
@@ -22,15 +22,6 @@
       ]
     },
     {
-      "cell_type": "raw",
-      "metadata": {},
-      "source": [
-        "collaborators:\n",
-        "- collaborator1\n",
-        "- collaborator2"
-      ]
-    },
-    {
       "cell_type": "markdown",
       "metadata": {},
       "source": [

--- a/docs/tutorials/taskrunner.ipynb
+++ b/docs/tutorials/taskrunner.ipynb
@@ -14,7 +14,20 @@
         "\n",
         "OpenFL must be installed for this tutorial. Refer to the [installation](https://openfl.readthedocs.io/en/latest/installation.html) guide.\n",
         "\n",
-        "Note: For a simplified setup by disabling TLS, refer to the step below [(Optional) Disable TLS for a simplified setup](https://noopurintel-openfl.readthedocs.io/en/latest/tutorials/taskrunner.html#optional-disable-tls-for-a-simplified-setup)."
+        "Note: For a simplified setup without TLS, perform below steps as and when applicable in the flow:\n",
+        "\n",
+        "1. Set `use_tls: false` in the FL plan before initialization.\n",
+        "2. Skip all certificate-related commands (incl. CA setup).\n",
+        "3. Manually populate the collaborator names in `cols.yaml`. For example:"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "        collaborators:\n",
+        "        - collaborator1\n",
+        "        - collaborator2"
       ]
     },
     {
@@ -33,7 +46,11 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "tags": [
+          "hide-output"
+        ]
+      },
       "outputs": [],
       "source": [
         "!fx workspace create --prefix ./mnist_example --template keras/mnist\n",
@@ -63,7 +80,10 @@
       "metadata": {
         "vscode": {
           "languageId": "shellscript"
-        }
+        },
+        "tags": [
+          "hide-output"
+        ]
       },
       "outputs": [],
       "source": [
@@ -91,7 +111,10 @@
       "metadata": {
         "vscode": {
           "languageId": "shellscript"
-        }
+        },
+        "tags": [
+          "hide-output"
+        ]
       },
       "outputs": [],
       "source": [
@@ -121,7 +144,10 @@
       "metadata": {
         "vscode": {
           "languageId": "shellscript"
-        }
+        },
+        "tags": [
+          "hide-output"
+        ]
       },
       "outputs": [],
       "source": [
@@ -161,7 +187,10 @@
       "metadata": {
         "vscode": {
           "languageId": "shellscript"
-        }
+        },
+        "tags": [
+          "hide-output"
+        ]
       },
       "outputs": [],
       "source": [
@@ -185,7 +214,10 @@
       "metadata": {
         "vscode": {
           "languageId": "shellscript"
-        }
+        },
+        "tags": [
+          "hide-output"
+        ]
       },
       "outputs": [],
       "source": [
@@ -211,7 +243,10 @@
       "metadata": {
         "vscode": {
           "languageId": "shellscript"
-        }
+        },
+        "tags": [
+          "hide-output"
+        ]
       },
       "outputs": [],
       "source": [
@@ -237,7 +272,10 @@
       "metadata": {
         "vscode": {
           "languageId": "shellscript"
-        }
+        },
+        "tags": [
+          "hide-output"
+        ]
       },
       "outputs": [],
       "source": [
@@ -261,7 +299,10 @@
       "metadata": {
         "vscode": {
           "languageId": "shellscript"
-        }
+        },
+        "tags": [
+          "hide-output"
+        ]
       },
       "outputs": [],
       "source": [
@@ -287,7 +328,10 @@
       "metadata": {
         "vscode": {
           "languageId": "shellscript"
-        }
+        },
+        "tags": [
+          "hide-output"
+        ]
       },
       "outputs": [],
       "source": [
@@ -313,7 +357,10 @@
       "metadata": {
         "vscode": {
           "languageId": "shellscript"
-        }
+        },
+        "tags": [
+          "hide-output"
+        ]
       },
       "outputs": [],
       "source": [
@@ -352,26 +399,6 @@
         "!fx aggregator start &\\\n",
         " fx collaborator start -n bob &\\\n",
         " fx collaborator start -n charlie"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### (Optional) Disable TLS for a simplified setup\n",
-        "\n",
-        "1. Set `use_tls: false` in the FL plan before initialization.\n",
-        "2. Skip all certificate-related commands (incl. CA setup) in the following steps of the tutorial.\n",
-        "3. Manually populate the collaborator names in `cols.yaml`. For example:"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "        collaborators:\n",
-        "        - collaborator1\n",
-        "        - collaborator2"
       ]
     },
     {

--- a/docs/tutorials/taskrunner.ipynb
+++ b/docs/tutorials/taskrunner.ipynb
@@ -14,11 +14,20 @@
         "\n",
         "OpenFL must be installed for this tutorial. Refer to the [installation](https://openfl.readthedocs.io/en/latest/installation.html) guide.\n",
         "\n",
-        "**(Optional)** For a simplified setup without TLS, perform below steps as and when applicable in the flow:\n",
+        "**(Optional)** For a simplified setup without TLS, follow these steps as applicable throughout the process:\n",
         "\n",
         "1. Set `use_tls: false` in the FL plan before initialization.\n",
         "2. Skip all certificate-related commands (incl. CA setup).\n",
         "3. Manually populate the collaborator names in `cols.yaml`. For example:"
+      ]
+    },
+    {
+      "cell_type": "raw",
+      "metadata": {},
+      "source": [
+        "collaborators:\n",
+        "- collaborator1\n",
+        "- collaborator2"
       ]
     },
     {

--- a/docs/tutorials/taskrunner.ipynb
+++ b/docs/tutorials/taskrunner.ipynb
@@ -12,7 +12,9 @@
         "\n",
         "In this guide, we will train a simple Convolutional Neural Network (CNN) on MNIST handwritten digits dataset. We will simulate a Federated Learning experiment between two collaborators, orchestrated by an aggregator, via few CLI commands.\n",
         "\n",
-        "OpenFL must be installed for this tutorial. Refer to the [installation](https://openfl.readthedocs.io/en/latest/installation.html) guide."
+        "OpenFL must be installed for this tutorial. Refer to the [installation](https://openfl.readthedocs.io/en/latest/installation.html) guide.\n",
+        "\n",
+        "Note: For a simplified setup by disabling TLS, refer to the step below [(Optional) Disable TLS for a simplified setup](https://openfl.readthedocs.io/en/latest/tutorials/taskrunner.html)."
       ]
     },
     {
@@ -350,6 +352,32 @@
         "!fx aggregator start &\\\n",
         " fx collaborator start -n bob &\\\n",
         " fx collaborator start -n charlie"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### (Optional) Disable TLS for a simplified setup\n",
+        "\n",
+        "1. Set `use_tls: false` in the FL plan before initialization.\n",
+        "2. Skip all certificate-related commands (incl. CA setup) in the following steps of the tutorial.\n",
+        "3. Manually populate the collaborator names in `cols.yaml`. For example:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "vscode": {
+          "languageId": "shellscript"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "collaborators:\n",
+        "- collaborator1\n",
+        "- collaborator2"
       ]
     },
     {

--- a/docs/tutorials/taskrunner.ipynb
+++ b/docs/tutorials/taskrunner.ipynb
@@ -14,7 +14,7 @@
         "\n",
         "OpenFL must be installed for this tutorial. Refer to the [installation](https://openfl.readthedocs.io/en/latest/installation.html) guide.\n",
         "\n",
-        "Note: For a simplified setup without TLS, perform below steps as and when applicable in the flow:\n",
+        "**(Optional)** For a simplified setup without TLS, perform below steps as and when applicable in the flow:\n",
         "\n",
         "1. Set `use_tls: false` in the FL plan before initialization.\n",
         "2. Skip all certificate-related commands (incl. CA setup).\n",
@@ -78,12 +78,12 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "vscode": {
-          "languageId": "shellscript"
-        },
         "tags": [
           "hide-output"
-        ]
+        ],
+        "vscode": {
+          "languageId": "shellscript"
+        }
       },
       "outputs": [],
       "source": [
@@ -109,12 +109,12 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "vscode": {
-          "languageId": "shellscript"
-        },
         "tags": [
           "hide-output"
-        ]
+        ],
+        "vscode": {
+          "languageId": "shellscript"
+        }
       },
       "outputs": [],
       "source": [
@@ -142,12 +142,12 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "vscode": {
-          "languageId": "shellscript"
-        },
         "tags": [
           "hide-output"
-        ]
+        ],
+        "vscode": {
+          "languageId": "shellscript"
+        }
       },
       "outputs": [],
       "source": [
@@ -185,12 +185,12 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "vscode": {
-          "languageId": "shellscript"
-        },
         "tags": [
           "hide-output"
-        ]
+        ],
+        "vscode": {
+          "languageId": "shellscript"
+        }
       },
       "outputs": [],
       "source": [
@@ -212,12 +212,12 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "vscode": {
-          "languageId": "shellscript"
-        },
         "tags": [
           "hide-output"
-        ]
+        ],
+        "vscode": {
+          "languageId": "shellscript"
+        }
       },
       "outputs": [],
       "source": [
@@ -241,12 +241,12 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "vscode": {
-          "languageId": "shellscript"
-        },
         "tags": [
           "hide-output"
-        ]
+        ],
+        "vscode": {
+          "languageId": "shellscript"
+        }
       },
       "outputs": [],
       "source": [
@@ -270,12 +270,12 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "vscode": {
-          "languageId": "shellscript"
-        },
         "tags": [
           "hide-output"
-        ]
+        ],
+        "vscode": {
+          "languageId": "shellscript"
+        }
       },
       "outputs": [],
       "source": [
@@ -297,12 +297,12 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "vscode": {
-          "languageId": "shellscript"
-        },
         "tags": [
           "hide-output"
-        ]
+        ],
+        "vscode": {
+          "languageId": "shellscript"
+        }
       },
       "outputs": [],
       "source": [
@@ -326,12 +326,12 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "vscode": {
-          "languageId": "shellscript"
-        },
         "tags": [
           "hide-output"
-        ]
+        ],
+        "vscode": {
+          "languageId": "shellscript"
+        }
       },
       "outputs": [],
       "source": [
@@ -355,12 +355,12 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "vscode": {
-          "languageId": "shellscript"
-        },
         "tags": [
           "hide-output"
-        ]
+        ],
+        "vscode": {
+          "languageId": "shellscript"
+        }
       },
       "outputs": [],
       "source": [


### PR DESCRIPTION
## Summary
Fixes issue https://github.com/securefederatedai/openfl/issues/1412 using documentation update.

## Type of Change (Mandatory)
Specify the type of change being made. 
- Documentation update  

## Description (Mandatory)
For `non-TLS` scenario, collaborators registration need to be done separately which is otherwise included in the certify process for `TLS`. This wasn't documented anywhere.

In this PR:
1. Added an Optional note in the beginning to mention steps for non-TLS scenario.
2. Made output section collapsible for all the steps (earlier it was present only for Simulation step).

## Testing
Changes are available here - https://noopurintel-openfl.readthedocs.io/en/latest/tutorials/taskrunner.html

<img width="1123" alt="image" src="https://github.com/user-attachments/assets/91bbf9c4-9859-4870-9abd-eb335e2565e8" />
