### PR TITLE
Update HippMapp3r plan, requirments and readme

### DIFF
--- a/openfl-workspace/keras/hippmapp3r/README.md
+++ b/openfl-workspace/keras/hippmapp3r/README.md
@@ -9,6 +9,14 @@ To set up the data, run the following command:
 python src/setup_data.py --num_collaborators $MAX_NUMBER_OF_COLLABORATORS --total_dataset_size_per_col_MB $DESIRED_DATASET_SIZE
 ```
 
+## Known Issues
+
+An error has been observed on Cascade Lake CPUs: "CPU implementation of Conv3D currently only supports the NHWC tensor format." 
+
+### Workarounds:
+1. Use a more recent CPU, such as Ice Lake, which supports the required tensor format.
+2. Alternatively, use a GPU to avoid this issue entirely.
+
 ## Reference
 
 Goubran, M., Ntiri E., Akhavein, H., Holmes, M., Nestor, S., Ramirez, J., Adamo, S., Gao, F., Ozzoude, M., Scott, C., Martel, A., Swardfager, W., Masellis, M., Swartz, R., MacIntosh B, and Black, SE. “Hippocampal segmentation for atrophied brains using three-dimensional convolutional neural networks”. Human Brain Mapping. 2020 Feb 1;41(2):291-308. https://onlinelibrary.wiley.com/doi/full/10.1002/hbm.24811

--- a/openfl-workspace/keras/hippmapp3r/README.md
+++ b/openfl-workspace/keras/hippmapp3r/README.md
@@ -14,7 +14,7 @@ python src/setup_data.py --num_collaborators $MAX_NUMBER_OF_COLLABORATORS --tota
 An error has been observed on Cascade Lake CPUs: "CPU implementation of Conv3D currently only supports the NHWC tensor format." 
 
 ### Workarounds:
-1. Use a more recent CPU, such as Ice Lake, which supports the required tensor format.
+1. Use a more recent CPU, such as 3rd Generation Intel® Xeon® Scalable Processors (codenamed Ice Lake), which supports the required tensor format.
 2. Alternatively, use a GPU to avoid this issue entirely.
 
 ## Reference

--- a/openfl-workspace/keras/hippmapp3r/README.md
+++ b/openfl-workspace/keras/hippmapp3r/README.md
@@ -11,7 +11,7 @@ python src/setup_data.py --num_collaborators $MAX_NUMBER_OF_COLLABORATORS --tota
 
 ## Known Issues
 
-An error has been observed on Cascade Lake CPUs: "CPU implementation of Conv3D currently only supports the NHWC tensor format." 
+An error has been observed on 2nd Generation Intel® Xeon® Scalable Processors (codenamed Cascade Lake): "CPU implementation of Conv3D currently only supports the NHWC tensor format." 
 
 ### Workarounds:
 1. Use a more recent CPU, such as 3rd Generation Intel® Xeon® Scalable Processors (codenamed Ice Lake), which supports the required tensor format.

--- a/openfl-workspace/keras/hippmapp3r/plan/plan.yaml
+++ b/openfl-workspace/keras/hippmapp3r/plan/plan.yaml
@@ -22,6 +22,7 @@ data_loader :
   template : src.dataloader.KerasHippmapp3rsynth
   settings :
     batch_size : 1
+    input_shape : [160, 160, 128]
 
 task_runner :
   defaults : plan/defaults/task_runner.yaml

--- a/openfl-workspace/keras/hippmapp3r/requirements.txt
+++ b/openfl-workspace/keras/hippmapp3r/requirements.txt
@@ -1,5 +1,5 @@
 keras==2.15.0
-tensorflow
-keras-contrib @ git+https://www.github.com/keras-team/keras-contrib.git
-gdown
-scikit-learn
+tensorflow-cpu==2.15.1
+keras-contrib @ git+https://www.github.com/keras-team/keras-contrib.git@3fc5ef709e061416f4bc8a92ca3750c824b5d2b0
+gdown==5.2.0
+scikit-learn==1.6.1


### PR DESCRIPTION
Added known issues section in README mentioning "CPU implementation of Conv3D currently only supports the NHWC tensor format" error
updated requirements including CPU only implementation of tensorflow
updated plan with input_shape parameter