### PR TITLE
add hippmapp3r

### DIFF
--- a/openfl-workspace/keras/hippmapp3r/.workspace
+++ b/openfl-workspace/keras/hippmapp3r/.workspace
@@ -1,0 +1,2 @@
+current_plan_name: default
+

--- a/openfl-workspace/keras/hippmapp3r/README.md
+++ b/openfl-workspace/keras/hippmapp3r/README.md
@@ -1,0 +1,14 @@
+# Implementation of Hipp Mapper for Medical Imaging
+
+This project implements a hippocampal mapper for medical imaging. It works similarly to other workspaces as described in the [OpenFL Taskrunner Tutorial](https://openfl.readthedocs.io/en/latest/tutorials/taskrunner.html).
+
+## Setup Instructions
+
+To set up the data, run the following command:
+```bash
+python src/setup_data.py --num_collaborators $MAX_NUMBER_OF_COLLABORATORS --total_dataset_size_per_col_MB $DESIRED_DATASET_SIZE
+```
+
+## Reference
+
+Goubran, M., Ntiri E., Akhavein, H., Holmes, M., Nestor, S., Ramirez, J., Adamo, S., Gao, F., Ozzoude, M., Scott, C., Martel, A., Swardfager, W., Masellis, M., Swartz, R., MacIntosh B, and Black, SE. “Hippocampal segmentation for atrophied brains using three-dimensional convolutional neural networks”. Human Brain Mapping. 2020 Feb 1;41(2):291-308. https://onlinelibrary.wiley.com/doi/full/10.1002/hbm.24811

--- a/openfl-workspace/keras/hippmapp3r/plan/cols.yaml
+++ b/openfl-workspace/keras/hippmapp3r/plan/cols.yaml
@@ -1,0 +1,4 @@
+# Copyright (C) 2020-2025 Intel Corporation
+# Licensed subject to the terms of the separately executed evaluation license agreement between Intel Corporation and you.
+
+collaborators:

--- a/openfl-workspace/keras/hippmapp3r/plan/data.yaml
+++ b/openfl-workspace/keras/hippmapp3r/plan/data.yaml
@@ -1,0 +1,6 @@
+# Copyright (C) 2020-2025 Intel Corporation
+# Licensed subject to the terms of the separately executed evaluation license agreement between Intel Corporation and you.
+
+# collaborator_name,data_directory_path
+collaborator1,data/1
+collaborator2,data/2

--- a/openfl-workspace/keras/hippmapp3r/plan/defaults
+++ b/openfl-workspace/keras/hippmapp3r/plan/defaults
@@ -1,0 +1,2 @@
+../../workspace/plan/defaults
+

--- a/openfl-workspace/keras/hippmapp3r/plan/plan.yaml
+++ b/openfl-workspace/keras/hippmapp3r/plan/plan.yaml
@@ -1,0 +1,65 @@
+# Copyright (C) 2020-2025 Intel Corporation
+# Licensed subject to the terms of the separately executed evaluation license agreement between Intel Corporation and you.
+
+aggregator :
+  defaults : plan/defaults/aggregator.yaml
+  template : openfl.component.Aggregator
+  settings :
+    init_state_path : save/init.pbuf
+    best_state_path : save/best.pbuf
+    last_state_path : save/last.pbuf
+    rounds_to_train : 10
+
+collaborator :
+  defaults : plan/defaults/collaborator.yaml
+  template : openfl.component.Collaborator
+  settings :
+    use_delta_updates    : false
+    opt_treatment    : RESET
+
+data_loader :
+  defaults : plan/defaults/data_loader.yaml
+  template : src.dataloader.KerasHippmapp3rsynth
+  settings :
+    batch_size : 1
+
+task_runner :
+  defaults : plan/defaults/task_runner.yaml
+  template : src.taskrunner.KerasHippmapp3r
+
+network :
+  defaults : plan/defaults/network.yaml
+  settings :
+    agg_port : 54678
+
+assigner :
+  defaults : plan/defaults/assigner.yaml
+
+tasks :
+  defaults : plan/defaults/tasks_keras.yaml
+  aggregated_model_validation:
+    function : validate_task
+    kwargs   :
+      batch_size : 1
+      apply      : global
+      metrics    :
+        - dice_coefficient
+
+  locally_tuned_model_validation:
+    function : validate_task
+    kwargs   :
+      batch_size : 1
+      apply      : local
+      metrics    :
+        - dice_coefficient
+
+  train:
+    function : train_task
+    kwargs   :
+      batch_size : 1
+      epochs     : 1
+      metrics    :
+      - loss
+
+compression_pipeline :
+  defaults : plan/defaults/compression_pipeline.yaml

--- a/openfl-workspace/keras/hippmapp3r/requirements.txt
+++ b/openfl-workspace/keras/hippmapp3r/requirements.txt
@@ -1,0 +1,5 @@
+keras==2.15.0
+tensorflow
+keras-contrib @ git+https://www.github.com/keras-team/keras-contrib.git
+gdown
+scikit-learn

--- a/openfl-workspace/keras/hippmapp3r/src/__init__.py
+++ b/openfl-workspace/keras/hippmapp3r/src/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2020-2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""You may copy this file as the starting point of your own model."""

--- a/openfl-workspace/keras/hippmapp3r/src/dataloader.py
+++ b/openfl-workspace/keras/hippmapp3r/src/dataloader.py
@@ -1,0 +1,59 @@
+# Copyright (C) 2020-2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""You may copy this file as the starting point of your own model."""
+
+from openfl.federated import KerasDataLoader
+import numpy as np
+from sklearn.model_selection import train_test_split
+from glob import glob
+
+
+class KerasHippmapp3rsynth(KerasDataLoader):
+    """Data Loader for synthetic Hippmapp3r Dataset."""
+
+    def __init__(self, data_path, batch_size, **kwargs):
+        """
+        Initialize.
+
+        Args:
+            data_path: File path for the dataset
+            batch_size (int): The batch size for the data loader
+            **kwargs: Additional arguments, passed to super init and load_mnist_shard
+        """
+        super().__init__(batch_size, **kwargs)
+
+        X_train = glob(f"{data_path}/X*.npy")
+        y_train = glob(f"{data_path}/y*.npy")
+        # Perform test-train split
+        X_train, X_valid, y_train, y_valid = train_test_split(
+            X_train, y_train, test_size=0.2, random_state=42
+        )
+        self.X_train = np.asarray(X_train)
+        self.X_valid = np.asarray(X_valid)
+        self.y_train = np.asarray(y_train)
+        self.y_valid = np.asarray(y_valid)
+
+    @staticmethod
+    def _batch_generator(X, y, idxs, batch_size, num_batches):
+        """Generates batches of data.
+
+        Args:
+            X (np.array): The input data.
+            y (np.array): The label data.
+            idxs (np.array): The index of the dataset.
+            batch_size (int): The batch size for the data loader.
+            num_batches (int): The number of batches.
+
+        Yields:
+            tuple: The input data and label data for each batch.
+        """
+        for i in range(num_batches):
+            a = i * batch_size
+            b = a + batch_size
+            x_list = []
+            y_list = []
+            for _x, _y in zip(X[idxs[a:b]], y[idxs[a:b]]):
+                x_list.append(np.load(_x))
+                y_list.append(np.load(_y))
+            yield np.stack(x_list), np.stack(y_list)

--- a/openfl-workspace/keras/hippmapp3r/src/setup_data.py
+++ b/openfl-workspace/keras/hippmapp3r/src/setup_data.py
@@ -1,0 +1,47 @@
+# Copyright (C) 2020-2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""You may copy this file as the starting point of your own model."""
+import os
+import numpy as np
+from tqdm import tqdm
+import argparse
+
+
+def create_data(collaborators, dst, total_dataset_size_per_col):
+    num_samples = 1
+    input_shape = (160, 160, 128)
+    X_train = np.random.random((num_samples,) + input_shape)
+    y_train = np.random.random((num_samples,) + input_shape)
+
+    # Save the arrays
+    os.makedirs(dst + "/1", exist_ok=True)
+    np.save(dst + "/1/X_train.npy", X_train)
+    np.save(dst + "/1/y_train.npy", y_train)
+    single_file_size_MB = os.path.getsize(dst + "/1/X_train.npy") / 1024 / 1024
+    single_file_size_MB += os.path.getsize(dst + "/1/y_train.npy") / 1024 / 1024
+    required_file_size_MB = total_dataset_size_per_col * collaborators
+    files_to_make = required_file_size_MB // single_file_size_MB
+    files_per_collaborator = int(files_to_make // collaborators)
+    for col in range(1, collaborators + 1):
+        print("making files for collaborator", col)
+        os.makedirs(dst + f"/{col}", exist_ok=True)
+        for i in tqdm(range(files_per_collaborator)):
+            X_train = np.random.random((num_samples,) + input_shape)
+            y_train = np.random.random((num_samples,) + input_shape)
+            np.save(dst + f"/{col}/X_train_{i}.npy", X_train)
+            np.save(dst + f"/{col}/y_train_{i}.npy", y_train)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--num_collaborators", type=int, help="Number of collaborators")
+    parser.add_argument(
+        "--total_dataset_size_per_col_MB", type=int, help="Total dataset size per collaborator"
+    )
+    args = parser.parse_args()
+
+    num_collaborators = args.num_collaborators
+    total_dataset_size_per_col = args.total_dataset_size_per_col_MB
+
+    dst = "data"
+    create_data(num_collaborators, dst, total_dataset_size_per_col)

--- a/openfl-workspace/keras/hippmapp3r/src/taskrunner.py
+++ b/openfl-workspace/keras/hippmapp3r/src/taskrunner.py
@@ -1,0 +1,106 @@
+# Copyright (C) 2020-2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""You may copy this file as the starting point of your own model."""
+
+from keras.models import model_from_json
+from keras_contrib.layers import InstanceNormalization
+
+from openfl.federated import KerasTaskRunner
+from keras import backend as K
+import requests
+import gdown
+import hashlib
+
+MODEL_JSON_HASH = "c35cfa990000ad87825f182460395ec5d1437a707bd33de4df55d45664e94214"
+MODEL_WEIGHTS_HASH = "cd5e52d42e2c6d737e370fb0e673aec5d257134e127c0e59478f11676fa327a5"
+
+
+def dice_coefficient(y_true, y_pred, smooth=1.0):
+    y_true_f = K.flatten(y_true)
+    y_pred_f = K.flatten(y_pred)
+    intersection = K.sum(y_true_f * y_pred_f)
+    return (2.0 * intersection + smooth) / (K.sum(y_true_f) + K.sum(y_pred_f) + smooth)
+
+
+def dice_coefficient_loss(y_true, y_pred):
+    return -dice_coefficient(y_true, y_pred)
+
+
+def compute_file_hash(file_path):
+    with open(file_path, "rb") as file:
+        data = file.read()
+        file_hash = hashlib.sha256(data).hexdigest()
+    return file_hash
+
+
+def download_file_from_google_drive(file_id, destination):
+    # Google Drive URL to access file content
+    url = f"https://drive.google.com/uc?export=download&id={file_id}"
+
+    # Send a GET request to the URL
+    response = requests.get(url, stream=True)
+
+    if response.status_code == 200:
+        with open(destination, "wb") as file:
+            for chunk in response.iter_content(1024):
+                if chunk:
+                    file.write(chunk)
+        print(f"File downloaded successfully to {destination}")
+    else:
+        print(f"Failed to download file. Status code: {response.status_code}")
+        response.raise_for_status()
+
+
+class KerasHippmapp3r(KerasTaskRunner):
+    """A basic convolutional neural network model."""
+
+    def __init__(self, **kwargs):
+        """
+        Initialize.
+
+        Args:
+            **kwargs: Additional parameters to pass to the function
+        """
+        super().__init__(**kwargs)
+
+        weights_id = "1_VEOScLGyr1qV-t-zggq8Lxwgf_z-IpQ"
+        gdown.download(id=weights_id, output="model.h5")
+        json_id = "1RUE3Cw_rpKnKfwlu75kLbkcr9hde9nV4"
+        gdown.download(id=json_id, output="model.json")
+
+        model_json_hash = compute_file_hash("model.json")
+        if model_json_hash != MODEL_JSON_HASH:
+            raise ValueError("Model JSON file hash does not match expected value.")
+
+        model_weights_hash = compute_file_hash("model.h5")
+        if model_weights_hash != MODEL_WEIGHTS_HASH:
+            raise ValueError("Model weights file hash does not match expected value.")
+
+        self.model = self.build_model(model_json="model.json", model_weights="model.h5", **kwargs)
+
+        self.initialize_tensorkeys_for_functions()
+
+    def build_model(self, model_json, model_weights, **kwargs):
+        """
+        Define the model architecture.
+
+        Args:
+            model_json (str): Path to model json config
+            model_weights (str): Path to model weights
+
+        Returns:
+            keras.models.Sequential: The model defined in Keras
+
+        """
+        custom_objects = {}
+        custom_objects["InstanceNormalization"] = InstanceNormalization
+        json_file = open(model_json, "r")
+        loaded_model_json = json_file.read()
+        json_file.close()
+        model = model_from_json(loaded_model_json, custom_objects=custom_objects)
+        model.load_weights(model_weights)
+
+        model.compile(loss=dice_coefficient_loss, optimizer="adam", metrics=[dice_coefficient])
+
+        return model

--- a/openfl-workspace/keras/hippmapp3r/src/taskrunner.py
+++ b/openfl-workspace/keras/hippmapp3r/src/taskrunner.py
@@ -8,7 +8,6 @@ from keras_contrib.layers import InstanceNormalization
 
 from openfl.federated import KerasTaskRunner
 from keras import backend as K
-import requests
 import gdown
 import hashlib
 
@@ -32,24 +31,6 @@ def compute_file_hash(file_path):
         data = file.read()
         file_hash = hashlib.sha256(data).hexdigest()
     return file_hash
-
-
-def download_file_from_google_drive(file_id, destination):
-    # Google Drive URL to access file content
-    url = f"https://drive.google.com/uc?export=download&id={file_id}"
-
-    # Send a GET request to the URL
-    response = requests.get(url, stream=True)
-
-    if response.status_code == 200:
-        with open(destination, "wb") as file:
-            for chunk in response.iter_content(1024):
-                if chunk:
-                    file.write(chunk)
-        print(f"File downloaded successfully to {destination}")
-    else:
-        print(f"Failed to download file. Status code: {response.status_code}")
-        response.raise_for_status()
 
 
 class KerasHippmapp3r(KerasTaskRunner):


### PR DESCRIPTION
### Integration of Hippmapp3r Model Training into openfl-security

#### Overview
This PR integrates the Hippmapp3r medical segmentation model into the openfl framework. It enables users to call the `keras/hippmapp3r` model using the command `fx workspace create --template keras/hippmapp3r`. The primary focus of this PR is to test the functionality of the Hippmapp3r model, training it on random synthetic data.

#### Key Features
1. **Model Integration**: 
   - The Hippmapp3r model is now part of the openfl-security framework.
   - Users can initiate the model training with the specified template.

2. **Synthetic Data Generation**:
   - Synthetic data is generated using `setup_data.py`.
   - The amount of synthetic data can be adjusted by modifying the `required_file_size_MB` parameter in the `setup_data.py` file.

3. **Model Configuration and Weights**:
   - The task runner downloads the model configuration and weights from Google Drive.
   - It verifies the hash to ensure data integrity before loading the model.

#### Testing
- The primary objective of this PR is to validate the functionality of the Hippmapp3r model.
- The model will be trained on randomly generated synthetic data to ensure proper integration and performance.

#### Usage
To use the Hippmapp3r model with openfl-security, run the following command:
```command line
fx workspace create --template keras/hippmapp3r
```

#### Notes
- Ensure that the `required_file_size_MB` parameter in `setup_data.py` is set according to your data requirements.
- The model configuration and weights are securely downloaded and verified for integrity.<!-- ##StartCodeSummary## -->
