### PR TITLE
Run an E2E test before publishing openfl-nightly package

### DIFF
--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -84,8 +84,6 @@ jobs:
 
     - name: Print package information
       run: |
-        echo "## Package Information" >> $GITHUB_STEP_SUMMARY
         echo "Version: $(pip list | grep openfl)" >> $GITHUB_STEP_SUMMARY
-        echo "Build Date: $(date +%Y-%m-%d)" >> $GITHUB_STEP_SUMMARY
         echo "Commit ID: ${{ env.COMMIT_ID }}" >> $GITHUB_STEP_SUMMARY
         echo "Package information printed successfully!"

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -55,14 +55,12 @@ jobs:
         python3 -m pip install setuptools wheel twine --upgrade build
         python3 -m pip install .
         python3 -m build
-        WHL_FILE=$(ls dist/*.whl)
-        echo "OPENFL_NIGHTLY_WHL_FILE=$WHL_FILE" >> $GITHUB_ENV
+        echo "OPENFL_NIGHTLY_WHL_FILE=$(ls dist/*.whl)" >> $GITHUB_ENV
         echo "Package built successfully!"
 
     - name: Install built package
       id: install_package_using_wheel
       run: |
-        echo ${{ env.OPENFL_NIGHTLY_WHL_FILE }}
         python3 -m pip uninstall -y openfl openfl-nightly
         python3 -m pip install ${{ env.OPENFL_NIGHTLY_WHL_FILE }}
         python3 -m pip install -r test-requirements.txt
@@ -77,13 +75,13 @@ jobs:
         --num_rounds 1 --num_collaborators 2
         echo "Verified the package installation successfully!"
 
-    - name: Upload package to PyPI
-      run: |
-        python3 -m twine upload dist/openfl_nightly* --verbose -u __token__ -p ${{ secrets.PYPI_API_TOKEN }}
-        echo "Package published successfully!"
+    # - name: Upload package to PyPI
+    #   run: |
+    #     python3 -m twine upload dist/openfl_nightly* --verbose -u __token__ -p ${{ secrets.PYPI_API_TOKEN }}
+    #     echo "Package published successfully!"
 
     - name: Print package information
       run: |
-        echo "Version: $(pip list | grep openfl)" >> $GITHUB_STEP_SUMMARY
-        echo "Commit ID: ${{ env.COMMIT_ID }}" >> $GITHUB_STEP_SUMMARY
+        echo "**Version:** $(pip list | grep openfl)" >> $GITHUB_STEP_SUMMARY
+        echo "**Commit ID:** ${{ env.COMMIT_ID }}" >> $GITHUB_STEP_SUMMARY
         echo "Package information printed successfully!"

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -56,9 +56,8 @@ jobs:
         python3 -m pip install .
         python3 -m build
         WHL_FILE=$(ls dist/*.whl)
-        echo "Wheel file: $WHL_FILE"
-        echo "Package built successfully!"
         echo "OPENFL_NIGHTLY_WHL_FILE=$WHL_FILE" >> $GITHUB_ENV
+        echo "Package built successfully!"
 
     - name: Install built package
       id: install_package_using_wheel
@@ -69,10 +68,10 @@ jobs:
         python3 -m pip install -r test-requirements.txt
         echo "Installed the built wheel file successfully!"
 
-    - name: Run Task Runner E2E test
-      id: run_tests
+    - name: Verify package installation with E2E test
+      id: verify_package_installation
       run: |
-        pip list| grep openfl
+        echo "OpenFL version is $(pip list | grep openfl)"
         python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
         -m task_runner_basic --model_name "keras/mnist" \
         --num_rounds 1 --num_collaborators 2

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -54,9 +54,11 @@ jobs:
         python3 -m pip install setuptools wheel twine --upgrade build
         python3 -m pip install .
         python3 -m build
+        WHL_FILE=$(ls dist/*.whl)
+        echo "Wheel file: $WHL_FILE"
         echo "Package built successfully!"
 
-    - name: Upload package to PyPI
-      run: |
-        python3 -m twine upload dist/openfl_nightly* --verbose -u __token__ -p ${{ secrets.PYPI_API_TOKEN }}
-        echo "Package published successfully!"
+    # - name: Upload package to PyPI
+    #   run: |
+    #     python3 -m twine upload dist/openfl_nightly* --verbose -u __token__ -p ${{ secrets.PYPI_API_TOKEN }}
+    #     echo "Package published successfully!"

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -50,6 +50,7 @@ jobs:
         sed -i 's/Development Status :: 5 - Production\/Stable/Development Status :: 4 - Beta/' setup.py
 
     - name: Build package
+      id: build_package
       run: |
         python3 -m pip install setuptools wheel twine --upgrade build
         python3 -m pip install .
@@ -57,6 +58,23 @@ jobs:
         WHL_FILE=$(ls dist/*.whl)
         echo "Wheel file: $WHL_FILE"
         echo "Package built successfully!"
+        echo "::set-output name=wheel_file::$WHL_FILE"  # Set the output variable
+
+    - name: Install built package
+      id: install_package_using_wheel
+      run: |
+        python3 -m pip uninstall -y openfl openfl-nightly
+        python3 -m pip install ${{ steps.build_package.outputs.wheel_file }}
+        echo "Installed the built wheel file successfully!"
+
+    - name: Run Task Runner E2E test
+      id: run_tests
+      run: |
+        pip list| grep openfl
+        python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+        -m task_runner_basic --model_name "keras/mnist" \
+        --num_rounds 1 --num_collaborators 2
+        echo "Verified the package installation successfully!"
 
     # - name: Upload package to PyPI
     #   run: |

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -75,10 +75,10 @@ jobs:
         --num_rounds 1 --num_collaborators 2
         echo "Verified the package installation successfully!"
 
-    # - name: Upload package to PyPI
-    #   run: |
-    #     python3 -m twine upload dist/openfl_nightly* --verbose -u __token__ -p ${{ secrets.PYPI_API_TOKEN }}
-    #     echo "Package published successfully!"
+    - name: Upload package to PyPI
+      run: |
+        python3 -m twine upload dist/openfl_nightly* --verbose -u __token__ -p ${{ secrets.PYPI_API_TOKEN }}
+        echo "Package published successfully!"
 
     - name: Print package information
       run: |

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -58,13 +58,15 @@ jobs:
         WHL_FILE=$(ls dist/*.whl)
         echo "Wheel file: $WHL_FILE"
         echo "Package built successfully!"
-        echo "::set-output name=wheel_file::$WHL_FILE"  # Set the output variable
+        echo "OPENFL_NIGHTLY_WHL_FILE=$WHL_FILE" >> $GITHUB_ENV
 
     - name: Install built package
       id: install_package_using_wheel
       run: |
+        echo ${{ env.OPENFL_NIGHTLY_WHL_FILE }}
         python3 -m pip uninstall -y openfl openfl-nightly
-        python3 -m pip install ${{ steps.build_package.outputs.wheel_file }}
+        python3 -m pip install ${{ env.OPENFL_NIGHTLY_WHL_FILE }}
+        python3 -m pip install -r test-requirements.txt
         echo "Installed the built wheel file successfully!"
 
     - name: Run Task Runner E2E test

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -81,3 +81,11 @@ jobs:
     #   run: |
     #     python3 -m twine upload dist/openfl_nightly* --verbose -u __token__ -p ${{ secrets.PYPI_API_TOKEN }}
     #     echo "Package published successfully!"
+
+    - name: Print package information
+      run: |
+        echo "## Package Information" >> $GITHUB_STEP_SUMMARY
+        echo "Version: $(pip list | grep openfl)" >> $GITHUB_STEP_SUMMARY
+        echo "Build Date: $(date +%Y-%m-%d)" >> $GITHUB_STEP_SUMMARY
+        echo "Commit ID: ${{ env.COMMIT_ID }}" >> $GITHUB_STEP_SUMMARY
+        echo "Package information printed successfully!"

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -77,10 +77,10 @@ jobs:
         --num_rounds 1 --num_collaborators 2
         echo "Verified the package installation successfully!"
 
-    # - name: Upload package to PyPI
-    #   run: |
-    #     python3 -m twine upload dist/openfl_nightly* --verbose -u __token__ -p ${{ secrets.PYPI_API_TOKEN }}
-    #     echo "Package published successfully!"
+    - name: Upload package to PyPI
+      run: |
+        python3 -m twine upload dist/openfl_nightly* --verbose -u __token__ -p ${{ secrets.PYPI_API_TOKEN }}
+        echo "Package published successfully!"
 
     - name: Print package information
       run: |

--- a/tests/end_to_end/utils/interruption_helper.py
+++ b/tests/end_to_end/utils/interruption_helper.py
@@ -127,11 +127,12 @@ def kill_processes(command_to_kill, fail_if_not_found=False):
     """
     try:
         pids = get_pids_for_active_command(command_to_kill)
-        log.info(f"PIDs for command '{command_to_kill}': {pids}")
-        # Kill each process
-        for pid in pids:
-            subprocess.run(['sudo', 'kill', '-9', str(pid)], check=fail_if_not_found)
-            log.info(f"Killed process with PID {pid}")
+        if len(pids):
+            log.info(f"PIDs for command '{command_to_kill}': {pids}")
+            # Kill each process
+            for pid in pids:
+                subprocess.run(['sudo', 'kill', '-9', str(pid)], check=fail_if_not_found)
+                log.info(f"Killed process with PID {pid}")
         return True
     except subprocess.CalledProcessError:
         if fail_if_not_found:


### PR DESCRIPTION
## Summary
Run E2E test before publishing openfl-nightly package

## Type of Change (Mandatory)
Specify the type of change being made. 
- Feature enhancement  - for Publish Nightly Package workflow

## Description (Mandatory)
Currently, as part of PQ pipeline we are building the openfl-nightly package and directly publishing it to pypi.
But we aren't testing the built package to see if everything worked out well.

This PR aims to bridge that gap and run a quick TaskRunner E2E test with model=keras/mnist, round=1 and collaborators=2.

In addition, prints the package information on GitHub summary page.
<img width="528" alt="image" src="https://github.com/user-attachments/assets/b4aa4c96-5c3d-433c-94a2-214bd4fac7f6" />


## Testing
Workflow run (with publish step skipped) - https://github.com/noopurintel/openfl/actions/runs/14397510558