### PR TITLE
Load native model with fx plan initialize

### DIFF
--- a/openfl/federated/task/runner_gandlf.py
+++ b/openfl/federated/task/runner_gandlf.py
@@ -419,9 +419,13 @@ class GaNDLFTaskRunner(TaskRunner):
                 dict in picked file. Defaults to 'optimizer_state_dict'.
             **kwargs: Additional keyword arguments.
         """
-        pickle_dict = pt.load(filepath)  # nosec B614
-        self.model.load_state_dict(pickle_dict[model_state_dict_key])
-        self.optimizer.load_state_dict(pickle_dict[optimizer_state_dict_key])
+        pickle_dict = pt.load(filepath, weights_only=True)  # nosec B614
+
+        if model_state_dict_key in pickle_dict and optimizer_state_dict_key in pickle_dict:
+            self.load_state_dict(pickle_dict[model_state_dict_key])
+            self.optimizer.load_state_dict(pickle_dict[optimizer_state_dict_key])
+        else:
+            self.load_state_dict(pickle_dict)
 
     def save_native(
         self,

--- a/openfl/federated/task/runner_pt.py
+++ b/openfl/federated/task/runner_pt.py
@@ -420,10 +420,14 @@ class PyTorchTaskRunner(nn.Module, TaskRunner):
         Returns:
             None
         """
-        pickle_dict = torch.load(filepath)  # nosec B614
-        self.load_state_dict(pickle_dict[model_state_dict_key])
-        self.optimizer.load_state_dict(pickle_dict[optimizer_state_dict_key])
+        pickle_dict = torch.load(filepath, weights_only=True)  # nosec B614
 
+        if model_state_dict_key in pickle_dict and optimizer_state_dict_key in pickle_dict:
+            self.load_state_dict(pickle_dict[model_state_dict_key])
+            self.optimizer.load_state_dict(pickle_dict[optimizer_state_dict_key])
+        else:
+            self.load_state_dict(pickle_dict)
+    
     def save_native(
         self,
         filepath,

--- a/openfl/federated/task/runner_xgb.py
+++ b/openfl/federated/task/runner_xgb.py
@@ -49,11 +49,13 @@ class XGBoostTaskRunner(TaskRunner):
         the global model and required tensor keys for XGBoost tasks.
 
         Attributes:
-            global_model (xgb.Booster): The global XGBoost model.
+            bst (xgb.Booster): gradient-boosted tree model for XGBoost.
+            global_model (np.ndarray): The numpy array containing global XGBoost tree.
             required_tensorkeys_for_function (dict): A dictionary to store required tensor keys
                 for each function.
         """
         super().__init__(**kwargs)
+        self.bst = None
         self.global_model = None
         self.required_tensorkeys_for_function = {}
 
@@ -337,6 +339,21 @@ class XGBoostTaskRunner(TaskRunner):
             global_model_byte_array = bytearray(self.global_model.astype(np.uint8).tobytes())
             self.bst = xgb.Booster()
             self.bst.load_model(global_model_byte_array)
+
+    def load_native(
+        self,
+        filepath,
+        **kwargs,
+    ):
+        """
+        Load XGBooster from a file specified by filepath.
+
+        Args:
+            filepath (str): Path to XGB booster file.
+            **kwargs: Additional keyword arguments.
+        """
+        self.bst = xgb.Booster()
+        self.bst.load_model(filepath)
 
     def save_native(
         self,

--- a/openfl/interface/plan.py
+++ b/openfl/interface/plan.py
@@ -223,7 +223,7 @@ def _initialize_tensor_dict(plan, input_shape, init_model_path):
                 init_tensor_dict = task_runner.get_tensor_dict(False)
             except Exception as e:
                 logger.error(f"Failed to load native model: {e}")
-                raise RuntimeError(f"Failed to load model from the provided path.")
+                raise
     else:
         init_tensor_dict = task_runner.get_tensor_dict(False)
 

--- a/openfl/interface/plan.py
+++ b/openfl/interface/plan.py
@@ -7,7 +7,7 @@
 import sys
 from logging import getLogger
 from os import makedirs
-from os.path import isfile
+from os.path import isfile, splitext
 from pathlib import Path
 from shutil import copyfile, rmtree
 
@@ -214,10 +214,12 @@ def _initialize_tensor_dict(plan, input_shape, init_model_path):
 
     if init_model_path and isfile(init_model_path):
         logger.info(f"Loading initial model from {init_model_path}")
-        try:
+        file_extension = splitext(init_model_path)[1]
+
+        if file_extension == ".pbuf":
             model_proto = utils.load_proto(init_model_path)
             init_tensor_dict, round_number = utils.deconstruct_model_proto(model_proto, tensor_pipe)
-        except Exception:
+        else:
             try:
                 task_runner.load_native(init_model_path)
                 init_tensor_dict = task_runner.get_tensor_dict(False)

--- a/openfl/interface/plan.py
+++ b/openfl/interface/plan.py
@@ -94,7 +94,7 @@ def plan(context):
     "-i",
     "--init_model_path",
     required=False,
-    help="Path to initial model protobuf file.",
+    help="Path to initial model. It can be a protobuf or native format.",
     type=ClickPath(exists=True),
 )
 def initialize(
@@ -202,7 +202,7 @@ def _initialize_tensor_dict(plan, input_shape, init_model_path):
     Args:
         plan: The federation plan object
         input_shape: The input shape to the model
-        init_model_path: Path to initial model protobuf file
+        init_model_path: Path to initial model. It can be a protobuf or native format."
 
     Returns:
         Tuple of (tensor_dict, task_runner, round_number)
@@ -214,8 +214,16 @@ def _initialize_tensor_dict(plan, input_shape, init_model_path):
 
     if init_model_path and isfile(init_model_path):
         logger.info(f"Loading initial model from {init_model_path}")
-        model_proto = utils.load_proto(init_model_path)
-        init_tensor_dict, round_number = utils.deconstruct_model_proto(model_proto, tensor_pipe)
+        try:
+            model_proto = utils.load_proto(init_model_path)
+            init_tensor_dict, round_number = utils.deconstruct_model_proto(model_proto, tensor_pipe)
+        except Exception:
+            try:
+                task_runner.load_native(init_model_path)
+                init_tensor_dict = task_runner.get_tensor_dict(False)
+            except Exception as e:
+                logger.error(f"Failed to load native model: {e}")
+                raise RuntimeError(f"Failed to load model from the provided path.")
     else:
         init_tensor_dict = task_runner.get_tensor_dict(False)
 


### PR DESCRIPTION
## Summary
This PR enables pretrained models to be loaded in their native file format via:
`fx plan initialize -i <model_path>`

## Type of Change (Mandatory)
- Feature enhancement  

## Description (Mandatory)
The ability to load a pretrained model as a protobuf was enabled in https://github.com/securefederatedai/openfl/pull/1290 for the federated evaluation efforts.

This PR extends that functionality to also accept models in their native file format (i.e. `.pth`) by calling the already existing `taskrunner.load_native()` method using the same `fx plan initialize` flag

When the `--init_model_path` flag is set, `fx plan initialize` will check if the file is a `pbuf` otherwise, it will try to load using `load_native()` before raising an error

_Additional changes:_
- updated both the `runner_gandalf.py` and `runner_pt.py` to be able to load the model state dictionary directly (users will not always save the `model.state_dict()` and the `optimizer.state_dict()` in the same `.pth` file, especially for inferencing)
- added `load_native()` method to `runner_xgb.py`


## Testing
Tested locally by loading in pretrained model and verifying weights

## Additional Information

_Security considerations:_
We purposely did not use an allow list for file extensions in order to stay framework agnostic. Since `load_native()` is part of the task runner and can be modified in the `taskrunner.py` subclass, a user can potentially modify it to load anything during initialization. This is important for flexibility for more complex models, but it is also a risk that participants must consider and it could be easily but thoroughly checked when reviewing the workload if `load_native()` is modified