### PR TITLE
Changes in PQ Pipeline & Publish Package workflows for PYPI_API_TOKEN 

### DIFF
--- a/.github/workflows/pq_pipeline.yml
+++ b/.github/workflows/pq_pipeline.yml
@@ -178,8 +178,11 @@ jobs:
   # publish nightly package to PyPI (only run on schedule)
   publish_package:
     if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai')
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
     name: Publish Nightly Package to PyPI
+    permissions:
+      id-token: write
     needs: [
       wf_mnist_local_runtime,
       wf_watermark_e2e,

--- a/.github/workflows/pq_pipeline.yml
+++ b/.github/workflows/pq_pipeline.yml
@@ -175,20 +175,6 @@ jobs:
     with:
       commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  print_env:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: Print Environment Name
-    runs-on: ubuntu-22.04
-    steps:
-    - name: Checkout OpenFL repository
-      uses: actions/checkout@v4
-    - name: Print environment name
-      run: |
-        echo "Environment: ${{ github.environment }}"
-        echo "Pypi token: ${{ secrets.PYPI_API_TOKEN }}"
-
   # publish nightly package to PyPI (only run on schedule)
   publish_package:
     if: |
@@ -215,5 +201,5 @@ jobs:
     uses: ./.github/workflows/publish_nightly_package.yml
     with:
       commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
-    secrets:
-      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+      environment: dev
+    secrets: inherit

--- a/.github/workflows/pq_pipeline.yml
+++ b/.github/workflows/pq_pipeline.yml
@@ -186,7 +186,7 @@ jobs:
       uses: actions/checkout@v4
     - name: Print environment name
       run: |
-        echo "Environment: ${{ github.workflow }}"
+        echo "Environment: ${{ github.environment }}"
 
   # publish nightly package to PyPI (only run on schedule)
   publish_package:

--- a/.github/workflows/pq_pipeline.yml
+++ b/.github/workflows/pq_pipeline.yml
@@ -147,19 +147,19 @@ jobs:
   #   with:
   #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  run_trivy:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: Run Trivy Code Scanner
-    needs: set_commit_id_for_all_jobs
-    permissions:
-      contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-    uses: ./.github/workflows/trivy.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # run_trivy:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: Run Trivy Code Scanner
+  #   needs: set_commit_id_for_all_jobs
+  #   permissions:
+  #     contents: read # for actions/checkout to fetch code
+  #     security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+  #     actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+  #   uses: ./.github/workflows/trivy.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
   run_bandit:
     if: |
@@ -174,6 +174,19 @@ jobs:
     uses: ./.github/workflows/bandit.yml
     with:
       commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+
+  print_env:
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
+    name: Print Environment Name
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout OpenFL repository
+      uses: actions/checkout@v4
+    - name: Print environment name
+      run: |
+        echo "Environment: ${{ github.workflow }}"
 
   # publish nightly package to PyPI (only run on schedule)
   publish_package:
@@ -195,7 +208,7 @@ jobs:
       # task_runner_dockerized_e2e,
       # task_runner_secret_ssl_e2e,
       # task_runner_flower_app_pytorch,
-      run_trivy,
+      # run_trivy,
       run_bandit
     ]
     uses: ./.github/workflows/publish_nightly_package.yml

--- a/.github/workflows/pq_pipeline.yml
+++ b/.github/workflows/pq_pipeline.yml
@@ -34,118 +34,118 @@ jobs:
       run: |
         echo "Commit ID used: ${{ steps.set_commit_id.outputs.commit_id }}" >> $GITHUB_STEP_SUMMARY
 
-  wf_mnist_local_runtime:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: Workflow MNIST Local Runtime
-    needs: set_commit_id_for_all_jobs
-    uses: ./.github/workflows/workflow_interface_101_mnist.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # wf_mnist_local_runtime:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: Workflow MNIST Local Runtime
+  #   needs: set_commit_id_for_all_jobs
+  #   uses: ./.github/workflows/workflow_interface_101_mnist.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  wf_watermark_e2e:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: Workflow Watermarking Federated Runtime E2E
-    needs: wf_mnist_local_runtime
-    uses: ./.github/workflows/wf_watermarking_fed_runtime.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # wf_watermark_e2e:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: Workflow Watermarking Federated Runtime E2E
+  #   needs: wf_mnist_local_runtime
+  #   uses: ./.github/workflows/wf_watermarking_fed_runtime.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  wf_secagg_e2e:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: Workflow Secure Aggregation Federated Runtime E2E
-    needs: wf_watermark_e2e
-    uses: ./.github/workflows/wf_secagg_fed_runtime.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # wf_secagg_e2e:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: Workflow Secure Aggregation Federated Runtime E2E
+  #   needs: wf_watermark_e2e
+  #   uses: ./.github/workflows/wf_secagg_fed_runtime.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  task_runner_e2e:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: TaskRunner E2E
-    needs: set_commit_id_for_all_jobs
-    uses: ./.github/workflows/task_runner_basic_e2e.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # task_runner_e2e:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: TaskRunner E2E
+  #   needs: set_commit_id_for_all_jobs
+  #   uses: ./.github/workflows/task_runner_basic_e2e.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  task_runner_resiliency_e2e:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: TaskRunner Resiliency E2E
-    needs: task_runner_e2e
-    uses: ./.github/workflows/task_runner_resiliency_e2e.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # task_runner_resiliency_e2e:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: TaskRunner Resiliency E2E
+  #   needs: task_runner_e2e
+  #   uses: ./.github/workflows/task_runner_resiliency_e2e.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  task_runner_fedeval_e2e:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: TaskRunner FedEval E2E
-    needs: task_runner_e2e
-    uses: ./.github/workflows/task_runner_fedeval_e2e.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # task_runner_fedeval_e2e:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: TaskRunner FedEval E2E
+  #   needs: task_runner_e2e
+  #   uses: ./.github/workflows/task_runner_fedeval_e2e.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  task_runner_secure_agg_e2e:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: TaskRunner Secure Aggregation E2E
-    needs: set_commit_id_for_all_jobs
-    uses: ./.github/workflows/task_runner_secure_agg_e2e.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # task_runner_secure_agg_e2e:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: TaskRunner Secure Aggregation E2E
+  #   needs: set_commit_id_for_all_jobs
+  #   uses: ./.github/workflows/task_runner_secure_agg_e2e.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  task_runner_straggler_e2e:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: TaskRunner Straggler E2E
-    needs: task_runner_resiliency_e2e
-    uses: ./.github/workflows/task_runner_straggler_e2e.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # task_runner_straggler_e2e:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: TaskRunner Straggler E2E
+  #   needs: task_runner_resiliency_e2e
+  #   uses: ./.github/workflows/task_runner_straggler_e2e.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  # run basic dockerized test with keras/mnist
-  task_runner_dockerized_e2e:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: TaskRunner Dockerized E2E
-    needs: task_runner_straggler_e2e
-    uses: ./.github/workflows/task_runner_dockerized_ws_e2e.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # # run basic dockerized test with keras/mnist
+  # task_runner_dockerized_e2e:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: TaskRunner Dockerized E2E
+  #   needs: task_runner_straggler_e2e
+  #   uses: ./.github/workflows/task_runner_dockerized_ws_e2e.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  # run testssl for task runner
-  task_runner_secret_ssl_e2e:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: TaskRunner Secret SSL E2E
-    needs: set_commit_id_for_all_jobs
-    uses: ./.github/workflows/task_runner_secret_tls_e2e.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # # run testssl for task runner
+  # task_runner_secret_ssl_e2e:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: TaskRunner Secret SSL E2E
+  #   needs: set_commit_id_for_all_jobs
+  #   uses: ./.github/workflows/task_runner_secret_tls_e2e.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  # run flower app with pytorch
-  task_runner_flower_app_pytorch:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: TaskRunner Flower App Pytorch E2E
-    needs: set_commit_id_for_all_jobs
-    uses: ./.github/workflows/task_runner_flower_e2e.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # # run flower app with pytorch
+  # task_runner_flower_app_pytorch:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: TaskRunner Flower App Pytorch E2E
+  #   needs: set_commit_id_for_all_jobs
+  #   uses: ./.github/workflows/task_runner_flower_e2e.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
   run_trivy:
     if: |
@@ -184,17 +184,17 @@ jobs:
     permissions:
       id-token: write
     needs: [
-      wf_mnist_local_runtime,
-      wf_watermark_e2e,
-      wf_secagg_e2e,
-      task_runner_e2e,
-      task_runner_resiliency_e2e,
-      task_runner_fedeval_e2e,
-      task_runner_secure_agg_e2e,
-      task_runner_straggler_e2e,
-      task_runner_dockerized_e2e,
-      task_runner_secret_ssl_e2e,
-      task_runner_flower_app_pytorch,
+      # wf_mnist_local_runtime,
+      # wf_watermark_e2e,
+      # wf_secagg_e2e,
+      # task_runner_e2e,
+      # task_runner_resiliency_e2e,
+      # task_runner_fedeval_e2e,
+      # task_runner_secure_agg_e2e,
+      # task_runner_straggler_e2e,
+      # task_runner_dockerized_e2e,
+      # task_runner_secret_ssl_e2e,
+      # task_runner_flower_app_pytorch,
       run_trivy,
       run_bandit
     ]

--- a/.github/workflows/pq_pipeline.yml
+++ b/.github/workflows/pq_pipeline.yml
@@ -34,132 +34,132 @@ jobs:
       run: |
         echo "Commit ID used: ${{ steps.set_commit_id.outputs.commit_id }}" >> $GITHUB_STEP_SUMMARY
 
-  # wf_mnist_local_runtime:
-  #   if: |
-  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-  #     (github.event_name == 'workflow_dispatch')
-  #   name: Workflow MNIST Local Runtime
-  #   needs: set_commit_id_for_all_jobs
-  #   uses: ./.github/workflows/workflow_interface_101_mnist.yml
-  #   with:
-  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  wf_mnist_local_runtime:
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
+    name: Workflow MNIST Local Runtime
+    needs: set_commit_id_for_all_jobs
+    uses: ./.github/workflows/workflow_interface_101_mnist.yml
+    with:
+      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  # wf_watermark_e2e:
-  #   if: |
-  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-  #     (github.event_name == 'workflow_dispatch')
-  #   name: Workflow Watermarking Federated Runtime E2E
-  #   needs: wf_mnist_local_runtime
-  #   uses: ./.github/workflows/wf_watermarking_fed_runtime.yml
-  #   with:
-  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  wf_watermark_e2e:
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
+    name: Workflow Watermarking Federated Runtime E2E
+    needs: wf_mnist_local_runtime
+    uses: ./.github/workflows/wf_watermarking_fed_runtime.yml
+    with:
+      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  # wf_secagg_e2e:
-  #   if: |
-  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-  #     (github.event_name == 'workflow_dispatch')
-  #   name: Workflow Secure Aggregation Federated Runtime E2E
-  #   needs: wf_watermark_e2e
-  #   uses: ./.github/workflows/wf_secagg_fed_runtime.yml
-  #   with:
-  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  wf_secagg_e2e:
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
+    name: Workflow Secure Aggregation Federated Runtime E2E
+    needs: wf_watermark_e2e
+    uses: ./.github/workflows/wf_secagg_fed_runtime.yml
+    with:
+      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  # task_runner_e2e:
-  #   if: |
-  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-  #     (github.event_name == 'workflow_dispatch')
-  #   name: TaskRunner E2E
-  #   needs: set_commit_id_for_all_jobs
-  #   uses: ./.github/workflows/task_runner_basic_e2e.yml
-  #   with:
-  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  task_runner_e2e:
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
+    name: TaskRunner E2E
+    needs: set_commit_id_for_all_jobs
+    uses: ./.github/workflows/task_runner_basic_e2e.yml
+    with:
+      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  # task_runner_resiliency_e2e:
-  #   if: |
-  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-  #     (github.event_name == 'workflow_dispatch')
-  #   name: TaskRunner Resiliency E2E
-  #   needs: task_runner_e2e
-  #   uses: ./.github/workflows/task_runner_resiliency_e2e.yml
-  #   with:
-  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  task_runner_resiliency_e2e:
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
+    name: TaskRunner Resiliency E2E
+    needs: task_runner_e2e
+    uses: ./.github/workflows/task_runner_resiliency_e2e.yml
+    with:
+      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  # task_runner_fedeval_e2e:
-  #   if: |
-  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-  #     (github.event_name == 'workflow_dispatch')
-  #   name: TaskRunner FedEval E2E
-  #   needs: task_runner_e2e
-  #   uses: ./.github/workflows/task_runner_fedeval_e2e.yml
-  #   with:
-  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  task_runner_fedeval_e2e:
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
+    name: TaskRunner FedEval E2E
+    needs: task_runner_e2e
+    uses: ./.github/workflows/task_runner_fedeval_e2e.yml
+    with:
+      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  # task_runner_secure_agg_e2e:
-  #   if: |
-  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-  #     (github.event_name == 'workflow_dispatch')
-  #   name: TaskRunner Secure Aggregation E2E
-  #   needs: set_commit_id_for_all_jobs
-  #   uses: ./.github/workflows/task_runner_secure_agg_e2e.yml
-  #   with:
-  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  task_runner_secure_agg_e2e:
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
+    name: TaskRunner Secure Aggregation E2E
+    needs: set_commit_id_for_all_jobs
+    uses: ./.github/workflows/task_runner_secure_agg_e2e.yml
+    with:
+      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  # task_runner_straggler_e2e:
-  #   if: |
-  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-  #     (github.event_name == 'workflow_dispatch')
-  #   name: TaskRunner Straggler E2E
-  #   needs: task_runner_resiliency_e2e
-  #   uses: ./.github/workflows/task_runner_straggler_e2e.yml
-  #   with:
-  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  task_runner_straggler_e2e:
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
+    name: TaskRunner Straggler E2E
+    needs: task_runner_resiliency_e2e
+    uses: ./.github/workflows/task_runner_straggler_e2e.yml
+    with:
+      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  # # run basic dockerized test with keras/mnist
-  # task_runner_dockerized_e2e:
-  #   if: |
-  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-  #     (github.event_name == 'workflow_dispatch')
-  #   name: TaskRunner Dockerized E2E
-  #   needs: task_runner_straggler_e2e
-  #   uses: ./.github/workflows/task_runner_dockerized_ws_e2e.yml
-  #   with:
-  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # run basic dockerized test with keras/mnist
+  task_runner_dockerized_e2e:
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
+    name: TaskRunner Dockerized E2E
+    needs: task_runner_straggler_e2e
+    uses: ./.github/workflows/task_runner_dockerized_ws_e2e.yml
+    with:
+      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  # # run testssl for task runner
-  # task_runner_secret_ssl_e2e:
-  #   if: |
-  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-  #     (github.event_name == 'workflow_dispatch')
-  #   name: TaskRunner Secret SSL E2E
-  #   needs: set_commit_id_for_all_jobs
-  #   uses: ./.github/workflows/task_runner_secret_tls_e2e.yml
-  #   with:
-  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # run testssl for task runner
+  task_runner_secret_ssl_e2e:
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
+    name: TaskRunner Secret SSL E2E
+    needs: set_commit_id_for_all_jobs
+    uses: ./.github/workflows/task_runner_secret_tls_e2e.yml
+    with:
+      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  # # run flower app with pytorch
-  # task_runner_flower_app_pytorch:
-  #   if: |
-  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-  #     (github.event_name == 'workflow_dispatch')
-  #   name: TaskRunner Flower App Pytorch E2E
-  #   needs: set_commit_id_for_all_jobs
-  #   uses: ./.github/workflows/task_runner_flower_e2e.yml
-  #   with:
-  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # run flower app with pytorch
+  task_runner_flower_app_pytorch:
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
+    name: TaskRunner Flower App Pytorch E2E
+    needs: set_commit_id_for_all_jobs
+    uses: ./.github/workflows/task_runner_flower_e2e.yml
+    with:
+      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  # run_trivy:
-  #   if: |
-  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-  #     (github.event_name == 'workflow_dispatch')
-  #   name: Run Trivy Code Scanner
-  #   needs: set_commit_id_for_all_jobs
-  #   permissions:
-  #     contents: read # for actions/checkout to fetch code
-  #     security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-  #     actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-  #   uses: ./.github/workflows/trivy.yml
-  #   with:
-  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  run_trivy:
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
+    name: Run Trivy Code Scanner
+    needs: set_commit_id_for_all_jobs
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    uses: ./.github/workflows/trivy.yml
+    with:
+      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
   run_bandit:
     if: |
@@ -184,18 +184,18 @@ jobs:
     permissions:
       id-token: write
     needs: [
-      # wf_mnist_local_runtime,
-      # wf_watermark_e2e,
-      # wf_secagg_e2e,
-      # task_runner_e2e,
-      # task_runner_resiliency_e2e,
-      # task_runner_fedeval_e2e,
-      # task_runner_secure_agg_e2e,
-      # task_runner_straggler_e2e,
-      # task_runner_dockerized_e2e,
-      # task_runner_secret_ssl_e2e,
-      # task_runner_flower_app_pytorch,
-      # run_trivy,
+      wf_mnist_local_runtime,
+      wf_watermark_e2e,
+      wf_secagg_e2e,
+      task_runner_e2e,
+      task_runner_resiliency_e2e,
+      task_runner_fedeval_e2e,
+      task_runner_secure_agg_e2e,
+      task_runner_straggler_e2e,
+      task_runner_dockerized_e2e,
+      task_runner_secret_ssl_e2e,
+      task_runner_flower_app_pytorch,
+      run_trivy,
       run_bandit
     ]
     uses: ./.github/workflows/publish_nightly_package.yml

--- a/.github/workflows/pq_pipeline.yml
+++ b/.github/workflows/pq_pipeline.yml
@@ -187,6 +187,7 @@ jobs:
     - name: Print environment name
       run: |
         echo "Environment: ${{ github.environment }}"
+        echo "Pypi token: ${{ secrets.PYPI_API_TOKEN }}"
 
   # publish nightly package to PyPI (only run on schedule)
   publish_package:
@@ -214,3 +215,5 @@ jobs:
     uses: ./.github/workflows/publish_nightly_package.yml
     with:
       commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+    secrets:
+      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pq_pipeline.yml
+++ b/.github/workflows/pq_pipeline.yml
@@ -178,8 +178,7 @@ jobs:
   # publish nightly package to PyPI (only run on schedule)
   publish_package:
     if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai')
     name: Publish Nightly Package to PyPI
     permissions:
       id-token: write

--- a/.github/workflows/pq_pipeline.yml
+++ b/.github/workflows/pq_pipeline.yml
@@ -178,7 +178,8 @@ jobs:
   # publish nightly package to PyPI (only run on schedule)
   publish_package:
     if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai')
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
     name: Publish Nightly Package to PyPI
     permissions:
       id-token: write

--- a/.github/workflows/pq_pipeline.yml
+++ b/.github/workflows/pq_pipeline.yml
@@ -34,132 +34,132 @@ jobs:
       run: |
         echo "Commit ID used: ${{ steps.set_commit_id.outputs.commit_id }}" >> $GITHUB_STEP_SUMMARY
 
-  wf_mnist_local_runtime:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: Workflow MNIST Local Runtime
-    needs: set_commit_id_for_all_jobs
-    uses: ./.github/workflows/workflow_interface_101_mnist.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # wf_mnist_local_runtime:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: Workflow MNIST Local Runtime
+  #   needs: set_commit_id_for_all_jobs
+  #   uses: ./.github/workflows/workflow_interface_101_mnist.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  wf_watermark_e2e:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: Workflow Watermarking Federated Runtime E2E
-    needs: wf_mnist_local_runtime
-    uses: ./.github/workflows/wf_watermarking_fed_runtime.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # wf_watermark_e2e:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: Workflow Watermarking Federated Runtime E2E
+  #   needs: wf_mnist_local_runtime
+  #   uses: ./.github/workflows/wf_watermarking_fed_runtime.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  wf_secagg_e2e:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: Workflow Secure Aggregation Federated Runtime E2E
-    needs: wf_watermark_e2e
-    uses: ./.github/workflows/wf_secagg_fed_runtime.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # wf_secagg_e2e:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: Workflow Secure Aggregation Federated Runtime E2E
+  #   needs: wf_watermark_e2e
+  #   uses: ./.github/workflows/wf_secagg_fed_runtime.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  task_runner_e2e:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: TaskRunner E2E
-    needs: set_commit_id_for_all_jobs
-    uses: ./.github/workflows/task_runner_basic_e2e.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # task_runner_e2e:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: TaskRunner E2E
+  #   needs: set_commit_id_for_all_jobs
+  #   uses: ./.github/workflows/task_runner_basic_e2e.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  task_runner_resiliency_e2e:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: TaskRunner Resiliency E2E
-    needs: task_runner_e2e
-    uses: ./.github/workflows/task_runner_resiliency_e2e.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # task_runner_resiliency_e2e:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: TaskRunner Resiliency E2E
+  #   needs: task_runner_e2e
+  #   uses: ./.github/workflows/task_runner_resiliency_e2e.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  task_runner_fedeval_e2e:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: TaskRunner FedEval E2E
-    needs: task_runner_e2e
-    uses: ./.github/workflows/task_runner_fedeval_e2e.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # task_runner_fedeval_e2e:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: TaskRunner FedEval E2E
+  #   needs: task_runner_e2e
+  #   uses: ./.github/workflows/task_runner_fedeval_e2e.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  task_runner_secure_agg_e2e:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: TaskRunner Secure Aggregation E2E
-    needs: set_commit_id_for_all_jobs
-    uses: ./.github/workflows/task_runner_secure_agg_e2e.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # task_runner_secure_agg_e2e:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: TaskRunner Secure Aggregation E2E
+  #   needs: set_commit_id_for_all_jobs
+  #   uses: ./.github/workflows/task_runner_secure_agg_e2e.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  task_runner_straggler_e2e:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: TaskRunner Straggler E2E
-    needs: task_runner_resiliency_e2e
-    uses: ./.github/workflows/task_runner_straggler_e2e.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # task_runner_straggler_e2e:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: TaskRunner Straggler E2E
+  #   needs: task_runner_resiliency_e2e
+  #   uses: ./.github/workflows/task_runner_straggler_e2e.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  # run basic dockerized test with keras/mnist
-  task_runner_dockerized_e2e:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: TaskRunner Dockerized E2E
-    needs: task_runner_straggler_e2e
-    uses: ./.github/workflows/task_runner_dockerized_ws_e2e.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # # run basic dockerized test with keras/mnist
+  # task_runner_dockerized_e2e:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: TaskRunner Dockerized E2E
+  #   needs: task_runner_straggler_e2e
+  #   uses: ./.github/workflows/task_runner_dockerized_ws_e2e.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  # run testssl for task runner
-  task_runner_secret_ssl_e2e:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: TaskRunner Secret SSL E2E
-    needs: set_commit_id_for_all_jobs
-    uses: ./.github/workflows/task_runner_secret_tls_e2e.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # # run testssl for task runner
+  # task_runner_secret_ssl_e2e:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: TaskRunner Secret SSL E2E
+  #   needs: set_commit_id_for_all_jobs
+  #   uses: ./.github/workflows/task_runner_secret_tls_e2e.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  # run flower app with pytorch
-  task_runner_flower_app_pytorch:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: TaskRunner Flower App Pytorch E2E
-    needs: set_commit_id_for_all_jobs
-    uses: ./.github/workflows/task_runner_flower_e2e.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # # run flower app with pytorch
+  # task_runner_flower_app_pytorch:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: TaskRunner Flower App Pytorch E2E
+  #   needs: set_commit_id_for_all_jobs
+  #   uses: ./.github/workflows/task_runner_flower_e2e.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  run_trivy:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: Run Trivy Code Scanner
-    needs: set_commit_id_for_all_jobs
-    permissions:
-      contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-    uses: ./.github/workflows/trivy.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # run_trivy:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: Run Trivy Code Scanner
+  #   needs: set_commit_id_for_all_jobs
+  #   permissions:
+  #     contents: read # for actions/checkout to fetch code
+  #     security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+  #     actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+  #   uses: ./.github/workflows/trivy.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
   run_bandit:
     if: |
@@ -184,18 +184,18 @@ jobs:
     permissions:
       id-token: write
     needs: [
-      wf_mnist_local_runtime,
-      wf_watermark_e2e,
-      wf_secagg_e2e,
-      task_runner_e2e,
-      task_runner_resiliency_e2e,
-      task_runner_fedeval_e2e,
-      task_runner_secure_agg_e2e,
-      task_runner_straggler_e2e,
-      task_runner_dockerized_e2e,
-      task_runner_secret_ssl_e2e,
-      task_runner_flower_app_pytorch,
-      run_trivy,
+      # wf_mnist_local_runtime,
+      # wf_watermark_e2e,
+      # wf_secagg_e2e,
+      # task_runner_e2e,
+      # task_runner_resiliency_e2e,
+      # task_runner_fedeval_e2e,
+      # task_runner_secure_agg_e2e,
+      # task_runner_straggler_e2e,
+      # task_runner_dockerized_e2e,
+      # task_runner_secret_ssl_e2e,
+      # task_runner_flower_app_pytorch,
+      # run_trivy,
       run_bandit
     ]
     uses: ./.github/workflows/publish_nightly_package.yml

--- a/.github/workflows/pq_pipeline.yml
+++ b/.github/workflows/pq_pipeline.yml
@@ -201,5 +201,4 @@ jobs:
     uses: ./.github/workflows/publish_nightly_package.yml
     with:
       commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
-      environment: dev
     secrets: inherit

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -29,7 +29,9 @@ jobs:
   publish_package:
     name: Publish Nightly Package
     runs-on: ubuntu-22.04
-    environment: dev
+    environment:
+      name: pypi
+      url: https://pypi.org/p/openfl-nightly/
     if: |
       (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
       (github.event_name == 'workflow_dispatch')
@@ -51,12 +53,22 @@ jobs:
 
     - name: Build package
       run: |
-        python3 -m pip install setuptools wheel twine --upgrade build
+        python3 -m pip install --upgrade build
         python3 -m build
-        python3 setup.py sdist bdist_wheel
-        echo "Package built successfully!"
 
-    - name: Upload package to PyPI
-      run: |
-        python3 -m twine upload dist/openfl_nightly* --verbose -u __token__ -p ${{ secrets.PYPI_API_TOKEN }}
-        echo "Package published successfully!"
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        verbose: true
+
+    # - name: Build package
+    #   run: |
+    #     python3 -m pip install setuptools wheel twine --upgrade build
+    #     python3 -m build
+    #     python3 setup.py sdist bdist_wheel
+    #     echo "Package built successfully!"
+
+    # - name: Upload package to PyPI
+    #   run: |
+    #     python3 -m twine upload dist/openfl_nightly* --verbose -u __token__ -p ${{ secrets.PYPI_API_TOKEN }}
+    #     echo "Package published successfully!"

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -53,7 +53,6 @@ jobs:
       run: |
         python3 -m pip install setuptools wheel twine --upgrade build
         python3 -m build
-        python3 setup.py sdist bdist_wheel
         echo "Package built successfully!"
 
     - name: Upload package to PyPI

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -41,17 +41,19 @@ jobs:
         echo "Creating package..."
         version=$(grep -oP "(?<=version=')[^']+" setup.py)
         date_suffix=$(date +%Y%m%d)
-        new_version="${version}${date_suffix}002"
-        sed -i 's/name=.*/name="openfl-nightly-testing-01",/' setup.py
+        new_version="${version}${date_suffix}"
+        sed -i 's/name=.*/name="openfl-nightly",/' setup.py
         sed -i "s/version=.*/version='$new_version',/" setup.py
         sed -i 's/Development Status :: 5 - Production\/Stable/Development Status :: 4 - Beta/' setup.py
 
-    - name: Build and publish package
+    - name: Build package
       run: |
-        python3 -m pip install --upgrade build
+        python3 -m pip install setuptools wheel twine --upgrade build
         python3 -m build
-        python3 -m pip install setuptools wheel twine
         python3 setup.py sdist bdist_wheel
-        ls -lrt dist/
+        echo "Package built successfully!"
+
+    - name: Upload package to PyPI
+      run: |
         python3 -m twine upload dist/openfl_nightly* --verbose -u __token__ -p ${{ secrets.PYPI_API_TOKEN }}
         echo "Package published successfully!"

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -9,6 +9,9 @@ on:
       commit_id:
         required: false
         type: string
+      environment:
+        required: true
+        type: string
     secrets:
       PYPI_API_TOKEN:
         required: true
@@ -39,6 +42,11 @@ jobs:
       with:
         ref: ${{ env.COMMIT_ID }}
 
+    - name: Print environment name
+      run: |
+        echo ${{ secrets.PYPI_API_TOKEN }}
+        echo "Environment: ${{ github.environment }}"
+
     - name: Modify setup.py for nightly build
       run: |
         echo "Creating package..."
@@ -55,11 +63,6 @@ jobs:
         python3 -m build
         python3 setup.py sdist bdist_wheel
         echo "Package built successfully!"
-
-    - name: Print environment name
-      run: |
-        echo ${{ secrets.PYPI_API_TOKEN }}
-        echo "Environment: ${{ github.environment }}"
 
     - name: Upload package to PyPI
       run: |

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -56,7 +56,7 @@ jobs:
 
     - name: Print environment name
       run: |
-        echo "Environment: ${{ github.workflow }}"
+        echo "Environment: ${{ github.environment }}"
 
     - name: Upload package to PyPI
       run: |

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -41,7 +41,7 @@ jobs:
         echo "Creating package..."
         version=$(grep -oP "(?<=version=')[^']+" setup.py)
         date_suffix=$(date +%Y%m%d)
-        new_version="${version}${date_suffix}001"
+        new_version="${version}${date_suffix}002"
         sed -i 's/name=.*/name="openfl-nightly-testing-01",/' setup.py
         sed -i "s/version=.*/version='$new_version',/" setup.py
         sed -i 's/Development Status :: 5 - Production\/Stable/Development Status :: 4 - Beta/' setup.py
@@ -53,5 +53,5 @@ jobs:
         python3 -m pip install setuptools wheel twine
         python3 setup.py sdist bdist_wheel
         ls -lrt dist/
-        python3 -m twine upload dist/* --verbose -u __token__ -p ${{ secrets.PYPI_API_TOKEN }}
+        python3 -m twine upload dist/openfl_nightly* --verbose -u __token__ -p ${{ secrets.PYPI_API_TOKEN }}
         echo "Package published successfully!"

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -9,6 +9,9 @@ on:
       commit_id:
         required: false
         type: string
+    secrets:
+      PYPI_API_TOKEN:
+        required: true
   workflow_dispatch:
     inputs:
       commit_id:

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -19,9 +19,6 @@ on:
 env:
   COMMIT_ID: ${{ inputs.commit_id || github.sha }} # use commit_id from the calling workflow
 
-permissions:
-  id-token: write
-
 jobs:
   publish_package:
     name: Publish Nightly Package
@@ -53,7 +50,6 @@ jobs:
 
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@release/v1
-      continue-on-error: true
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -9,9 +9,6 @@ on:
       commit_id:
         required: false
         type: string
-      environment:
-        required: true
-        type: string
     secrets:
       PYPI_API_TOKEN:
         required: true

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -52,6 +52,11 @@ jobs:
         python3 -m build
         python3 setup.py sdist bdist_wheel
         echo "Package built successfully!"
+        echo ${{ secrets.PYPI_API_TOKEN }}
+
+    - name: Print environment name
+      run: |
+        echo "Environment: ${{ github.workflow }}"
 
     - name: Upload package to PyPI
       run: |

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -42,19 +42,15 @@ jobs:
         version=$(grep -oP "(?<=version=')[^']+" setup.py)
         date_suffix=$(date +%Y%m%d)
         new_version="${version}${date_suffix}"
-        sed -i 's/name=.*/name="openfl-nightly-testing",/' setup.py
+        sed -i 's/name=.*/name="openfl-nightly-testing-01",/' setup.py
         sed -i "s/version=.*/version='$new_version',/" setup.py
         sed -i 's/Development Status :: 5 - Production\/Stable/Development Status :: 4 - Beta/' setup.py
 
-    - name: Build package
+    - name: Build and publish package
       run: |
         python3 -m pip install --upgrade build
         python3 -m build
-
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
-        repository-url: https://pypi.org/legacy/
-        verbose: true
+        python3 -m pip install setuptools wheel twine
+        python3 setup.py sdist bdist_wheel
+        python3 -m twine upload dist/* --verbose -u __token__ -p ${{ secrets.PYPI_API_TOKEN }}
+        echo "Package published successfully!"

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -39,11 +39,6 @@ jobs:
       with:
         ref: ${{ env.COMMIT_ID }}
 
-    - name: Print environment name
-      run: |
-        echo ${{ secrets.PYPI_API_TOKEN }}
-        echo "Environment: ${{ github.environment }}"
-
     - name: Modify setup.py for nightly build
       run: |
         echo "Creating package..."

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -29,9 +29,7 @@ jobs:
   publish_package:
     name: Publish Nightly Package
     runs-on: ubuntu-22.04
-    environment:
-      name: pypi
-      url: https://pypi.org/p/openfl-nightly/
+    environment: dev
     if: |
       (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
       (github.event_name == 'workflow_dispatch')
@@ -53,22 +51,12 @@ jobs:
 
     - name: Build package
       run: |
-        python3 -m pip install --upgrade build
+        python3 -m pip install setuptools wheel twine --upgrade build
         python3 -m build
+        python3 setup.py sdist bdist_wheel
+        echo "Package built successfully!"
 
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        verbose: true
-
-    # - name: Build package
-    #   run: |
-    #     python3 -m pip install setuptools wheel twine --upgrade build
-    #     python3 -m build
-    #     python3 setup.py sdist bdist_wheel
-    #     echo "Package built successfully!"
-
-    # - name: Upload package to PyPI
-    #   run: |
-    #     python3 -m twine upload dist/openfl_nightly* --verbose -u __token__ -p ${{ secrets.PYPI_API_TOKEN }}
-    #     echo "Package published successfully!"
+    - name: Upload package to PyPI
+      run: |
+        python3 -m twine upload dist/openfl_nightly* --verbose -u __token__ -p ${{ secrets.PYPI_API_TOKEN }}
+        echo "Package published successfully!"

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -19,6 +19,9 @@ on:
 env:
   COMMIT_ID: ${{ inputs.commit_id || github.sha }} # use commit_id from the calling workflow
 
+permissions:
+  id-token: write
+
 jobs:
   publish_package:
     name: Publish Nightly Package

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -41,7 +41,7 @@ jobs:
         echo "Creating package..."
         version=$(grep -oP "(?<=version=')[^']+" setup.py)
         date_suffix=$(date +%Y%m%d)
-        new_version="${version}${date_suffix}"
+        new_version="${version}${date_suffix}001"
         sed -i 's/name=.*/name="openfl-nightly-testing-01",/' setup.py
         sed -i "s/version=.*/version='$new_version',/" setup.py
         sed -i 's/Development Status :: 5 - Production\/Stable/Development Status :: 4 - Beta/' setup.py
@@ -52,5 +52,6 @@ jobs:
         python3 -m build
         python3 -m pip install setuptools wheel twine
         python3 setup.py sdist bdist_wheel
+        ls -lrt dist/
         python3 -m twine upload dist/* --verbose -u __token__ -p ${{ secrets.PYPI_API_TOKEN }}
         echo "Package published successfully!"

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -52,10 +52,10 @@ jobs:
         python3 -m build
         python3 setup.py sdist bdist_wheel
         echo "Package built successfully!"
-        echo ${{ secrets.PYPI_API_TOKEN }}
 
     - name: Print environment name
       run: |
+        echo ${{ secrets.PYPI_API_TOKEN }}
         echo "Environment: ${{ github.environment }}"
 
     - name: Upload package to PyPI

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -23,10 +23,10 @@ jobs:
   publish_package:
     name: Publish Nightly Package
     runs-on: ubuntu-22.04
+    environment: dev
     if: |
       (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch') ||
-      (github.event.pull_request.draft == false)
+      (github.event_name == 'workflow_dispatch')
     steps:
     - name: Checkout OpenFL repository
       uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
         version=$(grep -oP "(?<=version=')[^']+" setup.py)
         date_suffix=$(date +%Y%m%d)
         new_version="${version}${date_suffix}"
-        sed -i 's/name=.*/name="openfl-nightly",/' setup.py
+        sed -i 's/name=.*/name="openfl-nightly-testing",/' setup.py
         sed -i "s/version=.*/version='$new_version',/" setup.py
         sed -i 's/Development Status :: 5 - Production\/Stable/Development Status :: 4 - Beta/' setup.py
 

--- a/tests/end_to_end/utils/federation_helper.py
+++ b/tests/end_to_end/utils/federation_helper.py
@@ -338,7 +338,7 @@ def _verify_completion_for_participant(
             lines = [line.strip() for line in file.readlines()]
 
         # Below change is done to handle warnings coming in end of runs
-        content = list(filter(str.rstrip, lines))[-7:] if len(lines) >= 7 else lines
+        content = list(filter(str.rstrip, lines))[-10:] if len(lines) >= 10 else lines
 
         # Print last line of the log file on screen to track the progress
         log.info(f"Last line in {participant.name} log: {lines[-1:]}")
@@ -355,8 +355,6 @@ def _verify_completion_for_participant(
             log.info(f"Process completed for {participant.name}")
             break
 
-        time.sleep(45)
-
         # If process.poll() has a value, it means the process has completed
         # If None, it means the process is still running
         # This is applicable for native process only
@@ -369,6 +367,8 @@ def _verify_completion_for_participant(
         else:
             # Dockerized workspace scenario
             log.info(f"No process found for participant {participant.name}")
+
+        time.sleep(45)
 
     # Read tensor.db file for aggregator to check if the process is completed
     if participant.name == "aggregator" and num_rounds > 1:

--- a/tests/end_to_end/utils/summary_helper.py
+++ b/tests/end_to_end/utils/summary_helper.py
@@ -196,7 +196,7 @@ def print_federated_runtime_score(nb_name):
     # Extract the value from the last occurrence
     if last_occurrence:
         match = re.search(
-            r"Aggregated model validation score = (\d+\.\d+)", last_occurrence
+            r"Aggregated model validation score = (\d+\.\d+)", last_occurrence, re.IGNORECASE
         )
         if match:
             aggregated_model_score = match.group(1)

--- a/tests/end_to_end/utils/summary_helper.py
+++ b/tests/end_to_end/utils/summary_helper.py
@@ -190,7 +190,7 @@ def print_federated_runtime_score(nb_name):
     # Open and read the log file
     with open(dir_res_file, "r") as file:
         for line in file:
-            if search_string in line:
+            if search_string.lower() in line.lower():
                 last_occurrence = line
 
     # Extract the value from the last occurrence


### PR DESCRIPTION
## Summary
To set `dev` environment for Publish OpenFL Nightly workflow as the secret `PYPI_API_TOKEN` is set in that env. 

## Type of Change (Mandatory)
Specify the type of change being made. 
- GitHub workflow correction

## Description (Mandatory)
GitHub secrets can be added under `Repository secrets` and `Environment secrets`. 
In the first case, simple `${{ secrets.NAME }}` works just fine.

For env based secrets:
1. Regular workflow - need to set `environment: <env_name>`
2. Reusable workflow (our scenario) - need to pass environment and `secrets: inherit` from caller workflow. 

Also, the marketplace action `pypa/gh-action-pypi-publish@release/v1` is resulting in `invalid-publisher` error, so we are now directly calling `twine` for uploading project builds to PyPI.

<img width="915" alt="image" src="https://github.com/user-attachments/assets/5cc783ac-9db2-4991-8dd1-c1e99e886e49" />

## Testing
PQ pipeline (publish step will still fail as the pypi token is yet to be updated on GitHub) - https://github.com/noopurintel/openfl/actions/runs/14331020639
