### PR TITLE
[WIP] TaskRunner E2E test for `flower-app-pytorch` workspace

### DIFF
--- a/openfl/protocols/utils.py
+++ b/openfl/protocols/utils.py
@@ -313,7 +313,7 @@ def datastream_to_proto(proto, stream):
         npbytes.extend(chunk.npbytes)
 
     if len(npbytes) > 0:
-        proto.ParseFromString(npbytes)
+        proto.ParseFromString(bytes(npbytes))
         return proto
     else:
         raise RuntimeError(f"Received empty stream message of type {type(proto)}")


### PR DESCRIPTION
## Summary
This PR:
- adds an E2E task runner CI test for the `flower-app-pytorch`
- addresses `TypeError: expected bytes, bytearray found` found in `flower-app-pytorch` workspace

## Type of Change (Mandatory)
Specify the type of change being made. 
- Bug fix  
- Others [CI test]

## Description (Mandatory)
- `flwr` requires `protobuf<5.0.0` which exhibits `TypeError: expected bytes, bytearray found`. Explicitly setting value to `bytes` resolves this issue.
