### PR TITLE
Gandlf started working as setuptools postponed deprecation of code

### DIFF
--- a/.github/workflows/pr_pipeline.yml
+++ b/.github/workflows/pr_pipeline.yml
@@ -39,10 +39,9 @@ jobs:
     name: Federated Runtime Watermarking E2E
     uses: ./.github/workflows/wf_watermarking_fed_runtime.yml
 
-# Issue - https://github.com/mlcommons/GaNDLF/issues/993
-  # gandlf_taskrunner:
-  #   name: GaNDLF TaskRunner E2E
-  #   uses: ./.github/workflows/gandlf.yml
+  gandlf_taskrunner:
+    name: GaNDLF TaskRunner E2E
+    uses: ./.github/workflows/gandlf.yml
 
   hadolint_security_scan:
     name: Hadolint Security Scan


### PR DESCRIPTION
Issue of Gandlf was due to setuptools upgrade, some workaround was suggested in the issue - https://github.com/mlcommons/GaNDLF/issues/993
But since setuptools postponed removals of deprecated dash-separated and uppercase fields in setup.cfg. Code started working as-is. Reference - https://github.com/pypa/setuptools/blob/main/NEWS.rst 
We need not to perform any workaround and Gandlf started working without any suggested changes