### PR TITLE
Task Runner E2E: Remove additional folder permissioning

### DIFF
--- a/tests/end_to_end/utils/constants.py
+++ b/tests/end_to_end/utils/constants.py
@@ -43,7 +43,7 @@ DATA_SETUP_FILE = "setup_data.py" # currently xgb_higgs is using this file to se
 
 AGG_COL_RESULT_FILE = "{0}/{1}/workspace/{1}.log"  # example - /tmp/my_federation/aggregator/workspace/aggregator.log
 
-AGG_WORKSPACE_ZIP_NAME = "workspace.zip"
+DFLT_WORKSPACE_NAME = "workspace"
 
 # Memory logs related
 AGG_MEM_USAGE_JSON = "{}/aggregator/workspace/logs/aggregator_memory_usage.json"  # example - /tmp/my_federation/aggregator/workspace/logs/aggregator_memory_usage.json
@@ -55,5 +55,4 @@ COL_START_CMD = "fx collaborator start -n {}"
 COL_END_MSG = "Received shutdown signal"
 
 COL_CERTIFY_CMD = "fx collaborator certify --import 'agg_to_col_{}_signed_cert.zip'"
-DFLT_DOCKERIZE_IMAGE_NAME = "workspace"
 EXCEPTION = "Exception"

--- a/tests/end_to_end/utils/docker_helper.py
+++ b/tests/end_to_end/utils/docker_helper.py
@@ -94,7 +94,7 @@ def start_docker_container_with_federation_run(
         else:
             local_participant_path = participant.workspace_path
 
-            docker_participant_path = f"/{constants.DFLT_DOCKERIZE_IMAGE_NAME}"
+            docker_participant_path = f"/{constants.DFLT_WORKSPACE_NAME}"
 
         volumes = {
             local_participant_path: {"bind": docker_participant_path, "mode": "rw"},

--- a/tests/end_to_end/utils/federation_helper.py
+++ b/tests/end_to_end/utils/federation_helper.py
@@ -263,7 +263,7 @@ def run_federation_for_dws(fed_obj, use_tls):
         try:
             container = dh.start_docker_container_with_federation_run(
                 participant=participant,
-                image=constants.DFLT_DOCKERIZE_IMAGE_NAME,
+                image=constants.DFLT_WORKSPACE_NAME,
                 use_tls=use_tls,
                 env_keyval_list=set_keras_backend(fed_obj.model_name) if "keras" in fed_obj.model_name else None,
             )
@@ -462,30 +462,6 @@ def federation_env_setup_and_validate(request, eval_scope=False):
     return workspace_path, local_bind_path, agg_domain_name
 
 
-def add_local_workspace_permission(local_bind_path):
-    """
-    Add permission to workspace. This is aggregator/model owner specific operation.
-    Args:
-        workspace_path (str): Workspace path
-        agg_container_id (str): Container ID
-    """
-    try:
-        agg_workspace_path = constants.AGG_WORKSPACE_PATH.format(local_bind_path)
-        return_code, output, error = run_command(
-            f"sudo chmod -R 777 {agg_workspace_path}",
-            workspace_path=local_bind_path,
-        )
-        if return_code != 0:
-            raise Exception(f"Failed to add local permission to workspace: {error}")
-
-        log.debug(
-            f"Recursive permission added to workspace on local machine: {agg_workspace_path}"
-        )
-    except Exception as e:
-        log.error(f"Failed to add local permission to workspace: {e}")
-        raise e
-
-
 def create_persistent_store(participant_name, local_bind_path):
     """
     Create persistent store for the participant on local machine (even for docker)
@@ -498,8 +474,7 @@ def create_persistent_store(participant_name, local_bind_path):
         error_msg = f"Failed to create persistent store for {participant_name}"
         cmd_persistent_store = (
             f"export WORKING_DIRECTORY={local_bind_path}; "
-            f"mkdir -p $WORKING_DIRECTORY/{participant_name}/workspace; "
-            "sudo chmod -R 755 $WORKING_DIRECTORY"
+            f"mkdir -p $WORKING_DIRECTORY/{participant_name}/workspace"
         )
         log.debug(f"Creating persistent store")
         return_code, output, error = run_command(
@@ -639,7 +614,7 @@ def setup_collaborator(index, workspace_path, local_bind_path):
             local_bind_path, collaborator.name
         )
         copy_file_between_participants(
-            local_agg_ws_path, local_col_ws_path, constants.AGG_WORKSPACE_ZIP_NAME
+            local_agg_ws_path, local_col_ws_path, f"{constants.DFLT_WORKSPACE_NAME}.zip"
         )
         collaborator.import_workspace()
     except Exception as e:

--- a/tests/end_to_end/utils/tr_workspace.py
+++ b/tests/end_to_end/utils/tr_workspace.py
@@ -54,7 +54,6 @@ def common_workspace_creation(request, eval_scope=False):
     fh.create_persistent_store(model_owner.name, local_bind_path)
 
     model_owner.create_workspace()
-    fh.add_local_workspace_permission(local_bind_path)
 
     # Modify the plan
     plan_path = constants.AGG_PLAN_PATH.format(local_bind_path)
@@ -294,7 +293,6 @@ def create_tr_dws_workspace(request, eval_scope=False):
     # Command 'fx workspace dockerize --save ..' will use the workspace name for
     # image name which is 'workspace' in this case.
     model_owner.dockerize_workspace(constants.DEFAULT_OPENFL_IMAGE)
-    image_name = constants.DFLT_DOCKERIZE_IMAGE_NAME
 
     # Certify the workspace in case of TLS
     if request.config.use_tls:
@@ -357,7 +355,7 @@ def create_tr_dws_workspace(request, eval_scope=False):
 
     # Note: In case of multiple machines setup, scp this workspace tar
     # to the other machine(s) so that docker load can load the image.
-    model_owner.load_workspace(workspace_tar_name=f"{image_name}.tar")
+    model_owner.load_workspace(workspace_tar_name=f"{constants.DFLT_WORKSPACE_NAME}.tar")
 
     # Return the federation fixture
     return federation_details(


### PR DESCRIPTION
## Summary
Improve E2E tests to remove any folder/file level permissioning added earlier which isn't required anymore.

## Type of Change (Mandatory)
- E2E test improvement

## Description (Mandatory)
In the beginning, when E2E test framework was modified for dockerized version, it wasn't with dockerized workspace but a generic docker approach - https://wiki.ith.intel.com/display/TPE/OpenFL+Docker+workflow+for+TaskRunner+API+aka+Aggregator

This required some folder/file level permissions as well. Later this approach was removed, but the permissioning code stayed. This PR aims to remove that.

## Testing
PR pipeline already covers these tests.
PQ pipeline in my fork - https://github.com/noopurintel/openfl/actions/runs/14060519332
