### PR TITLE
1.8: Raise error if data is not found when running flower-app-pytorch workspace

### DIFF
--- a/openfl-workspace/flower-app-pytorch/src/aggregator.py
+++ b/openfl-workspace/flower-app-pytorch/src/aggregator.py
@@ -13,7 +13,6 @@ from openfl.component.aggregator.straggler_handling import CutoffTimePolicy, Str
 from openfl.databases import PersistentTensorDB, TensorDB
 from openfl.pipelines import NoCompressionPipeline, TensorCodec
 from openfl.protocols import base_pb2, utils
-from openfl.utilities.secagg.setup import Setup as secagg_setup
 from openfl.utilities import TaskResultKey
 
 from openfl.component import Aggregator
@@ -143,10 +142,11 @@ class AggregatorFlower(Aggregator):
                 self.model: base_pb2.ModelProto = utils.load_proto(self.init_state_path)
                 self._load_initial_tensors()  # keys are TensorKeys
 
-        self.collaborator_tensor_results = {}  # {TensorKey: nparray}}
         self._secure_aggregation_enabled = secure_aggregation
         if self._secure_aggregation_enabled:
-            self.secagg = secagg_setup(self.uuid, self.authorized_cols, self.tensor_db)
+            from openfl.utilities.secagg.bootstrap import SecAggSetup
+
+            self.secagg = SecAggSetup(self.uuid, self.authorized_cols, self.tensor_db)
 
         if self.persistent_db and self._recover():
             logger.info("Recovered state of aggregator")

--- a/openfl-workspace/flower-app-pytorch/src/loader.py
+++ b/openfl-workspace/flower-app-pytorch/src/loader.py
@@ -4,6 +4,7 @@
 """FlowerDataLoader module."""
 
 from openfl.federated.data.loader import DataLoader
+import os
 
 
 class FlowerDataLoader(DataLoader):
@@ -21,8 +22,14 @@ class FlowerDataLoader(DataLoader):
         Args:
             data_path (str or int): The directory of the dataset.
             **kwargs: Additional keyword arguments to pass to the parent DataLoader class.
+
+        Raises:
+            FileNotFoundError: If the specified data path does not exist.
          """
         super().__init__(**kwargs)
+        if not os.path.exists(data_path):
+            raise FileNotFoundError(f"The specified data path does not exist: {data_path}")
+        
         self.data_path = data_path
 
     def get_node_configs(self):


### PR DESCRIPTION
## Summary
Flower workspace will run even if data is not found (with 2 failed collaborators)

## Type of Change (Mandatory)
Specify the type of change being made. 
- Bug fix  
- partial fix for https://github.com/securefederatedai/openfl/issues/1468

## Description (Mandatory)
> If data is not present, it keeps running without giving any exception and run successfully without giving rounds summary.

This PR adds a check to see if the data path passed into the collaborator is found. If not, it will raise `FileNotFoundError` and not proceed.

**_Note_**: the Flower SuperLink itself will remain in a state where it is waiting for all collaborators to start, but the experiment won't commence. This is aligned with OpenFL's aggregator behavior

## Testing
Run flower-app-pytorch with and without `data/1`. When `data/1` was missing, collaborator 1 exited with error:
<img width="476" alt="image" src="https://github.com/user-attachments/assets/4daddabd-b80a-435c-b4b1-2097fb5f2a47" />
