### PR TITLE
Skipping GaNDLF run from PR pipeline

### DIFF
--- a/.github/workflows/pr_pipeline.yml
+++ b/.github/workflows/pr_pipeline.yml
@@ -39,9 +39,10 @@ jobs:
     name: Federated Runtime Watermarking E2E
     uses: ./.github/workflows/wf_watermarking_fed_runtime.yml
 
-  gandlf_taskrunner:
-    name: GaNDLF TaskRunner E2E
-    uses: ./.github/workflows/gandlf.yml
+# Issue - https://github.com/mlcommons/GaNDLF/issues/993
+  # gandlf_taskrunner:
+  #   name: GaNDLF TaskRunner E2E
+  #   uses: ./.github/workflows/gandlf.yml
 
   hadolint_security_scan:
     name: Hadolint Security Scan

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,5 +6,5 @@ pytest-asyncio==0.25.3
 pytest-mock==3.14.0
 defusedxml==0.7.1
 matplotlib==3.10.1
-fpdf==1.7.2
+fpdf2=2.8.2
 papermill==2.6.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,5 +6,5 @@ pytest-asyncio==0.25.3
 pytest-mock==3.14.0
 defusedxml==0.7.1
 matplotlib==3.10.1
-fpdf2=2.8.2
+fpdf2==2.8.2
 papermill==2.6.0


### PR DESCRIPTION
Post setuptools upgrade to 78.0.1, GaNDLF pre-requisites are failing. So skipping it from PR pipeline.

Raised issue in Gandlf - https://github.com/mlcommons/GaNDLF/issues/993 