### PR TITLE
Minor bug fix to `runner_xgb.py` to properly rebuild model during aggregated model validation

### DIFF
--- a/openfl/federated/task/runner_xgb.py
+++ b/openfl/federated/task/runner_xgb.py
@@ -122,7 +122,6 @@ class XGBoostTaskRunner(TaskRunner):
         output_tensor_dict = {TensorKey(metric.name, origin, round_num, True, tags): metric.value}
 
         # Empty list represents metrics that should only be stored locally
-        print(output_tensor_dict)
         return output_tensor_dict, {}
 
     def train_task(

--- a/openfl/federated/task/runner_xgb.py
+++ b/openfl/federated/task/runner_xgb.py
@@ -95,9 +95,9 @@ class XGBoostTaskRunner(TaskRunner):
         """
         data = self.data_loader.get_valid_dmatrix()
 
-        # during agg validation, self.bst will still be None. during local validation,
-        # it will have a value - no need to rebuild
-        if self.bst is None:
+        # during agg validation, rebuild self.bst from global model. during local validation,
+        # continue with trained self.bst, no need to rebuild
+        if kwargs["apply"] != "local":
             self.rebuild_model(input_tensor_dict)
 
         # if self.bst is still None after rebuilding, then there was no initial global model, so
@@ -122,6 +122,7 @@ class XGBoostTaskRunner(TaskRunner):
         output_tensor_dict = {TensorKey(metric.name, origin, round_num, True, tags): metric.value}
 
         # Empty list represents metrics that should only be stored locally
+        print(output_tensor_dict)
         return output_tensor_dict, {}
 
     def train_task(


### PR DESCRIPTION
## Summary
This PR fixes a bug where the XGB booster is using the old local model during aggregated model validation

## Type of Change (Mandatory)
Specify the type of change being made. 
- Bug fix  

## Description (Mandatory)
During aggregated model validation, the model needs to be rebuilt in order to incorporate aggregated changes. During local model validation, the model can use the existing locally fine-tuned model. The original behavior of the conditional was to rebuild the model when `self.bst=None` otherwise do not. However, `self.bst=None` is only True during the very first pass since the object attributes do not get reset between rounds. This caused the model to run model validation on the locally tuned model before incorporated the aggregated model during the train task. By setting the conditional to check if `kwargs["apply"] != "local"` we ensure the new aggregated model is properly being built.

_Note_ for XGB, only the new trees are actually saved after fine-tuning (appended to the old global model at the aggregator), which is why we don't rebuilt the model for local validation. This was originally to avoid having to send an increasingly large model from the collaborator back to the aggregator; however, the full global model is still sent from the aggregator so there is an opportunity to optimize this

## Testing
Original behavior (note that validate_local from round 1 is equal to validate_agg of round 2):
<img width="563" alt="image" src="https://github.com/user-attachments/assets/86940365-7499-42e0-8f50-c6647ac8012d" />

New behavior:
<img width="571" alt="image" src="https://github.com/user-attachments/assets/c5f0304f-cbb2-4977-97e8-5e8e9a484aaa" />

<!-- ## Additional Information
[Any additional information that reviewers should be aware of.] -->