### PR TITLE
Collaborator CLI command for pinging the aggregator

### DIFF
--- a/docs/about/features_index/taskrunner.rst
+++ b/docs/about/features_index/taskrunner.rst
@@ -448,18 +448,19 @@ STEP 3: Start the Federation
 
 1. Open a new terminal, change the directory to the workspace, and activate the virtual environment.
 
-2. Run the Collaborator.
+2. Test the connectivity with the Aggregator.
 
     .. code-block:: shell
 
-       $ fx collaborator start -n {COLLABORATOR_LABEL}
+       $ fx collaborator ping -n {COLLABORATOR_LABEL}
 
     where :code:`COLLABORATOR_LABEL` is the label for this Collaborator.
 
     .. note::
 
        Each workspace may have multiple FL plans and multiple collaborator lists associated with it.
-       Therefore, :code:`fx collaborator start` has the following optional parameters.
+       Therefore, the :code:`fx collaborator start` and :code:`fx collaborator ping` commands have
+       the following optional parameters:
 
            +-------------------------+---------------------------------------------------------+
            | Optional Parameters     | Description                                             |
@@ -469,7 +470,15 @@ STEP 3: Start the Federation
            | -d, --data_config PATH  | The data set/shard configuration file                   |
            +-------------------------+---------------------------------------------------------+
 
-3. Repeat the earlier steps for each collaborator node in the federation.
+3. Run the Collaborator.
+
+    .. code-block:: shell
+
+       $ fx collaborator start -n {COLLABORATOR_LABEL}
+
+    where :code:`COLLABORATOR_LABEL` is the label for this Collaborator.
+
+4. Repeat the earlier steps for each collaborator node in the federation.
 
   When all of the Collaborators connect, the Aggregator starts training. You will see log messages describing the progress of the federated training.
 

--- a/docs/developer_guide/running_the_federation_with_gandlf.rst
+++ b/docs/developer_guide/running_the_federation_with_gandlf.rst
@@ -438,18 +438,19 @@ STEP 3: Start the Federation
 
 1. Open a new terminal, change the directory to the workspace, and activate the virtual environment.
 
-2. Run the Collaborator.
+2. Test the connectivity with the Aggregator.
 
     .. code-block:: shell
 
-       $ fx collaborator start -n {COLLABORATOR_LABEL}
+       $ fx collaborator ping -n {COLLABORATOR_LABEL}
 
     where :code:`COLLABORATOR_LABEL` is the label for this Collaborator.
 
     .. note::
 
        Each workspace may have multiple FL plans and multiple collaborator lists associated with it.
-       Therefore, :code:`fx collaborator start` has the following optional parameters.
+       Therefore, the :code:`fx collaborator start` and :code:`fx collaborator ping` commands have
+       the following optional parameters:
 
            +-------------------------+---------------------------------------------------------+
            | Optional Parameters     | Description                                             |
@@ -459,7 +460,15 @@ STEP 3: Start the Federation
            | -d, --data_config PATH  | The data set/shard configuration file                   |
            +-------------------------+---------------------------------------------------------+
 
-3. Repeat the earlier steps for each collaborator node in the federation.
+3. Run the Collaborator.
+
+    .. code-block:: shell
+
+       $ fx collaborator start -n {COLLABORATOR_LABEL}
+
+    where :code:`COLLABORATOR_LABEL` is the label for this Collaborator.
+
+4. Repeat the earlier steps for each collaborator node in the federation.
 
   When all of the Collaborators connect, the Aggregator starts training. You will see log messages describing the progress of the federated training.
 

--- a/openfl/component/collaborator/collaborator.py
+++ b/openfl/component/collaborator/collaborator.py
@@ -153,6 +153,10 @@ class Collaborator:
             client=self.client,
         )
 
+    def ping(self):
+        """Ping the Aggregator."""
+        self.client.ping()
+
     def run(self):
         """Run the collaborator."""
         # Experiment begin

--- a/openfl/interface/collaborator.py
+++ b/openfl/interface/collaborator.py
@@ -61,7 +61,14 @@ def collaborator(context):
     required=True,
     help="The certified common name of the collaborator.",
 )
-def start_(plan, collaborator_name, data_config):
+@option(
+    "--ping",
+    is_flag=True,
+    required=False,
+    default=False,
+    help="Flag for attempting to ping the aggregator, without starting any tasks.",
+)
+def start_(plan, collaborator_name, data_config, ping):
     """Starts a collaborator service."""
 
     if plan and is_directory_traversal(plan):
@@ -80,8 +87,12 @@ def start_(plan, collaborator_name, data_config):
 
     echo(f"Data = {plan.cols_data_paths}")
     logger.info("🧿 Starting a Collaborator Service.")
+    col = plan.get_collaborator(collaborator_name)
 
-    plan.get_collaborator(collaborator_name).run()
+    if ping:
+        col.ping()
+    else:
+        col.run()
 
 
 @collaborator.command(name="create")

--- a/openfl/interface/collaborator.py
+++ b/openfl/interface/collaborator.py
@@ -119,13 +119,23 @@ def ping_(plan, collaborator_name, data_config):
         echo("The data set/shard configuration file path is out of the openfl workspace scope.")
         sys.exit(1)
 
-    plan = Plan.parse(
+    fl_plan = Plan.parse(
         plan_config_path=Path(plan).absolute(),
         data_config_path=Path(data_config).absolute(),
     )
 
-    col = plan.get_collaborator(collaborator_name)
-    col.ping()
+    agg_addr = fl_plan.config["network"]["settings"]["agg_addr"]
+    agg_port = fl_plan.config["network"]["settings"]["agg_port"]
+    use_tls = fl_plan.config["network"]["settings"]["use_tls"]
+    protocol = "TLS" if use_tls else "TCP"
+
+    logger.info(
+        f"🧿 Testing connectivity with the Aggregator at {agg_addr}:{agg_port} via {protocol}..."
+    )
+    fl_plan.get_collaborator(collaborator_name).ping()
+
+    logger.info(f"The Aggregator is reachable at {agg_addr}:{agg_port}")
+    logger.info(f"{protocol} connection established.")
 
 
 @collaborator.command(name="create")

--- a/openfl/interface/collaborator.py
+++ b/openfl/interface/collaborator.py
@@ -61,14 +61,7 @@ def collaborator(context):
     required=True,
     help="The certified common name of the collaborator.",
 )
-@option(
-    "--ping",
-    is_flag=True,
-    required=False,
-    default=False,
-    help="Flag for attempting to ping the aggregator, without starting any tasks.",
-)
-def start_(plan, collaborator_name, data_config, ping):
+def start_(plan, collaborator_name, data_config):
     """Starts a collaborator service."""
 
     if plan and is_directory_traversal(plan):
@@ -87,12 +80,52 @@ def start_(plan, collaborator_name, data_config, ping):
 
     echo(f"Data = {plan.cols_data_paths}")
     logger.info("🧿 Starting a Collaborator Service.")
-    col = plan.get_collaborator(collaborator_name)
 
-    if ping:
-        col.ping()
-    else:
-        col.run()
+    plan.get_collaborator(collaborator_name).run()
+
+
+@collaborator.command(name="ping")
+@option(
+    "-p",
+    "--plan",
+    required=False,
+    help="Path to an FL plan.",
+    default="plan/plan.yaml",
+    type=ClickPath(exists=True),
+    show_default=True,
+)
+@option(
+    "-d",
+    "--data_config",
+    required=False,
+    help="The dataset shard configuration file.",
+    default="plan/data.yaml",
+    type=ClickPath(exists=True),
+    show_default=True,
+)
+@option(
+    "-n",
+    "--collaborator_name",
+    required=True,
+    help="The certified common name of the collaborator.",
+)
+def ping_(plan, collaborator_name, data_config):
+    """Ping the aggregator without starting any tasks."""
+
+    if plan and is_directory_traversal(plan):
+        echo("Federated learning plan path is out of the openfl workspace scope.")
+        sys.exit(1)
+    if data_config and is_directory_traversal(data_config):
+        echo("The data set/shard configuration file path is out of the openfl workspace scope.")
+        sys.exit(1)
+
+    plan = Plan.parse(
+        plan_config_path=Path(plan).absolute(),
+        data_config_path=Path(data_config).absolute(),
+    )
+
+    col = plan.get_collaborator(collaborator_name)
+    col.ping()
 
 
 @collaborator.command(name="create")

--- a/openfl/protocols/aggregator.proto
+++ b/openfl/protocols/aggregator.proto
@@ -9,6 +9,7 @@ import "openfl/protocols/base.proto";
 
 
 service Aggregator {
+  rpc Ping(PingRequest) returns (PingResponse) {}
   rpc GetTasks(GetTasksRequest) returns (GetTasksResponse) {}
   rpc GetAggregatedTensor(GetAggregatedTensorRequest) returns (GetAggregatedTensorResponse) {}
   rpc SendLocalTaskResults(stream DataStream) returns (SendLocalTaskResultsResponse) {}
@@ -20,6 +21,14 @@ message MessageHeader {
   string receiver = 2;
   string federation_uuid = 3;
   string single_col_cert_common_name = 4;
+}
+
+message PingRequest {
+  MessageHeader header = 1;
+}
+
+message PingResponse {
+  MessageHeader header = 1;
 }
 
 message GetTasksRequest {

--- a/openfl/transport/grpc/aggregator_client.py
+++ b/openfl/transport/grpc/aggregator_client.py
@@ -291,6 +291,29 @@ class AggregatorGRPCClient:
 
     @_resend_data_on_reconnection
     @_atomic_connection
+    def ping(self):
+        """Ping the aggregator to check connectivity.
+
+        Returns:
+            bool: True if the aggregator is reachable, False otherwise.
+        """
+        logger.info("Aggregator ping...")
+        header = create_header(
+            sender=self.collaborator_name,
+            receiver=self.aggregator_uuid,
+            federation_uuid=self.federation_uuid,
+            single_col_cert_common_name=self.single_col_cert_common_name,
+        )
+        request = aggregator_pb2.PingRequest(header=header)
+        response = self.stub.Ping(request)
+        if response:
+            self.validate_response(response)
+            logger.info("Aggregator pong!")
+        else:
+            logger.warning("Aggregator ping failed...")
+
+    @_resend_data_on_reconnection
+    @_atomic_connection
     def get_tasks(self):
         """Get tasks from the aggregator.
 

--- a/openfl/transport/grpc/aggregator_client.py
+++ b/openfl/transport/grpc/aggregator_client.py
@@ -292,11 +292,7 @@ class AggregatorGRPCClient:
     @_resend_data_on_reconnection
     @_atomic_connection
     def ping(self):
-        """Ping the aggregator to check connectivity.
-
-        Returns:
-            bool: True if the aggregator is reachable, False otherwise.
-        """
+        """Ping the aggregator to check connectivity."""
         logger.info("Aggregator ping...")
         header = create_header(
             sender=self.collaborator_name,

--- a/openfl/transport/grpc/aggregator_server.py
+++ b/openfl/transport/grpc/aggregator_server.py
@@ -138,6 +138,30 @@ class AggregatorGRPCServer(aggregator_pb2_grpc.AggregatorServicer):
             f"Expected: {self.aggregator.single_col_cert_common_name}, Actual: {request.header.single_col_cert_common_name}"  # noqa: E501
         )
 
+    def Ping(self, request, context):  # NOQA:N802
+        """Ping the Aggregator server.
+
+        This method handles a ping request from a collaborator.
+
+        Args:
+            request (aggregator_pb2.PingRequest): The ping request from the
+                collaborator.
+            context (grpc.ServicerContext): The context of the request.
+
+        Returns:
+            aggregator_pb2.PingResponse: The response to the ping request.
+        """
+        self.validate_collaborator(request, context)
+        self.check_request(request)
+        header = create_header(
+            sender=self.aggregator.uuid,
+            receiver=request.header.sender,
+            federation_uuid=self.aggregator.federation_uuid,
+            single_col_cert_common_name=self.aggregator.single_col_cert_common_name,
+        )
+
+        return aggregator_pb2.PingResponse(header=header)
+
     def GetTasks(self, request, context):  # NOQA:N802
         """Request a job from aggregator.
 

--- a/openfl/transport/grpc/aggregator_server.py
+++ b/openfl/transport/grpc/aggregator_server.py
@@ -139,7 +139,7 @@ class AggregatorGRPCServer(aggregator_pb2_grpc.AggregatorServicer):
         )
 
     def Ping(self, request, context):  # NOQA:N802
-        """Ping the Aggregator server.
+        """Ping endpoint of the Aggregator server.
 
         This method handles a ping request from a collaborator.
 


### PR DESCRIPTION
## Summary

Introducing a `fx collaborator ping` command for testing the connectivity with the aggregator, based on the FL plan settings.

More context around why this is needed can be found [in this discussion](https://github.com/securefederatedai/openfl/discussions/1505)

## Type of Change (Mandatory)
Specify the type of change being made. 
- Feature enhancement  

## Description (Mandatory)
This PR enhances the existing `fx collaborator start` command with the optional `--ping` flag, enabling a connectivity "unit test" without starting an actual FL experiment.

## Testing
Deployed a local federation (with TLS enabled), and tested collaborator ping with and without an active aggregator.