### PR TITLE
PQ Pipeline Fix: Removed `keras/jax/mnist` from dockerized workspace run

### DIFF
--- a/.github/workflows/pq_pipeline.yml
+++ b/.github/workflows/pq_pipeline.yml
@@ -175,11 +175,11 @@ jobs:
     with:
       commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  # publish nightly package to PyPI (only run on schedule)
+  # publish nightly package to PyPI
+  # enable this job only for securefederatedai and not forked repos
   publish_package:
     if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.repository_owner == 'securefederatedai'
     name: Publish Nightly Package to PyPI
     permissions:
       id-token: write

--- a/.github/workflows/task_runner_dockerized_ws_e2e.yml
+++ b/.github/workflows/task_runner_dockerized_ws_e2e.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       matrix:
         # IMP: Models requiring higher config might fail on current GitHub runners due to resource constraints.
-        model_name: ["keras/mnist", "keras/jax/mnist"]
+        model_name: ["keras/mnist"]
         python_version: ["3.10", "3.11"] # Keras does not support Python 3.12
       fail-fast: false # do not immediately fail if one of the combinations fail
 


### PR DESCRIPTION
## Summary
To remove `keras/jax/mnist` from running as part of dockerized workspace (it will keep running for TaskRunner native). 
In addition, to enable openfl-nightly publish job only for `securefederatedai` and not forked repos.

## Type of Change (Mandatory)
Specify the type of change being made. 
- Bug fix  (internally for PQ pipeline)

## Description (Mandatory)
Command `fx workspace dockerize --base-image openfl --save` has been failing on and off from last 3-4 days for this model and this is leading to PQ pipeline failure. This mostly occurs due to space constraint of the runner machine.

We tried reproducing this issue on our local Azure VMs but it was always successful (as the machine size is higher than GitHub runners)

On GitHub, the failure is intermittent - for e.g. [3.10 success and 3.11 failure](https://github.com/noopurintel/openfl/actions/runs/14462060255)

## Testing
PQ pipeline from my branch - https://github.com/noopurintel/openfl/actions/runs/14462248451
