### PR TITLE
Change to add time taken for each round in metrics

### DIFF
--- a/openfl/callbacks/metric_writer.py
+++ b/openfl/callbacks/metric_writer.py
@@ -51,16 +51,19 @@ class MetricWriter(Callback):
             logs: A key-value pair of scalar metrics.
         """
         logs = logs or {}
-        logs["round_number"] = round_num
-        # time taken for the round to complete in seconds
-        logs["time_taken"] = time.monotonic() - self._round_start_time
-        logger.info(f"Round {round_num}: Metrics: {logs}")
+        elapsed_seconds = time.monotonic() - self._round_start_time
+        metrics = {
+            "round_number": round_num,
+            "elapsed_seconds": elapsed_seconds,
+            **logs,
+        }
+        logger.info(f"Round {round_num}: Metrics: {metrics}")
 
-        self._log_file_handle.write(json.dumps(logs) + "\n")
+        self._log_file_handle.write(json.dumps(metrics) + "\n")
         self._log_file_handle.flush()
 
         if self._summary_writer:
-            for key, value in logs.items():
+            for key, value in metrics.items():
                 self._summary_writer.add_scalar(key, value, round_num)
             self._summary_writer.flush()
 

--- a/openfl/callbacks/metric_writer.py
+++ b/openfl/callbacks/metric_writer.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import time
 
 from tensorboardX import SummaryWriter
 
@@ -26,6 +27,7 @@ class MetricWriter(Callback):
 
         self._log_file_handle = None
         self._summary_writer = None
+        self._round_start_time = None
 
     def on_experiment_begin(self, logs=None):
         """Open file handles for logging."""
@@ -49,6 +51,9 @@ class MetricWriter(Callback):
             logs: A key-value pair of scalar metrics.
         """
         logs = logs or {}
+        logs["round_number"] = round_num
+        # time taken for the round to complete in seconds
+        logs["time_taken"] = time.monotonic() - self._round_start_time
         logger.info(f"Round {round_num}: Metrics: {logs}")
 
         self._log_file_handle.write(json.dumps(logs) + "\n")
@@ -67,3 +72,6 @@ class MetricWriter(Callback):
 
         if self._summary_writer:
             self._summary_writer.close()
+            
+    def on_round_begin(self, round_num: int, logs=None):
+        self._round_start_time = time.monotonic()


### PR DESCRIPTION
## Summary
Adding time taken by each round in metrics log

## Type of Change (Mandatory)
Specify the type of change being made. 
- Feature enhancement  

## Description (Mandatory)
This change is to document time taken by each round in second. This information will only be gather if we keep write_metrics True in plan.yaml. 
It can help to analyse if number of rounds changing the duration for each round. Also in aggregator side it can help to understand how increase in collaborators is impacting each round duration 

## Testing
Simple PR pass.
 