### PR TITLE
TaskRunner E2E FedEval: Skip checking TensorDB for federation run completion

### DIFF
--- a/tests/end_to_end/utils/federation_helper.py
+++ b/tests/end_to_end/utils/federation_helper.py
@@ -395,7 +395,7 @@ def _verify_completion_for_participant(
             log.info(f"Process is yet to complete for {participant.name}")
 
     # Read tensor.db file for aggregator to check if the process is completed
-    if participant.name == "aggregator":
+    if participant.name == "aggregator" and num_rounds > 1:
         current_round = get_current_round(participant.tensor_db_file)
         if (current_round + 1) != num_rounds:
             raise Exception(f"Process completed but only till round {current_round}")


### PR DESCRIPTION
## Summary
Recently, TaskRunner automation was modified to use `LOG_FILE` while starting participants. In the same PR, a check was also added to compare the total no of rounds with current round verifying the end of experiment.

FedEval has single round, so this check kept failing for it, also resulting in PQ pipeline failure.

## Type of Change (Mandatory)
Specify the type of change being made. 
- Others - Automation fix for FedEval test cases.

## Description (Mandatory)
Added a condition of `num_of_rounds > 1` while comparing the rounds; so that it is skipped for FedEval.

## Testing
PQ pipeline (using my branch) - https://github.com/noopurintel/openfl/actions/runs/13967804647
PR pipeline also includes multiple tests which use the modified code. 