### PR TITLE
WIP: Added `calling_workflow` input & included a FedEval testcase in PR pipeline

### DIFF
--- a/.github/workflows/pq_pipeline.yml
+++ b/.github/workflows/pq_pipeline.yml
@@ -34,35 +34,35 @@ jobs:
       run: |
         echo "Commit ID used: ${{ steps.set_commit_id.outputs.commit_id }}" >> $GITHUB_STEP_SUMMARY
 
-  # wf_mnist_local_runtime:
-  #   if: |
-  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-  #     (github.event_name == 'workflow_dispatch')
-  #   name: Workflow MNIST Local Runtime
-  #   needs: set_commit_id_for_all_jobs
-  #   uses: ./.github/workflows/workflow_interface_101_mnist.yml
-  #   with:
-  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  wf_mnist_local_runtime:
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
+    name: Workflow MNIST Local Runtime
+    needs: set_commit_id_for_all_jobs
+    uses: ./.github/workflows/workflow_interface_101_mnist.yml
+    with:
+      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  # wf_watermark_e2e:
-  #   if: |
-  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-  #     (github.event_name == 'workflow_dispatch')
-  #   name: Workflow Watermarking Federated Runtime E2E
-  #   needs: wf_mnist_local_runtime
-  #   uses: ./.github/workflows/wf_watermarking_fed_runtime.yml
-  #   with:
-  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  wf_watermark_e2e:
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
+    name: Workflow Watermarking Federated Runtime E2E
+    needs: wf_mnist_local_runtime
+    uses: ./.github/workflows/wf_watermarking_fed_runtime.yml
+    with:
+      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  # wf_secagg_e2e:
-  #   if: |
-  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-  #     (github.event_name == 'workflow_dispatch')
-  #   name: Workflow Secure Aggregation Federated Runtime E2E
-  #   needs: wf_watermark_e2e
-  #   uses: ./.github/workflows/wf_secagg_fed_runtime.yml
-  #   with:
-  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  wf_secagg_e2e:
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
+    name: Workflow Secure Aggregation Federated Runtime E2E
+    needs: wf_watermark_e2e
+    uses: ./.github/workflows/wf_secagg_fed_runtime.yml
+    with:
+      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
   task_runner_e2e:
     if: |

--- a/.github/workflows/pq_pipeline.yml
+++ b/.github/workflows/pq_pipeline.yml
@@ -75,132 +75,132 @@ jobs:
       commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
       calling_workflow: "pq"
 
-  # task_runner_resiliency_e2e:
-  #   if: |
-  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-  #     (github.event_name == 'workflow_dispatch')
-  #   name: TaskRunner Resiliency E2E
-  #   needs: task_runner_e2e
-  #   uses: ./.github/workflows/task_runner_resiliency_e2e.yml
-  #   with:
-  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  task_runner_resiliency_e2e:
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
+    name: TaskRunner Resiliency E2E
+    needs: task_runner_e2e
+    uses: ./.github/workflows/task_runner_resiliency_e2e.yml
+    with:
+      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
   task_runner_fedeval_e2e:
     if: |
       (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
       (github.event_name == 'workflow_dispatch')
     name: TaskRunner FedEval E2E
-    # needs: task_runner_e2e
+    needs: task_runner_e2e
     uses: ./.github/workflows/task_runner_fedeval_e2e.yml
     with:
       commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
       calling_workflow: "pq"
 
-  # task_runner_secure_agg_e2e:
-  #   if: |
-  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-  #     (github.event_name == 'workflow_dispatch')
-  #   name: TaskRunner Secure Aggregation E2E
-  #   needs: set_commit_id_for_all_jobs
-  #   uses: ./.github/workflows/task_runner_secure_agg_e2e.yml
-  #   with:
-  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  task_runner_secure_agg_e2e:
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
+    name: TaskRunner Secure Aggregation E2E
+    needs: set_commit_id_for_all_jobs
+    uses: ./.github/workflows/task_runner_secure_agg_e2e.yml
+    with:
+      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  # task_runner_straggler_e2e:
-  #   if: |
-  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-  #     (github.event_name == 'workflow_dispatch')
-  #   name: TaskRunner Straggler E2E
-  #   needs: task_runner_resiliency_e2e
-  #   uses: ./.github/workflows/task_runner_straggler_e2e.yml
-  #   with:
-  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  task_runner_straggler_e2e:
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
+    name: TaskRunner Straggler E2E
+    needs: task_runner_resiliency_e2e
+    uses: ./.github/workflows/task_runner_straggler_e2e.yml
+    with:
+      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  # # run basic dockerized test with keras/mnist
-  # task_runner_dockerized_e2e:
-  #   if: |
-  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-  #     (github.event_name == 'workflow_dispatch')
-  #   name: TaskRunner Dockerized E2E
-  #   needs: task_runner_straggler_e2e
-  #   uses: ./.github/workflows/task_runner_dockerized_ws_e2e.yml
-  #   with:
-  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # run basic dockerized test with keras/mnist
+  task_runner_dockerized_e2e:
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
+    name: TaskRunner Dockerized E2E
+    needs: task_runner_straggler_e2e
+    uses: ./.github/workflows/task_runner_dockerized_ws_e2e.yml
+    with:
+      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  # # run testssl for task runner
-  # task_runner_secret_ssl_e2e:
-  #   if: |
-  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-  #     (github.event_name == 'workflow_dispatch')
-  #   name: TaskRunner Secret SSL E2E
-  #   needs: set_commit_id_for_all_jobs
-  #   uses: ./.github/workflows/task_runner_secret_tls_e2e.yml
-  #   with:
-  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # run testssl for task runner
+  task_runner_secret_ssl_e2e:
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
+    name: TaskRunner Secret SSL E2E
+    needs: set_commit_id_for_all_jobs
+    uses: ./.github/workflows/task_runner_secret_tls_e2e.yml
+    with:
+      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  # # run flower app with pytorch
-  # task_runner_flower_app_pytorch:
-  #   if: |
-  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-  #     (github.event_name == 'workflow_dispatch')
-  #   name: TaskRunner Flower App Pytorch E2E
-  #   needs: set_commit_id_for_all_jobs
-  #   uses: ./.github/workflows/task_runner_flower_e2e.yml
-  #   with:
-  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # run flower app with pytorch
+  task_runner_flower_app_pytorch:
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
+    name: TaskRunner Flower App Pytorch E2E
+    needs: set_commit_id_for_all_jobs
+    uses: ./.github/workflows/task_runner_flower_e2e.yml
+    with:
+      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  # run_trivy:
-  #   if: |
-  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-  #     (github.event_name == 'workflow_dispatch')
-  #   name: Run Trivy Code Scanner
-  #   needs: set_commit_id_for_all_jobs
-  #   permissions:
-  #     contents: read # for actions/checkout to fetch code
-  #     security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-  #     actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-  #   uses: ./.github/workflows/trivy.yml
-  #   with:
-  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  run_trivy:
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
+    name: Run Trivy Code Scanner
+    needs: set_commit_id_for_all_jobs
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    uses: ./.github/workflows/trivy.yml
+    with:
+      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  # run_bandit:
-  #   if: |
-  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-  #     (github.event_name == 'workflow_dispatch')
-  #   name: Run Bandit Code Scanner
-  #   needs: set_commit_id_for_all_jobs
-  #   permissions:
-  #     contents: read # for actions/checkout to fetch code
-  #     security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-  #     actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-  #   uses: ./.github/workflows/bandit.yml
-  #   with:
-  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  run_bandit:
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
+    name: Run Bandit Code Scanner
+    needs: set_commit_id_for_all_jobs
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    uses: ./.github/workflows/bandit.yml
+    with:
+      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  # # publish nightly package to PyPI
-  # # enable this job only for securefederatedai and not forked repos
-  # publish_package:
-  #   if: |
-  #     (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.repository_owner == 'securefederatedai'
-  #   name: Publish Nightly Package to PyPI
-  #   permissions:
-  #     id-token: write
-  #   needs: [
-  #     wf_mnist_local_runtime,
-  #     wf_watermark_e2e,
-  #     wf_secagg_e2e,
-  #     task_runner_e2e,
-  #     task_runner_resiliency_e2e,
-  #     task_runner_fedeval_e2e,
-  #     task_runner_secure_agg_e2e,
-  #     task_runner_straggler_e2e,
-  #     task_runner_dockerized_e2e,
-  #     task_runner_secret_ssl_e2e,
-  #     task_runner_flower_app_pytorch,
-  #     run_trivy,
-  #     run_bandit
-  #   ]
-  #   uses: ./.github/workflows/publish_nightly_package.yml
-  #   with:
-  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
-  #   secrets: inherit
+  # publish nightly package to PyPI
+  # enable this job only for securefederatedai and not forked repos
+  publish_package:
+    if: |
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.repository_owner == 'securefederatedai'
+    name: Publish Nightly Package to PyPI
+    permissions:
+      id-token: write
+    needs: [
+      wf_mnist_local_runtime,
+      wf_watermark_e2e,
+      wf_secagg_e2e,
+      task_runner_e2e,
+      task_runner_resiliency_e2e,
+      task_runner_fedeval_e2e,
+      task_runner_secure_agg_e2e,
+      task_runner_straggler_e2e,
+      task_runner_dockerized_e2e,
+      task_runner_secret_ssl_e2e,
+      task_runner_flower_app_pytorch,
+      run_trivy,
+      run_bandit
+    ]
+    uses: ./.github/workflows/publish_nightly_package.yml
+    with:
+      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+    secrets: inherit

--- a/.github/workflows/pq_pipeline.yml
+++ b/.github/workflows/pq_pipeline.yml
@@ -34,35 +34,35 @@ jobs:
       run: |
         echo "Commit ID used: ${{ steps.set_commit_id.outputs.commit_id }}" >> $GITHUB_STEP_SUMMARY
 
-  wf_mnist_local_runtime:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: Workflow MNIST Local Runtime
-    needs: set_commit_id_for_all_jobs
-    uses: ./.github/workflows/workflow_interface_101_mnist.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # wf_mnist_local_runtime:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: Workflow MNIST Local Runtime
+  #   needs: set_commit_id_for_all_jobs
+  #   uses: ./.github/workflows/workflow_interface_101_mnist.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  wf_watermark_e2e:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: Workflow Watermarking Federated Runtime E2E
-    needs: wf_mnist_local_runtime
-    uses: ./.github/workflows/wf_watermarking_fed_runtime.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # wf_watermark_e2e:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: Workflow Watermarking Federated Runtime E2E
+  #   needs: wf_mnist_local_runtime
+  #   uses: ./.github/workflows/wf_watermarking_fed_runtime.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  wf_secagg_e2e:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: Workflow Secure Aggregation Federated Runtime E2E
-    needs: wf_watermark_e2e
-    uses: ./.github/workflows/wf_secagg_fed_runtime.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # wf_secagg_e2e:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: Workflow Secure Aggregation Federated Runtime E2E
+  #   needs: wf_watermark_e2e
+  #   uses: ./.github/workflows/wf_secagg_fed_runtime.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
   task_runner_e2e:
     if: |
@@ -75,15 +75,15 @@ jobs:
       commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
       calling_workflow: "pq"
 
-  task_runner_resiliency_e2e:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: TaskRunner Resiliency E2E
-    needs: task_runner_e2e
-    uses: ./.github/workflows/task_runner_resiliency_e2e.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # task_runner_resiliency_e2e:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: TaskRunner Resiliency E2E
+  #   needs: task_runner_e2e
+  #   uses: ./.github/workflows/task_runner_resiliency_e2e.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
   task_runner_fedeval_e2e:
     if: |
@@ -96,111 +96,111 @@ jobs:
       commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
       calling_workflow: "pq"
 
-  task_runner_secure_agg_e2e:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: TaskRunner Secure Aggregation E2E
-    needs: set_commit_id_for_all_jobs
-    uses: ./.github/workflows/task_runner_secure_agg_e2e.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # task_runner_secure_agg_e2e:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: TaskRunner Secure Aggregation E2E
+  #   needs: set_commit_id_for_all_jobs
+  #   uses: ./.github/workflows/task_runner_secure_agg_e2e.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  task_runner_straggler_e2e:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: TaskRunner Straggler E2E
-    needs: task_runner_resiliency_e2e
-    uses: ./.github/workflows/task_runner_straggler_e2e.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # task_runner_straggler_e2e:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: TaskRunner Straggler E2E
+  #   needs: task_runner_resiliency_e2e
+  #   uses: ./.github/workflows/task_runner_straggler_e2e.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  # run basic dockerized test with keras/mnist
-  task_runner_dockerized_e2e:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: TaskRunner Dockerized E2E
-    needs: task_runner_straggler_e2e
-    uses: ./.github/workflows/task_runner_dockerized_ws_e2e.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # # run basic dockerized test with keras/mnist
+  # task_runner_dockerized_e2e:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: TaskRunner Dockerized E2E
+  #   needs: task_runner_straggler_e2e
+  #   uses: ./.github/workflows/task_runner_dockerized_ws_e2e.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  # run testssl for task runner
-  task_runner_secret_ssl_e2e:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: TaskRunner Secret SSL E2E
-    needs: set_commit_id_for_all_jobs
-    uses: ./.github/workflows/task_runner_secret_tls_e2e.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # # run testssl for task runner
+  # task_runner_secret_ssl_e2e:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: TaskRunner Secret SSL E2E
+  #   needs: set_commit_id_for_all_jobs
+  #   uses: ./.github/workflows/task_runner_secret_tls_e2e.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  # run flower app with pytorch
-  task_runner_flower_app_pytorch:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: TaskRunner Flower App Pytorch E2E
-    needs: set_commit_id_for_all_jobs
-    uses: ./.github/workflows/task_runner_flower_e2e.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # # run flower app with pytorch
+  # task_runner_flower_app_pytorch:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: TaskRunner Flower App Pytorch E2E
+  #   needs: set_commit_id_for_all_jobs
+  #   uses: ./.github/workflows/task_runner_flower_e2e.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  run_trivy:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: Run Trivy Code Scanner
-    needs: set_commit_id_for_all_jobs
-    permissions:
-      contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-    uses: ./.github/workflows/trivy.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # run_trivy:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: Run Trivy Code Scanner
+  #   needs: set_commit_id_for_all_jobs
+  #   permissions:
+  #     contents: read # for actions/checkout to fetch code
+  #     security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+  #     actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+  #   uses: ./.github/workflows/trivy.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  run_bandit:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    name: Run Bandit Code Scanner
-    needs: set_commit_id_for_all_jobs
-    permissions:
-      contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-    uses: ./.github/workflows/bandit.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  # run_bandit:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   name: Run Bandit Code Scanner
+  #   needs: set_commit_id_for_all_jobs
+  #   permissions:
+  #     contents: read # for actions/checkout to fetch code
+  #     security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+  #     actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+  #   uses: ./.github/workflows/bandit.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
 
-  # publish nightly package to PyPI
-  # enable this job only for securefederatedai and not forked repos
-  publish_package:
-    if: |
-      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.repository_owner == 'securefederatedai'
-    name: Publish Nightly Package to PyPI
-    permissions:
-      id-token: write
-    needs: [
-      wf_mnist_local_runtime,
-      wf_watermark_e2e,
-      wf_secagg_e2e,
-      task_runner_e2e,
-      task_runner_resiliency_e2e,
-      task_runner_fedeval_e2e,
-      task_runner_secure_agg_e2e,
-      task_runner_straggler_e2e,
-      task_runner_dockerized_e2e,
-      task_runner_secret_ssl_e2e,
-      task_runner_flower_app_pytorch,
-      run_trivy,
-      run_bandit
-    ]
-    uses: ./.github/workflows/publish_nightly_package.yml
-    with:
-      commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
-    secrets: inherit
+  # # publish nightly package to PyPI
+  # # enable this job only for securefederatedai and not forked repos
+  # publish_package:
+  #   if: |
+  #     (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.repository_owner == 'securefederatedai'
+  #   name: Publish Nightly Package to PyPI
+  #   permissions:
+  #     id-token: write
+  #   needs: [
+  #     wf_mnist_local_runtime,
+  #     wf_watermark_e2e,
+  #     wf_secagg_e2e,
+  #     task_runner_e2e,
+  #     task_runner_resiliency_e2e,
+  #     task_runner_fedeval_e2e,
+  #     task_runner_secure_agg_e2e,
+  #     task_runner_straggler_e2e,
+  #     task_runner_dockerized_e2e,
+  #     task_runner_secret_ssl_e2e,
+  #     task_runner_flower_app_pytorch,
+  #     run_trivy,
+  #     run_bandit
+  #   ]
+  #   uses: ./.github/workflows/publish_nightly_package.yml
+  #   with:
+  #     commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+  #   secrets: inherit

--- a/.github/workflows/pq_pipeline.yml
+++ b/.github/workflows/pq_pipeline.yml
@@ -90,7 +90,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
       (github.event_name == 'workflow_dispatch')
     name: TaskRunner FedEval E2E
-    needs: task_runner_e2e
+    # needs: task_runner_e2e
     uses: ./.github/workflows/task_runner_fedeval_e2e.yml
     with:
       commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}

--- a/.github/workflows/pq_pipeline.yml
+++ b/.github/workflows/pq_pipeline.yml
@@ -73,6 +73,7 @@ jobs:
     uses: ./.github/workflows/task_runner_basic_e2e.yml
     with:
       commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+      calling_workflow: "pq"
 
   task_runner_resiliency_e2e:
     if: |
@@ -93,6 +94,7 @@ jobs:
     uses: ./.github/workflows/task_runner_fedeval_e2e.yml
     with:
       commit_id: ${{ needs.set_commit_id_for_all_jobs.outputs.commit_id }}
+      calling_workflow: "pq"
 
   task_runner_secure_agg_e2e:
     if: |

--- a/.github/workflows/pr_pipeline.yml
+++ b/.github/workflows/pr_pipeline.yml
@@ -18,43 +18,43 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # bandit_code_scan:
-  #   name: Bandit Code Scan
-  #   # DO NOT remove the permissions block. Without this, these permissions are assumed as none in the called workflow and the workflow fails.
-  #   permissions:
-  #     contents: read # for actions/checkout to fetch code
-  #     security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-  #     actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-  #   uses: ./.github/workflows/bandit.yml
+  bandit_code_scan:
+    name: Bandit Code Scan
+    # DO NOT remove the permissions block. Without this, these permissions are assumed as none in the called workflow and the workflow fails.
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    uses: ./.github/workflows/bandit.yml
 
-  # check_code_format:
-  #   name: Check code format
-  #   uses: ./.github/workflows/lint.yml
+  check_code_format:
+    name: Check code format
+    uses: ./.github/workflows/lint.yml
 
-  # docker_bench_security:
-  #   name: Docker Bench for Security
-  #   uses: ./.github/workflows/docker-bench-security.yml
+  docker_bench_security:
+    name: Docker Bench for Security
+    uses: ./.github/workflows/docker-bench-security.yml
 
-  # fr_301_watermark_nb_run:
-  #   name: Federated Runtime Watermarking E2E
-  #   uses: ./.github/workflows/wf_watermarking_fed_runtime.yml
+  fr_301_watermark_nb_run:
+    name: Federated Runtime Watermarking E2E
+    uses: ./.github/workflows/wf_watermarking_fed_runtime.yml
 
-  # gandlf_taskrunner:
-  #   name: GaNDLF TaskRunner E2E
-  #   uses: ./.github/workflows/gandlf.yml
+  gandlf_taskrunner:
+    name: GaNDLF TaskRunner E2E
+    uses: ./.github/workflows/gandlf.yml
 
-  # hadolint_security_scan:
-  #   name: Hadolint Security Scan
-  #   uses: ./.github/workflows/hadolint.yml
+  hadolint_security_scan:
+    name: Hadolint Security Scan
+    uses: ./.github/workflows/hadolint.yml
 
-  # pytest_coverage:
-  #   name: Pytest and code coverage
-  #   uses: ./.github/workflows/pytest_coverage.yml
+  pytest_coverage:
+    name: Pytest and code coverage
+    uses: ./.github/workflows/pytest_coverage.yml
 
-  # windows:
-  #   name: Windows pytest coverage and workspace runs
-  #   uses: ./.github/workflows/windows.yml
-    
+  windows:
+    name: Windows pytest coverage and workspace runs
+    uses: ./.github/workflows/windows.yml
+
   task_runner_e2e:
     name: TaskRunner E2E
     uses: ./.github/workflows/task_runner_basic_e2e.yml
@@ -67,30 +67,30 @@ jobs:
     with:
       calling_workflow: "pr"
 
-  # task_runner_resiliency_e2e:
-  #   name: TaskRunner Resiliency E2E
-  #   uses: ./.github/workflows/task_runner_resiliency_e2e.yml
+  task_runner_resiliency_e2e:
+    name: TaskRunner Resiliency E2E
+    uses: ./.github/workflows/task_runner_resiliency_e2e.yml
 
-  # task_runner_secure_agg_e2e:
-  #   name: TaskRunner Secure Aggregation E2E
-  #   uses: ./.github/workflows/task_runner_secure_agg_e2e.yml
+  task_runner_secure_agg_e2e:
+    name: TaskRunner Secure Aggregation E2E
+    uses: ./.github/workflows/task_runner_secure_agg_e2e.yml
 
-  # tr_docker_gramine_direct:
-  #   name: TaskRunner (docker/gramine-direct)
-  #   uses: ./.github/workflows/tr_docker_gramine_direct.yml
+  tr_docker_gramine_direct:
+    name: TaskRunner (docker/gramine-direct)
+    uses: ./.github/workflows/tr_docker_gramine_direct.yml
 
-  # tr_docker_native:
-  #   name: TaskRunner (docker/native)
-  #   uses: ./.github/workflows/tr_docker_native.yml
+  tr_docker_native:
+    name: TaskRunner (docker/native)
+    uses: ./.github/workflows/tr_docker_native.yml
 
-  # wf_functional_e2e:
-  #   name: Workflow Functional E2E
-  #   uses: ./.github/workflows/wf_functional_e2e.yml
+  wf_functional_e2e:
+    name: Workflow Functional E2E
+    uses: ./.github/workflows/wf_functional_e2e.yml
 
-  # workflow_interface_101_mnist:
-  #   name: Workflow Interface 101 MNIST Notebook
-  #   uses: ./.github/workflows/workflow_interface_101_mnist.yml
+  workflow_interface_101_mnist:
+    name: Workflow Interface 101 MNIST Notebook
+    uses: ./.github/workflows/workflow_interface_101_mnist.yml
 
-  # workflow_interface_tests:
-  #   name: Workflow Interface Tests
-  #   uses: ./.github/workflows/experimental_workflow_tests.yml
+  workflow_interface_tests:
+    name: Workflow Interface Tests
+    uses: ./.github/workflows/experimental_workflow_tests.yml

--- a/.github/workflows/pr_pipeline.yml
+++ b/.github/workflows/pr_pipeline.yml
@@ -18,71 +18,79 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  bandit_code_scan:
-    name: Bandit Code Scan
-    # DO NOT remove the permissions block. Without this, these permissions are assumed as none in the called workflow and the workflow fails.
-    permissions:
-      contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-    uses: ./.github/workflows/bandit.yml
+  # bandit_code_scan:
+  #   name: Bandit Code Scan
+  #   # DO NOT remove the permissions block. Without this, these permissions are assumed as none in the called workflow and the workflow fails.
+  #   permissions:
+  #     contents: read # for actions/checkout to fetch code
+  #     security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+  #     actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+  #   uses: ./.github/workflows/bandit.yml
 
-  check_code_format:
-    name: Check code format
-    uses: ./.github/workflows/lint.yml
+  # check_code_format:
+  #   name: Check code format
+  #   uses: ./.github/workflows/lint.yml
 
-  docker_bench_security:
-    name: Docker Bench for Security
-    uses: ./.github/workflows/docker-bench-security.yml
+  # docker_bench_security:
+  #   name: Docker Bench for Security
+  #   uses: ./.github/workflows/docker-bench-security.yml
 
-  fr_301_watermark_nb_run:
-    name: Federated Runtime Watermarking E2E
-    uses: ./.github/workflows/wf_watermarking_fed_runtime.yml
+  # fr_301_watermark_nb_run:
+  #   name: Federated Runtime Watermarking E2E
+  #   uses: ./.github/workflows/wf_watermarking_fed_runtime.yml
 
-  gandlf_taskrunner:
-    name: GaNDLF TaskRunner E2E
-    uses: ./.github/workflows/gandlf.yml
+  # gandlf_taskrunner:
+  #   name: GaNDLF TaskRunner E2E
+  #   uses: ./.github/workflows/gandlf.yml
 
-  hadolint_security_scan:
-    name: Hadolint Security Scan
-    uses: ./.github/workflows/hadolint.yml
+  # hadolint_security_scan:
+  #   name: Hadolint Security Scan
+  #   uses: ./.github/workflows/hadolint.yml
 
-  pytest_coverage:
-    name: Pytest and code coverage
-    uses: ./.github/workflows/pytest_coverage.yml
+  # pytest_coverage:
+  #   name: Pytest and code coverage
+  #   uses: ./.github/workflows/pytest_coverage.yml
 
-  windows:
-    name: Windows pytest coverage and workspace runs
-    uses: ./.github/workflows/windows.yml
+  # windows:
+  #   name: Windows pytest coverage and workspace runs
+  #   uses: ./.github/workflows/windows.yml
     
   task_runner_e2e:
     name: TaskRunner E2E
     uses: ./.github/workflows/task_runner_basic_e2e.yml
-  
-  task_runner_resiliency_e2e:
-    name: TaskRunner Resiliency E2E
-    uses: ./.github/workflows/task_runner_resiliency_e2e.yml
+    with:
+      calling_workflow: "pr"
 
-  task_runner_secure_agg_e2e:
-    name: TaskRunner Secure Aggregation E2E
-    uses: ./.github/workflows/task_runner_secure_agg_e2e.yml
+  task_runner_fedeval_e2e:
+    name: TaskRunner FedEval E2E
+    uses: ./.github/workflows/task_runner_fedeval_e2e.yml
+    with:
+      calling_workflow: "pr"
 
-  tr_docker_gramine_direct:
-    name: TaskRunner (docker/gramine-direct)
-    uses: ./.github/workflows/tr_docker_gramine_direct.yml
+  # task_runner_resiliency_e2e:
+  #   name: TaskRunner Resiliency E2E
+  #   uses: ./.github/workflows/task_runner_resiliency_e2e.yml
 
-  tr_docker_native:
-    name: TaskRunner (docker/native)
-    uses: ./.github/workflows/tr_docker_native.yml
+  # task_runner_secure_agg_e2e:
+  #   name: TaskRunner Secure Aggregation E2E
+  #   uses: ./.github/workflows/task_runner_secure_agg_e2e.yml
 
-  wf_functional_e2e:
-    name: Workflow Functional E2E
-    uses: ./.github/workflows/wf_functional_e2e.yml
+  # tr_docker_gramine_direct:
+  #   name: TaskRunner (docker/gramine-direct)
+  #   uses: ./.github/workflows/tr_docker_gramine_direct.yml
 
-  workflow_interface_101_mnist:
-    name: Workflow Interface 101 MNIST Notebook
-    uses: ./.github/workflows/workflow_interface_101_mnist.yml
+  # tr_docker_native:
+  #   name: TaskRunner (docker/native)
+  #   uses: ./.github/workflows/tr_docker_native.yml
 
-  workflow_interface_tests:
-    name: Workflow Interface Tests
-    uses: ./.github/workflows/experimental_workflow_tests.yml
+  # wf_functional_e2e:
+  #   name: Workflow Functional E2E
+  #   uses: ./.github/workflows/wf_functional_e2e.yml
+
+  # workflow_interface_101_mnist:
+  #   name: Workflow Interface 101 MNIST Notebook
+  #   uses: ./.github/workflows/workflow_interface_101_mnist.yml
+
+  # workflow_interface_tests:
+  #   name: Workflow Interface Tests
+  #   uses: ./.github/workflows/experimental_workflow_tests.yml

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -182,224 +182,224 @@ jobs:
         with:
           test_type: "With_TLS"
 
-  test_without_tls:
-    name: Without TLS
-    needs: input_selection
-    if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_without_tls'
-    runs-on: ubuntu-22.04
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_non_tls) }}
-        python_version: ${{ fromJson(needs.input_selection.outputs.selected_python_for_non_tls) }}
-        exclude: # Keras does not support Python 3.12
-          - model_name: "keras/mnist"
-            python_version: "3.12"
-          - model_name: "keras/jax/mnist"
-            python_version: "3.12"
-          - model_name: "keras/torch/mnist" 
-            python_version: "3.12"
-      fail-fast: false # do not immediately fail if one of the combinations fail
+  # test_without_tls:
+  #   name: Without TLS
+  #   needs: input_selection
+  #   if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_without_tls'
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: 30
+  #   strategy:
+  #     matrix:
+  #       model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_non_tls) }}
+  #       python_version: ${{ fromJson(needs.input_selection.outputs.selected_python_for_non_tls) }}
+  #       exclude: # Keras does not support Python 3.12
+  #         - model_name: "keras/mnist"
+  #           python_version: "3.12"
+  #         - model_name: "keras/jax/mnist"
+  #           python_version: "3.12"
+  #         - model_name: "keras/torch/mnist" 
+  #           python_version: "3.12"
+  #     fail-fast: false # do not immediately fail if one of the combinations fail
 
-    env:
-      MODEL_NAME: ${{ matrix.model_name }}
-      PYTHON_VERSION: ${{ matrix.python_version }}
+  #   env:
+  #     MODEL_NAME: ${{ matrix.model_name }}
+  #     PYTHON_VERSION: ${{ matrix.python_version }}
 
-    steps:
-      - name: Checkout OpenFL repository
-        id: checkout_openfl
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.COMMIT_ID }}
+  #   steps:
+  #     - name: Checkout OpenFL repository
+  #       id: checkout_openfl
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ env.COMMIT_ID }}
 
-      - name: Pre test run
-        uses: ./.github/actions/tr_pre_test_run
-        if: ${{ always() }}
+  #     - name: Pre test run
+  #       uses: ./.github/actions/tr_pre_test_run
+  #       if: ${{ always() }}
 
-      - name: Run Task Runner E2E tests without TLS
-        id: run_tests
-        run: |
-          python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
-          -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
-          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_tls
-          echo "Task runner end to end test run completed"
+  #     - name: Run Task Runner E2E tests without TLS
+  #       id: run_tests
+  #       run: |
+  #         python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+  #         -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
+  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_tls
+  #         echo "Task runner end to end test run completed"
 
-      - name: Post test run
-        uses: ./.github/actions/tr_post_test_run
-        if: ${{ always() }}
-        with:
-          test_type: "Without_TLS"
+  #     - name: Post test run
+  #       uses: ./.github/actions/tr_post_test_run
+  #       if: ${{ always() }}
+  #       with:
+  #         test_type: "Without_TLS"
 
-  test_without_client_auth:
-    name: Without Client Auth
-    needs: input_selection
-    if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_without_client_auth'
-    runs-on: ubuntu-22.04
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_no_client_auth) }}
-        python_version: ${{ fromJson(needs.input_selection.outputs.selected_python_for_no_client_auth) }}
-        exclude: # Keras does not support Python 3.12
-          - model_name: "keras/mnist"
-            python_version: "3.12"
-          - model_name: "keras/jax/mnist"
-            python_version: "3.12"
-          - model_name: "keras/torch/mnist" 
-            python_version: "3.12"
-      fail-fast: false # do not immediately fail if one of the combinations fail
+  # test_without_client_auth:
+  #   name: Without Client Auth
+  #   needs: input_selection
+  #   if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_without_client_auth'
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: 30
+  #   strategy:
+  #     matrix:
+  #       model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_no_client_auth) }}
+  #       python_version: ${{ fromJson(needs.input_selection.outputs.selected_python_for_no_client_auth) }}
+  #       exclude: # Keras does not support Python 3.12
+  #         - model_name: "keras/mnist"
+  #           python_version: "3.12"
+  #         - model_name: "keras/jax/mnist"
+  #           python_version: "3.12"
+  #         - model_name: "keras/torch/mnist" 
+  #           python_version: "3.12"
+  #     fail-fast: false # do not immediately fail if one of the combinations fail
 
-    env:
-      MODEL_NAME: ${{ matrix.model_name }}
-      PYTHON_VERSION: ${{ matrix.python_version }}
+  #   env:
+  #     MODEL_NAME: ${{ matrix.model_name }}
+  #     PYTHON_VERSION: ${{ matrix.python_version }}
 
-    steps:
-      - name: Checkout OpenFL repository
-        id: checkout_openfl
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.COMMIT_ID }}
+  #   steps:
+  #     - name: Checkout OpenFL repository
+  #       id: checkout_openfl
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ env.COMMIT_ID }}
 
-      - name: Pre test run
-        uses: ./.github/actions/tr_pre_test_run
-        if: ${{ always() }}
+  #     - name: Pre test run
+  #       uses: ./.github/actions/tr_pre_test_run
+  #       if: ${{ always() }}
 
-      - name: Run Task Runner E2E tests without TLS
-        id: run_tests
-        run: |
-          python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
-          -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
-          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_client_auth
-          echo "Task runner end to end test run completed"
+  #     - name: Run Task Runner E2E tests without TLS
+  #       id: run_tests
+  #       run: |
+  #         python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+  #         -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
+  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_client_auth
+  #         echo "Task runner end to end test run completed"
 
-      - name: Post test run
-        uses: ./.github/actions/tr_post_test_run
-        if: ${{ always() }}
-        with:
-          test_type: 'Without_Client_Auth'
+  #     - name: Post test run
+  #       uses: ./.github/actions/tr_post_test_run
+  #       if: ${{ always() }}
+  #       with:
+  #         test_type: 'Without_Client_Auth'
 
-  test_memory_logs:
-    name: With Memory Logs
-    needs: input_selection
-    if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_memory_logs'
-    runs-on: ubuntu-22.04
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_memory_logs) }}
-        python_version: ${{ fromJson(needs.input_selection.outputs.selected_python_for_memory_logs) }}
-        exclude: # Keras does not support Python 3.12
-          - model_name: "keras/mnist"
-            python_version: "3.12"
-          - model_name: "keras/jax/mnist"
-            python_version: "3.12"
-          - model_name: "keras/torch/mnist" 
-            python_version: "3.12"
-      fail-fast: false # do not immediately fail if one of the combinations fail
+  # test_memory_logs:
+  #   name: With Memory Logs
+  #   needs: input_selection
+  #   if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_memory_logs'
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: 30
+  #   strategy:
+  #     matrix:
+  #       model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_memory_logs) }}
+  #       python_version: ${{ fromJson(needs.input_selection.outputs.selected_python_for_memory_logs) }}
+  #       exclude: # Keras does not support Python 3.12
+  #         - model_name: "keras/mnist"
+  #           python_version: "3.12"
+  #         - model_name: "keras/jax/mnist"
+  #           python_version: "3.12"
+  #         - model_name: "keras/torch/mnist" 
+  #           python_version: "3.12"
+  #     fail-fast: false # do not immediately fail if one of the combinations fail
 
-    env:
-      MODEL_NAME: ${{ matrix.model_name }}
-      PYTHON_VERSION: ${{ matrix.python_version }}
+  #   env:
+  #     MODEL_NAME: ${{ matrix.model_name }}
+  #     PYTHON_VERSION: ${{ matrix.python_version }}
 
-    steps:
-      - name: Checkout OpenFL repository
-        id: checkout_openfl
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.COMMIT_ID }}
+  #   steps:
+  #     - name: Checkout OpenFL repository
+  #       id: checkout_openfl
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ env.COMMIT_ID }}
 
-      - name: Pre test run
-        uses: ./.github/actions/tr_pre_test_run
-        if: ${{ always() }}
+  #     - name: Pre test run
+  #       uses: ./.github/actions/tr_pre_test_run
+  #       if: ${{ always() }}
 
-      - name: Run Task Runner E2E tests with TLS and memory logs
-        id: run_tests
-        run: |
-          python -m pytest -s tests/end_to_end/test_suites/memory_logs_tests.py \
-          -k test_log_memory_usage_basic --model_name ${{ env.MODEL_NAME }} \
-          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} \
-          --log_memory_usage
-          echo "Task runner memory logs test run completed"
+  #     - name: Run Task Runner E2E tests with TLS and memory logs
+  #       id: run_tests
+  #       run: |
+  #         python -m pytest -s tests/end_to_end/test_suites/memory_logs_tests.py \
+  #         -k test_log_memory_usage_basic --model_name ${{ env.MODEL_NAME }} \
+  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} \
+  #         --log_memory_usage
+  #         echo "Task runner memory logs test run completed"
 
-      - name: Post test run
-        uses: ./.github/actions/tr_post_test_run
-        if: ${{ always() }}
-        with:
-          test_type: "With_Memory_Logs"
+  #     - name: Post test run
+  #       uses: ./.github/actions/tr_post_test_run
+  #       if: ${{ always() }}
+  #       with:
+  #         test_type: "With_Memory_Logs"
 
-  test_straggler_check:
-    name: With TLS (torch/mnist_straggler_check, 3.10)
-    runs-on: ubuntu-22.04
-    timeout-minutes: 30
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch') ||
-      (github.event.pull_request.draft == false) ||
-      (needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_straggler_check')
+  # test_straggler_check:
+  #   name: With TLS (torch/mnist_straggler_check, 3.10)
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: 30
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch') ||
+  #     (github.event.pull_request.draft == false) ||
+  #     (needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_straggler_check')
 
-    env:
-      MODEL_NAME: "torch/mnist_straggler_check"
-      PYTHON_VERSION: "3.10"
+  #   env:
+  #     MODEL_NAME: "torch/mnist_straggler_check"
+  #     PYTHON_VERSION: "3.10"
 
-    steps:
-      - name: Checkout OpenFL repository
-        id: checkout_openfl
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.COMMIT_ID }}
+  #   steps:
+  #     - name: Checkout OpenFL repository
+  #       id: checkout_openfl
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ env.COMMIT_ID }}
 
-      - name: Pre test run
-        uses: ./.github/actions/tr_pre_test_run
-        if: ${{ always() }}
+  #     - name: Pre test run
+  #       uses: ./.github/actions/tr_pre_test_run
+  #       if: ${{ always() }}
 
-      - name: Run Straggler Handling Interface Test
-        id: run_tests
-        run: |
-          python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
-          -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
-          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
-          echo "Straggler handling test run completed"
+  #     - name: Run Straggler Handling Interface Test
+  #       id: run_tests
+  #       run: |
+  #         python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+  #         -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
+  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
+  #         echo "Straggler handling test run completed"
 
-      - name: Post test run
-        uses: ./.github/actions/tr_post_test_run
-        if: ${{ always() }}
-        with:
-          test_type: "With_TLS"
+  #     - name: Post test run
+  #       uses: ./.github/actions/tr_post_test_run
+  #       if: ${{ always() }}
+  #       with:
+  #         test_type: "With_TLS"
 
-  test_eden_compression:
-    name: With TLS (torch/mnist_eden_compression, 3.10)
-    runs-on: ubuntu-22.04
-    timeout-minutes: 30
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch') ||
-      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'eden_compression')) || (needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_eden_compression')
+  # test_eden_compression:
+  #   name: With TLS (torch/mnist_eden_compression, 3.10)
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: 30
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch') ||
+  #     (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'eden_compression')) || (needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_eden_compression')
 
-    env:
-      MODEL_NAME: "torch/mnist_eden_compression"
-      PYTHON_VERSION: "3.10"
+  #   env:
+  #     MODEL_NAME: "torch/mnist_eden_compression"
+  #     PYTHON_VERSION: "3.10"
 
-    steps:
-      - name: Checkout OpenFL repository
-        id: checkout_openfl
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.COMMIT_ID }}
+  #   steps:
+  #     - name: Checkout OpenFL repository
+  #       id: checkout_openfl
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ env.COMMIT_ID }}
 
-      - name: Pre test run
-        uses: ./.github/actions/tr_pre_test_run
-        if: ${{ always() }}
+  #     - name: Pre test run
+  #       uses: ./.github/actions/tr_pre_test_run
+  #       if: ${{ always() }}
 
-      - name: Run Eden Compression Test
-        id: run_tests
-        run: |
-          python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
-          -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
-          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
-          echo "Eden compression test run completed"
+  #     - name: Run Eden Compression Test
+  #       id: run_tests
+  #       run: |
+  #         python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+  #         -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
+  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
+  #         echo "Eden compression test run completed"
 
-      - name: Post test run
-        uses: ./.github/actions/tr_post_test_run
-        if: ${{ always() }}
-        with:
-          test_type: "With_TLS"
+  #     - name: Post test run
+  #       uses: ./.github/actions/tr_post_test_run
+  #       if: ${{ always() }}
+  #       with:
+  #         test_type: "With_TLS"

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -182,224 +182,224 @@ jobs:
         with:
           test_type: "With_TLS"
 
-  # test_without_tls:
-  #   name: Without TLS
-  #   needs: input_selection
-  #   if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_without_tls'
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 30
-  #   strategy:
-  #     matrix:
-  #       model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_non_tls) }}
-  #       python_version: ${{ fromJson(needs.input_selection.outputs.selected_python_for_non_tls) }}
-  #       exclude: # Keras does not support Python 3.12
-  #         - model_name: "keras/mnist"
-  #           python_version: "3.12"
-  #         - model_name: "keras/jax/mnist"
-  #           python_version: "3.12"
-  #         - model_name: "keras/torch/mnist" 
-  #           python_version: "3.12"
-  #     fail-fast: false # do not immediately fail if one of the combinations fail
+  test_without_tls:
+    name: Without TLS
+    needs: input_selection
+    if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_without_tls'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_non_tls) }}
+        python_version: ${{ fromJson(needs.input_selection.outputs.selected_python_for_non_tls) }}
+        exclude: # Keras does not support Python 3.12
+          - model_name: "keras/mnist"
+            python_version: "3.12"
+          - model_name: "keras/jax/mnist"
+            python_version: "3.12"
+          - model_name: "keras/torch/mnist" 
+            python_version: "3.12"
+      fail-fast: false # do not immediately fail if one of the combinations fail
 
-  #   env:
-  #     MODEL_NAME: ${{ matrix.model_name }}
-  #     PYTHON_VERSION: ${{ matrix.python_version }}
+    env:
+      MODEL_NAME: ${{ matrix.model_name }}
+      PYTHON_VERSION: ${{ matrix.python_version }}
 
-  #   steps:
-  #     - name: Checkout OpenFL repository
-  #       id: checkout_openfl
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ env.COMMIT_ID }}
+    steps:
+      - name: Checkout OpenFL repository
+        id: checkout_openfl
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.COMMIT_ID }}
 
-  #     - name: Pre test run
-  #       uses: ./.github/actions/tr_pre_test_run
-  #       if: ${{ always() }}
+      - name: Pre test run
+        uses: ./.github/actions/tr_pre_test_run
+        if: ${{ always() }}
 
-  #     - name: Run Task Runner E2E tests without TLS
-  #       id: run_tests
-  #       run: |
-  #         python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
-  #         -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
-  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_tls
-  #         echo "Task runner end to end test run completed"
+      - name: Run Task Runner E2E tests without TLS
+        id: run_tests
+        run: |
+          python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+          -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
+          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_tls
+          echo "Task runner end to end test run completed"
 
-  #     - name: Post test run
-  #       uses: ./.github/actions/tr_post_test_run
-  #       if: ${{ always() }}
-  #       with:
-  #         test_type: "Without_TLS"
+      - name: Post test run
+        uses: ./.github/actions/tr_post_test_run
+        if: ${{ always() }}
+        with:
+          test_type: "Without_TLS"
 
-  # test_without_client_auth:
-  #   name: Without Client Auth
-  #   needs: input_selection
-  #   if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_without_client_auth'
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 30
-  #   strategy:
-  #     matrix:
-  #       model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_no_client_auth) }}
-  #       python_version: ${{ fromJson(needs.input_selection.outputs.selected_python_for_no_client_auth) }}
-  #       exclude: # Keras does not support Python 3.12
-  #         - model_name: "keras/mnist"
-  #           python_version: "3.12"
-  #         - model_name: "keras/jax/mnist"
-  #           python_version: "3.12"
-  #         - model_name: "keras/torch/mnist" 
-  #           python_version: "3.12"
-  #     fail-fast: false # do not immediately fail if one of the combinations fail
+  test_without_client_auth:
+    name: Without Client Auth
+    needs: input_selection
+    if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_without_client_auth'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_no_client_auth) }}
+        python_version: ${{ fromJson(needs.input_selection.outputs.selected_python_for_no_client_auth) }}
+        exclude: # Keras does not support Python 3.12
+          - model_name: "keras/mnist"
+            python_version: "3.12"
+          - model_name: "keras/jax/mnist"
+            python_version: "3.12"
+          - model_name: "keras/torch/mnist" 
+            python_version: "3.12"
+      fail-fast: false # do not immediately fail if one of the combinations fail
 
-  #   env:
-  #     MODEL_NAME: ${{ matrix.model_name }}
-  #     PYTHON_VERSION: ${{ matrix.python_version }}
+    env:
+      MODEL_NAME: ${{ matrix.model_name }}
+      PYTHON_VERSION: ${{ matrix.python_version }}
 
-  #   steps:
-  #     - name: Checkout OpenFL repository
-  #       id: checkout_openfl
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ env.COMMIT_ID }}
+    steps:
+      - name: Checkout OpenFL repository
+        id: checkout_openfl
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.COMMIT_ID }}
 
-  #     - name: Pre test run
-  #       uses: ./.github/actions/tr_pre_test_run
-  #       if: ${{ always() }}
+      - name: Pre test run
+        uses: ./.github/actions/tr_pre_test_run
+        if: ${{ always() }}
 
-  #     - name: Run Task Runner E2E tests without TLS
-  #       id: run_tests
-  #       run: |
-  #         python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
-  #         -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
-  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_client_auth
-  #         echo "Task runner end to end test run completed"
+      - name: Run Task Runner E2E tests without TLS
+        id: run_tests
+        run: |
+          python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+          -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
+          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_client_auth
+          echo "Task runner end to end test run completed"
 
-  #     - name: Post test run
-  #       uses: ./.github/actions/tr_post_test_run
-  #       if: ${{ always() }}
-  #       with:
-  #         test_type: 'Without_Client_Auth'
+      - name: Post test run
+        uses: ./.github/actions/tr_post_test_run
+        if: ${{ always() }}
+        with:
+          test_type: 'Without_Client_Auth'
 
-  # test_memory_logs:
-  #   name: With Memory Logs
-  #   needs: input_selection
-  #   if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_memory_logs'
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 30
-  #   strategy:
-  #     matrix:
-  #       model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_memory_logs) }}
-  #       python_version: ${{ fromJson(needs.input_selection.outputs.selected_python_for_memory_logs) }}
-  #       exclude: # Keras does not support Python 3.12
-  #         - model_name: "keras/mnist"
-  #           python_version: "3.12"
-  #         - model_name: "keras/jax/mnist"
-  #           python_version: "3.12"
-  #         - model_name: "keras/torch/mnist" 
-  #           python_version: "3.12"
-  #     fail-fast: false # do not immediately fail if one of the combinations fail
+  test_memory_logs:
+    name: With Memory Logs
+    needs: input_selection
+    if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_memory_logs'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_memory_logs) }}
+        python_version: ${{ fromJson(needs.input_selection.outputs.selected_python_for_memory_logs) }}
+        exclude: # Keras does not support Python 3.12
+          - model_name: "keras/mnist"
+            python_version: "3.12"
+          - model_name: "keras/jax/mnist"
+            python_version: "3.12"
+          - model_name: "keras/torch/mnist" 
+            python_version: "3.12"
+      fail-fast: false # do not immediately fail if one of the combinations fail
 
-  #   env:
-  #     MODEL_NAME: ${{ matrix.model_name }}
-  #     PYTHON_VERSION: ${{ matrix.python_version }}
+    env:
+      MODEL_NAME: ${{ matrix.model_name }}
+      PYTHON_VERSION: ${{ matrix.python_version }}
 
-  #   steps:
-  #     - name: Checkout OpenFL repository
-  #       id: checkout_openfl
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ env.COMMIT_ID }}
+    steps:
+      - name: Checkout OpenFL repository
+        id: checkout_openfl
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.COMMIT_ID }}
 
-  #     - name: Pre test run
-  #       uses: ./.github/actions/tr_pre_test_run
-  #       if: ${{ always() }}
+      - name: Pre test run
+        uses: ./.github/actions/tr_pre_test_run
+        if: ${{ always() }}
 
-  #     - name: Run Task Runner E2E tests with TLS and memory logs
-  #       id: run_tests
-  #       run: |
-  #         python -m pytest -s tests/end_to_end/test_suites/memory_logs_tests.py \
-  #         -k test_log_memory_usage_basic --model_name ${{ env.MODEL_NAME }} \
-  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} \
-  #         --log_memory_usage
-  #         echo "Task runner memory logs test run completed"
+      - name: Run Task Runner E2E tests with TLS and memory logs
+        id: run_tests
+        run: |
+          python -m pytest -s tests/end_to_end/test_suites/memory_logs_tests.py \
+          -k test_log_memory_usage_basic --model_name ${{ env.MODEL_NAME }} \
+          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} \
+          --log_memory_usage
+          echo "Task runner memory logs test run completed"
 
-  #     - name: Post test run
-  #       uses: ./.github/actions/tr_post_test_run
-  #       if: ${{ always() }}
-  #       with:
-  #         test_type: "With_Memory_Logs"
+      - name: Post test run
+        uses: ./.github/actions/tr_post_test_run
+        if: ${{ always() }}
+        with:
+          test_type: "With_Memory_Logs"
 
-  # test_straggler_check:
-  #   name: With TLS (torch/mnist_straggler_check, 3.10)
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 30
-  #   if: |
-  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-  #     (github.event_name == 'workflow_dispatch') ||
-  #     (github.event.pull_request.draft == false) ||
-  #     (needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_straggler_check')
+  test_straggler_check:
+    name: With TLS (torch/mnist_straggler_check, 3.10)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event.pull_request.draft == false) ||
+      (needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_straggler_check')
 
-  #   env:
-  #     MODEL_NAME: "torch/mnist_straggler_check"
-  #     PYTHON_VERSION: "3.10"
+    env:
+      MODEL_NAME: "torch/mnist_straggler_check"
+      PYTHON_VERSION: "3.10"
 
-  #   steps:
-  #     - name: Checkout OpenFL repository
-  #       id: checkout_openfl
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ env.COMMIT_ID }}
+    steps:
+      - name: Checkout OpenFL repository
+        id: checkout_openfl
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.COMMIT_ID }}
 
-  #     - name: Pre test run
-  #       uses: ./.github/actions/tr_pre_test_run
-  #       if: ${{ always() }}
+      - name: Pre test run
+        uses: ./.github/actions/tr_pre_test_run
+        if: ${{ always() }}
 
-  #     - name: Run Straggler Handling Interface Test
-  #       id: run_tests
-  #       run: |
-  #         python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
-  #         -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
-  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
-  #         echo "Straggler handling test run completed"
+      - name: Run Straggler Handling Interface Test
+        id: run_tests
+        run: |
+          python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+          -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
+          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
+          echo "Straggler handling test run completed"
 
-  #     - name: Post test run
-  #       uses: ./.github/actions/tr_post_test_run
-  #       if: ${{ always() }}
-  #       with:
-  #         test_type: "With_TLS"
+      - name: Post test run
+        uses: ./.github/actions/tr_post_test_run
+        if: ${{ always() }}
+        with:
+          test_type: "With_TLS"
 
-  # test_eden_compression:
-  #   name: With TLS (torch/mnist_eden_compression, 3.10)
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 30
-  #   if: |
-  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-  #     (github.event_name == 'workflow_dispatch') ||
-  #     (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'eden_compression')) || (needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_eden_compression')
+  test_eden_compression:
+    name: With TLS (torch/mnist_eden_compression, 3.10)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'eden_compression')) || (needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_eden_compression')
 
-  #   env:
-  #     MODEL_NAME: "torch/mnist_eden_compression"
-  #     PYTHON_VERSION: "3.10"
+    env:
+      MODEL_NAME: "torch/mnist_eden_compression"
+      PYTHON_VERSION: "3.10"
 
-  #   steps:
-  #     - name: Checkout OpenFL repository
-  #       id: checkout_openfl
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ env.COMMIT_ID }}
+    steps:
+      - name: Checkout OpenFL repository
+        id: checkout_openfl
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.COMMIT_ID }}
 
-  #     - name: Pre test run
-  #       uses: ./.github/actions/tr_pre_test_run
-  #       if: ${{ always() }}
+      - name: Pre test run
+        uses: ./.github/actions/tr_pre_test_run
+        if: ${{ always() }}
 
-  #     - name: Run Eden Compression Test
-  #       id: run_tests
-  #       run: |
-  #         python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
-  #         -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
-  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
-  #         echo "Eden compression test run completed"
+      - name: Run Eden Compression Test
+        id: run_tests
+        run: |
+          python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+          -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
+          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
+          echo "Eden compression test run completed"
 
-  #     - name: Post test run
-  #       uses: ./.github/actions/tr_post_test_run
-  #       if: ${{ always() }}
-  #       with:
-  #         test_type: "With_TLS"
+      - name: Post test run
+        uses: ./.github/actions/tr_post_test_run
+        if: ${{ always() }}
+        with:
+          test_type: "With_TLS"

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -74,13 +74,84 @@ env:
   CALLING_WORKFLOW: ${{ inputs.calling_workflow || github.workflow }} # use calling workflow name
 
 jobs:
-  test_with_tls:
-    name: With TLS
+  input_selection:
     if: |
       (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event.pull_request.draft == false)
+    name: Input value selection
+    runs-on: ubuntu-22.04
+    outputs:
+      # Output all the variables related to models and python versions to be used in the matrix strategy
+      # for different jobs, however their usage depends on the selected job.
+      selected_jobs: ${{ steps.input_selection.outputs.jobs_to_run }}
+      selected_models_for_tls: ${{ steps.input_selection.outputs.models_for_tls }}
+      selected_python_for_tls: ${{ steps.input_selection.outputs.python_for_tls }}
+      selected_models_for_non_tls: ${{ steps.input_selection.outputs.models_for_non_tls }}
+      selected_models_for_no_client_auth: ${{ steps.input_selection.outputs.models_for_no_client_auth }}
+      selected_models_for_memory_logs: ${{ steps.input_selection.outputs.models_for_memory_logs }}
+      selected_python_for_non_tls: ${{ steps.input_selection.outputs.python_for_non_tls }}
+      selected_python_for_no_client_auth: ${{ steps.input_selection.outputs.python_for_no_client_auth }}
+      selected_python_for_memory_logs: ${{ steps.input_selection.outputs.python_for_memory_logs }}
+      calling_workflow: ${{ steps.input_selection.outputs.calling_workflow }}
+    steps:
+      - name: Job to select input values
+        id: input_selection
+        run: |
+          # ---------------------------------------------------------------
+          # Models like XGBoost (xgb_higgs) and torch/histology require runners with higher memory and CPU to run.
+          # Thus these models are excluded from the matrix for now.
+          # Default combination if no input is provided (i.e. 'all' is selected).
+          # * TLS - models [keras/torch/mnist, keras/jax/mnist] and python versions [3.10, 3.11]
+          # * Non-TLS - models [torch/mnist] and python version [3.12]
+          # * No client auth - models [keras/mnist] and python version [3.10]
+          # * Memory logs - models [torch/mnist] and python version [3.11]
+          # ---------------------------------------------------------------
+          echo "jobs_to_run=${{ env.JOBS_TO_RUN }}" >> "$GITHUB_OUTPUT"
+          echo "calling_workflow=${{ env.CALLING_WORKFLOW }}" >> "$GITHUB_OUTPUT"
+
+          if [ "${{ env.MODEL_NAME }}" == "all" ]; then
+            echo "models_for_tls=[\"keras/torch/mnist\", \"keras/jax/mnist\"]" >> "$GITHUB_OUTPUT"
+            echo "models_for_non_tls=[\"torch/mnist\"]" >> "$GITHUB_OUTPUT"
+            echo "models_for_no_client_auth=[\"keras/mnist\"]" >> "$GITHUB_OUTPUT"
+            echo "models_for_memory_logs=[\"torch/mnist\"]" >> "$GITHUB_OUTPUT"
+          else
+            echo "models_for_tls=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
+            echo "models_for_non_tls=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
+            echo "models_for_no_client_auth=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
+            echo "models_for_memory_logs=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
+          fi
+          if [ "${{ env.PYTHON_VERSION }}" == "all" ]; then
+            echo "python_for_tls=[\"3.10\", \"3.11\", \"3.12\"]" >> "$GITHUB_OUTPUT"
+            echo "python_for_non_tls=[\"3.12\"]" >> "$GITHUB_OUTPUT"
+            echo "python_for_no_client_auth=[\"3.10\"]" >> "$GITHUB_OUTPUT"
+            echo "python_for_memory_logs=[\"3.11\"]" >> "$GITHUB_OUTPUT"
+          else
+            echo "python_for_tls=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
+            echo "python_for_non_tls=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
+            echo "python_for_no_client_auth=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
+            echo "python_for_memory_logs=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
+          fi
+
+  test_with_tls:
+    name: With TLS
+    needs: input_selection
+    if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_with_tls'
     runs-on: ubuntu-22.04
     timeout-minutes: 30
+    strategy:
+      matrix:
+        model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_tls) }}
+        python_version: ${{ fromJson(needs.input_selection.outputs.selected_python_for_tls) }}
+        exclude: # Keras does not support Python 3.12
+          - model_name: "keras/mnist"
+            python_version: "3.12"
+          - model_name: "keras/jax/mnist"
+            python_version: "3.12"
+          - model_name: "keras/torch/mnist" 
+            python_version: "3.12"
+
+      fail-fast: false # do not immediately fail if one of the combinations fail
 
     env:
       MODEL_NAME: ${{ matrix.model_name }}
@@ -93,334 +164,242 @@ jobs:
         with:
           ref: ${{ env.COMMIT_ID }}
 
-      - name: Print CALLING_WORKFLOW
+      - name: Pre test run
+        uses: ./.github/actions/tr_pre_test_run
+        if: ${{ always() }}
+
+      - name: Run Task Runner E2E tests with TLS
+        id: run_tests
         run: |
-          echo "Calling workflow: ${{ env.CALLING_WORKFLOW }}"
+          python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+          -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
+          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
+          echo "Task runner end to end test run completed"
 
-  # input_selection:
-  #   if: |
-  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-  #     (github.event_name == 'workflow_dispatch') ||
-  #     (github.event.pull_request.draft == false)
-  #   name: Input value selection
-  #   runs-on: ubuntu-22.04
-  #   outputs:
-  #     # Output all the variables related to models and python versions to be used in the matrix strategy
-  #     # for different jobs, however their usage depends on the selected job.
-  #     selected_jobs: ${{ steps.input_selection.outputs.jobs_to_run }}
-  #     selected_models_for_tls: ${{ steps.input_selection.outputs.models_for_tls }}
-  #     selected_python_for_tls: ${{ steps.input_selection.outputs.python_for_tls }}
-  #     selected_models_for_non_tls: ${{ steps.input_selection.outputs.models_for_non_tls }}
-  #     selected_models_for_no_client_auth: ${{ steps.input_selection.outputs.models_for_no_client_auth }}
-  #     selected_models_for_memory_logs: ${{ steps.input_selection.outputs.models_for_memory_logs }}
-  #     selected_python_for_non_tls: ${{ steps.input_selection.outputs.python_for_non_tls }}
-  #     selected_python_for_no_client_auth: ${{ steps.input_selection.outputs.python_for_no_client_auth }}
-  #     selected_python_for_memory_logs: ${{ steps.input_selection.outputs.python_for_memory_logs }}
-  #   steps:
-  #     - name: Job to select input values
-  #       id: input_selection
-  #       run: |
-  #         # ---------------------------------------------------------------
-  #         # Models like XGBoost (xgb_higgs) and torch/histology require runners with higher memory and CPU to run.
-  #         # Thus these models are excluded from the matrix for now.
-  #         # Default combination if no input is provided (i.e. 'all' is selected).
-  #         # * TLS - models [keras/torch/mnist, keras/jax/mnist] and python versions [3.10, 3.11]
-  #         # * Non-TLS - models [torch/mnist] and python version [3.12]
-  #         # * No client auth - models [keras/mnist] and python version [3.10]
-  #         # * Memory logs - models [torch/mnist] and python version [3.11]
-  #         # ---------------------------------------------------------------
-  #         echo "jobs_to_run=${{ env.JOBS_TO_RUN }}" >> "$GITHUB_OUTPUT"
+      - name: Post test run
+        uses: ./.github/actions/tr_post_test_run
+        if: ${{ always() }}
+        with:
+          test_type: "With_TLS"
 
-  #         if [ "${{ env.MODEL_NAME }}" == "all" ]; then
-  #           echo "models_for_tls=[\"keras/torch/mnist\", \"keras/jax/mnist\"]" >> "$GITHUB_OUTPUT"
-  #           echo "models_for_non_tls=[\"torch/mnist\"]" >> "$GITHUB_OUTPUT"
-  #           echo "models_for_no_client_auth=[\"keras/mnist\"]" >> "$GITHUB_OUTPUT"
-  #           echo "models_for_memory_logs=[\"torch/mnist\"]" >> "$GITHUB_OUTPUT"
-  #         else
-  #           echo "models_for_tls=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
-  #           echo "models_for_non_tls=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
-  #           echo "models_for_no_client_auth=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
-  #           echo "models_for_memory_logs=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
-  #         fi
-  #         if [ "${{ env.PYTHON_VERSION }}" == "all" ]; then
-  #           echo "python_for_tls=[\"3.10\", \"3.11\", \"3.12\"]" >> "$GITHUB_OUTPUT"
-  #           echo "python_for_non_tls=[\"3.12\"]" >> "$GITHUB_OUTPUT"
-  #           echo "python_for_no_client_auth=[\"3.10\"]" >> "$GITHUB_OUTPUT"
-  #           echo "python_for_memory_logs=[\"3.11\"]" >> "$GITHUB_OUTPUT"
-  #         else
-  #           echo "python_for_tls=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
-  #           echo "python_for_non_tls=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
-  #           echo "python_for_no_client_auth=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
-  #           echo "python_for_memory_logs=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
-  #         fi
+  test_without_tls:
+    name: Without TLS
+    needs: input_selection
+    if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_without_tls'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_non_tls) }}
+        python_version: ${{ fromJson(needs.input_selection.outputs.selected_python_for_non_tls) }}
+        exclude: # Keras does not support Python 3.12
+          - model_name: "keras/mnist"
+            python_version: "3.12"
+          - model_name: "keras/jax/mnist"
+            python_version: "3.12"
+          - model_name: "keras/torch/mnist" 
+            python_version: "3.12"
+      fail-fast: false # do not immediately fail if one of the combinations fail
 
-  # test_with_tls:
-  #   name: With TLS
-  #   needs: input_selection
-  #   if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_with_tls'
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 30
-  #   strategy:
-  #     matrix:
-  #       model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_tls) }}
-  #       python_version: ${{ fromJson(needs.input_selection.outputs.selected_python_for_tls) }}
-  #       exclude: # Keras does not support Python 3.12
-  #         - model_name: "keras/mnist"
-  #           python_version: "3.12"
-  #         - model_name: "keras/jax/mnist"
-  #           python_version: "3.12"
-  #         - model_name: "keras/torch/mnist" 
-  #           python_version: "3.12"
+    env:
+      MODEL_NAME: ${{ matrix.model_name }}
+      PYTHON_VERSION: ${{ matrix.python_version }}
 
-  #     fail-fast: false # do not immediately fail if one of the combinations fail
+    steps:
+      - name: Checkout OpenFL repository
+        id: checkout_openfl
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.COMMIT_ID }}
 
-  #   env:
-  #     MODEL_NAME: ${{ matrix.model_name }}
-  #     PYTHON_VERSION: ${{ matrix.python_version }}
+      - name: Pre test run
+        uses: ./.github/actions/tr_pre_test_run
+        if: ${{ always() }}
 
-  #   steps:
-  #     - name: Checkout OpenFL repository
-  #       id: checkout_openfl
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ env.COMMIT_ID }}
+      - name: Run Task Runner E2E tests without TLS
+        id: run_tests
+        run: |
+          python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+          -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
+          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_tls
+          echo "Task runner end to end test run completed"
 
-  #     - name: Pre test run
-  #       uses: ./.github/actions/tr_pre_test_run
-  #       if: ${{ always() }}
+      - name: Post test run
+        uses: ./.github/actions/tr_post_test_run
+        if: ${{ always() }}
+        with:
+          test_type: "Without_TLS"
 
-  #     - name: Run Task Runner E2E tests with TLS
-  #       id: run_tests
-  #       run: |
-  #         python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
-  #         -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
-  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
-  #         echo "Task runner end to end test run completed"
+  test_without_client_auth:
+    name: Without Client Auth
+    needs: input_selection
+    if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_without_client_auth'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_no_client_auth) }}
+        python_version: ${{ fromJson(needs.input_selection.outputs.selected_python_for_no_client_auth) }}
+        exclude: # Keras does not support Python 3.12
+          - model_name: "keras/mnist"
+            python_version: "3.12"
+          - model_name: "keras/jax/mnist"
+            python_version: "3.12"
+          - model_name: "keras/torch/mnist" 
+            python_version: "3.12"
+      fail-fast: false # do not immediately fail if one of the combinations fail
 
-  #     - name: Post test run
-  #       uses: ./.github/actions/tr_post_test_run
-  #       if: ${{ always() }}
-  #       with:
-  #         test_type: "With_TLS"
+    env:
+      MODEL_NAME: ${{ matrix.model_name }}
+      PYTHON_VERSION: ${{ matrix.python_version }}
 
-  # test_without_tls:
-  #   name: Without TLS
-  #   needs: input_selection
-  #   if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_without_tls'
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 30
-  #   strategy:
-  #     matrix:
-  #       model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_non_tls) }}
-  #       python_version: ${{ fromJson(needs.input_selection.outputs.selected_python_for_non_tls) }}
-  #       exclude: # Keras does not support Python 3.12
-  #         - model_name: "keras/mnist"
-  #           python_version: "3.12"
-  #         - model_name: "keras/jax/mnist"
-  #           python_version: "3.12"
-  #         - model_name: "keras/torch/mnist" 
-  #           python_version: "3.12"
-  #     fail-fast: false # do not immediately fail if one of the combinations fail
+    steps:
+      - name: Checkout OpenFL repository
+        id: checkout_openfl
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.COMMIT_ID }}
 
-  #   env:
-  #     MODEL_NAME: ${{ matrix.model_name }}
-  #     PYTHON_VERSION: ${{ matrix.python_version }}
+      - name: Pre test run
+        uses: ./.github/actions/tr_pre_test_run
+        if: ${{ always() }}
 
-  #   steps:
-  #     - name: Checkout OpenFL repository
-  #       id: checkout_openfl
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ env.COMMIT_ID }}
+      - name: Run Task Runner E2E tests without TLS
+        id: run_tests
+        run: |
+          python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+          -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
+          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_client_auth
+          echo "Task runner end to end test run completed"
 
-  #     - name: Pre test run
-  #       uses: ./.github/actions/tr_pre_test_run
-  #       if: ${{ always() }}
+      - name: Post test run
+        uses: ./.github/actions/tr_post_test_run
+        if: ${{ always() }}
+        with:
+          test_type: 'Without_Client_Auth'
 
-  #     - name: Run Task Runner E2E tests without TLS
-  #       id: run_tests
-  #       run: |
-  #         python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
-  #         -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
-  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_tls
-  #         echo "Task runner end to end test run completed"
+  test_memory_logs:
+    name: With Memory Logs
+    needs: input_selection
+    if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_memory_logs'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_memory_logs) }}
+        python_version: ${{ fromJson(needs.input_selection.outputs.selected_python_for_memory_logs) }}
+        exclude: # Keras does not support Python 3.12
+          - model_name: "keras/mnist"
+            python_version: "3.12"
+          - model_name: "keras/jax/mnist"
+            python_version: "3.12"
+          - model_name: "keras/torch/mnist" 
+            python_version: "3.12"
+      fail-fast: false # do not immediately fail if one of the combinations fail
 
-  #     - name: Post test run
-  #       uses: ./.github/actions/tr_post_test_run
-  #       if: ${{ always() }}
-  #       with:
-  #         test_type: "Without_TLS"
+    env:
+      MODEL_NAME: ${{ matrix.model_name }}
+      PYTHON_VERSION: ${{ matrix.python_version }}
 
-  # test_without_client_auth:
-  #   name: Without Client Auth
-  #   needs: input_selection
-  #   if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_without_client_auth'
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 30
-  #   strategy:
-  #     matrix:
-  #       model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_no_client_auth) }}
-  #       python_version: ${{ fromJson(needs.input_selection.outputs.selected_python_for_no_client_auth) }}
-  #       exclude: # Keras does not support Python 3.12
-  #         - model_name: "keras/mnist"
-  #           python_version: "3.12"
-  #         - model_name: "keras/jax/mnist"
-  #           python_version: "3.12"
-  #         - model_name: "keras/torch/mnist" 
-  #           python_version: "3.12"
-  #     fail-fast: false # do not immediately fail if one of the combinations fail
+    steps:
+      - name: Checkout OpenFL repository
+        id: checkout_openfl
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.COMMIT_ID }}
 
-  #   env:
-  #     MODEL_NAME: ${{ matrix.model_name }}
-  #     PYTHON_VERSION: ${{ matrix.python_version }}
+      - name: Pre test run
+        uses: ./.github/actions/tr_pre_test_run
+        if: ${{ always() }}
 
-  #   steps:
-  #     - name: Checkout OpenFL repository
-  #       id: checkout_openfl
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ env.COMMIT_ID }}
+      - name: Run Task Runner E2E tests with TLS and memory logs
+        id: run_tests
+        run: |
+          python -m pytest -s tests/end_to_end/test_suites/memory_logs_tests.py \
+          -k test_log_memory_usage_basic --model_name ${{ env.MODEL_NAME }} \
+          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} \
+          --log_memory_usage
+          echo "Task runner memory logs test run completed"
 
-  #     - name: Pre test run
-  #       uses: ./.github/actions/tr_pre_test_run
-  #       if: ${{ always() }}
+      - name: Post test run
+        uses: ./.github/actions/tr_post_test_run
+        if: ${{ always() }}
+        with:
+          test_type: "With_Memory_Logs"
 
-  #     - name: Run Task Runner E2E tests without TLS
-  #       id: run_tests
-  #       run: |
-  #         python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
-  #         -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
-  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_client_auth
-  #         echo "Task runner end to end test run completed"
+  test_straggler_check:
+    name: With TLS (torch/mnist_straggler_check, 3.10)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event.pull_request.draft == false) ||
+      (needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_straggler_check')
 
-  #     - name: Post test run
-  #       uses: ./.github/actions/tr_post_test_run
-  #       if: ${{ always() }}
-  #       with:
-  #         test_type: 'Without_Client_Auth'
+    env:
+      MODEL_NAME: "torch/mnist_straggler_check"
+      PYTHON_VERSION: "3.10"
 
-  # test_memory_logs:
-  #   name: With Memory Logs
-  #   needs: input_selection
-  #   if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_memory_logs'
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 30
-  #   strategy:
-  #     matrix:
-  #       model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_memory_logs) }}
-  #       python_version: ${{ fromJson(needs.input_selection.outputs.selected_python_for_memory_logs) }}
-  #       exclude: # Keras does not support Python 3.12
-  #         - model_name: "keras/mnist"
-  #           python_version: "3.12"
-  #         - model_name: "keras/jax/mnist"
-  #           python_version: "3.12"
-  #         - model_name: "keras/torch/mnist" 
-  #           python_version: "3.12"
-  #     fail-fast: false # do not immediately fail if one of the combinations fail
+    steps:
+      - name: Checkout OpenFL repository
+        id: checkout_openfl
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.COMMIT_ID }}
 
-  #   env:
-  #     MODEL_NAME: ${{ matrix.model_name }}
-  #     PYTHON_VERSION: ${{ matrix.python_version }}
+      - name: Pre test run
+        uses: ./.github/actions/tr_pre_test_run
+        if: ${{ always() }}
 
-  #   steps:
-  #     - name: Checkout OpenFL repository
-  #       id: checkout_openfl
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ env.COMMIT_ID }}
+      - name: Run Straggler Handling Interface Test
+        id: run_tests
+        run: |
+          python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+          -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
+          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
+          echo "Straggler handling test run completed"
 
-  #     - name: Pre test run
-  #       uses: ./.github/actions/tr_pre_test_run
-  #       if: ${{ always() }}
+      - name: Post test run
+        uses: ./.github/actions/tr_post_test_run
+        if: ${{ always() }}
+        with:
+          test_type: "With_TLS"
 
-  #     - name: Run Task Runner E2E tests with TLS and memory logs
-  #       id: run_tests
-  #       run: |
-  #         python -m pytest -s tests/end_to_end/test_suites/memory_logs_tests.py \
-  #         -k test_log_memory_usage_basic --model_name ${{ env.MODEL_NAME }} \
-  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} \
-  #         --log_memory_usage
-  #         echo "Task runner memory logs test run completed"
+  test_eden_compression:
+    name: With TLS (torch/mnist_eden_compression, 3.10)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'eden_compression')) || (needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_eden_compression')
 
-  #     - name: Post test run
-  #       uses: ./.github/actions/tr_post_test_run
-  #       if: ${{ always() }}
-  #       with:
-  #         test_type: "With_Memory_Logs"
+    env:
+      MODEL_NAME: "torch/mnist_eden_compression"
+      PYTHON_VERSION: "3.10"
 
-  # test_straggler_check:
-  #   name: With TLS (torch/mnist_straggler_check, 3.10)
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 30
-  #   if: |
-  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-  #     (github.event_name == 'workflow_dispatch') ||
-  #     (github.event.pull_request.draft == false) ||
-  #     (needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_straggler_check')
+    steps:
+      - name: Checkout OpenFL repository
+        id: checkout_openfl
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.COMMIT_ID }}
 
-  #   env:
-  #     MODEL_NAME: "torch/mnist_straggler_check"
-  #     PYTHON_VERSION: "3.10"
+      - name: Pre test run
+        uses: ./.github/actions/tr_pre_test_run
+        if: ${{ always() }}
 
-  #   steps:
-  #     - name: Checkout OpenFL repository
-  #       id: checkout_openfl
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ env.COMMIT_ID }}
+      - name: Run Eden Compression Test
+        id: run_tests
+        run: |
+          python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+          -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
+          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
+          echo "Eden compression test run completed"
 
-  #     - name: Pre test run
-  #       uses: ./.github/actions/tr_pre_test_run
-  #       if: ${{ always() }}
-
-  #     - name: Run Straggler Handling Interface Test
-  #       id: run_tests
-  #       run: |
-  #         python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
-  #         -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
-  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
-  #         echo "Straggler handling test run completed"
-
-  #     - name: Post test run
-  #       uses: ./.github/actions/tr_post_test_run
-  #       if: ${{ always() }}
-  #       with:
-  #         test_type: "With_TLS"
-
-  # test_eden_compression:
-  #   name: With TLS (torch/mnist_eden_compression, 3.10)
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 30
-  #   if: |
-  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-  #     (github.event_name == 'workflow_dispatch') ||
-  #     (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'eden_compression')) || (needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_eden_compression')
-
-  #   env:
-  #     MODEL_NAME: "torch/mnist_eden_compression"
-  #     PYTHON_VERSION: "3.10"
-
-  #   steps:
-  #     - name: Checkout OpenFL repository
-  #       id: checkout_openfl
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ env.COMMIT_ID }}
-
-  #     - name: Pre test run
-  #       uses: ./.github/actions/tr_pre_test_run
-  #       if: ${{ always() }}
-
-  #     - name: Run Eden Compression Test
-  #       id: run_tests
-  #       run: |
-  #         python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
-  #         -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
-  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
-  #         echo "Eden compression test run completed"
-
-  #     - name: Post test run
-  #       uses: ./.github/actions/tr_post_test_run
-  #       if: ${{ always() }}
-  #       with:
-  #         test_type: "With_TLS"
+      - name: Post test run
+        uses: ./.github/actions/tr_post_test_run
+        if: ${{ always() }}
+        with:
+          test_type: "With_TLS"

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -9,6 +9,9 @@ on:
       commit_id:
         required: false
         type: string
+      calling_workflow:
+        required: false
+        type: string
   workflow_dispatch:
     inputs:
       num_rounds:
@@ -68,310 +71,20 @@ env:
   PYTHON_VERSION: ${{ inputs.python_version || 'all' }}
   JOBS_TO_RUN: ${{ inputs.jobs_to_run || 'all' }}
   COMMIT_ID: ${{ inputs.commit_id || github.sha }} # use commit_id from the calling workflow
+  CALLING_WORKFLOW: ${{ inputs.calling_workflow || github.workflow }} # use calling workflow name
 
 jobs:
-  input_selection:
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch') ||
-      (github.event.pull_request.draft == false)
-    name: Input value selection
-    runs-on: ubuntu-22.04
-    outputs:
-      # Output all the variables related to models and python versions to be used in the matrix strategy
-      # for different jobs, however their usage depends on the selected job.
-      selected_jobs: ${{ steps.input_selection.outputs.jobs_to_run }}
-      selected_models_for_tls: ${{ steps.input_selection.outputs.models_for_tls }}
-      selected_python_for_tls: ${{ steps.input_selection.outputs.python_for_tls }}
-      selected_models_for_non_tls: ${{ steps.input_selection.outputs.models_for_non_tls }}
-      selected_models_for_no_client_auth: ${{ steps.input_selection.outputs.models_for_no_client_auth }}
-      selected_models_for_memory_logs: ${{ steps.input_selection.outputs.models_for_memory_logs }}
-      selected_python_for_non_tls: ${{ steps.input_selection.outputs.python_for_non_tls }}
-      selected_python_for_no_client_auth: ${{ steps.input_selection.outputs.python_for_no_client_auth }}
-      selected_python_for_memory_logs: ${{ steps.input_selection.outputs.python_for_memory_logs }}
-    steps:
-      - name: Job to select input values
-        id: input_selection
-        run: |
-          # ---------------------------------------------------------------
-          # Models like XGBoost (xgb_higgs) and torch/histology require runners with higher memory and CPU to run.
-          # Thus these models are excluded from the matrix for now.
-          # Default combination if no input is provided (i.e. 'all' is selected).
-          # * TLS - models [keras/torch/mnist, keras/jax/mnist] and python versions [3.10, 3.11]
-          # * Non-TLS - models [torch/mnist] and python version [3.12]
-          # * No client auth - models [keras/mnist] and python version [3.10]
-          # * Memory logs - models [torch/mnist] and python version [3.11]
-          # ---------------------------------------------------------------
-          echo "jobs_to_run=${{ env.JOBS_TO_RUN }}" >> "$GITHUB_OUTPUT"
-
-          if [ "${{ env.MODEL_NAME }}" == "all" ]; then
-            echo "models_for_tls=[\"keras/torch/mnist\", \"keras/jax/mnist\"]" >> "$GITHUB_OUTPUT"
-            echo "models_for_non_tls=[\"torch/mnist\"]" >> "$GITHUB_OUTPUT"
-            echo "models_for_no_client_auth=[\"keras/mnist\"]" >> "$GITHUB_OUTPUT"
-            echo "models_for_memory_logs=[\"torch/mnist\"]" >> "$GITHUB_OUTPUT"
-          else
-            echo "models_for_tls=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
-            echo "models_for_non_tls=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
-            echo "models_for_no_client_auth=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
-            echo "models_for_memory_logs=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
-          fi
-          if [ "${{ env.PYTHON_VERSION }}" == "all" ]; then
-            echo "python_for_tls=[\"3.10\", \"3.11\", \"3.12\"]" >> "$GITHUB_OUTPUT"
-            echo "python_for_non_tls=[\"3.12\"]" >> "$GITHUB_OUTPUT"
-            echo "python_for_no_client_auth=[\"3.10\"]" >> "$GITHUB_OUTPUT"
-            echo "python_for_memory_logs=[\"3.11\"]" >> "$GITHUB_OUTPUT"
-          else
-            echo "python_for_tls=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
-            echo "python_for_non_tls=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
-            echo "python_for_no_client_auth=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
-            echo "python_for_memory_logs=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
-          fi
-
   test_with_tls:
     name: With TLS
-    needs: input_selection
-    if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_with_tls'
-    runs-on: ubuntu-22.04
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_tls) }}
-        python_version: ${{ fromJson(needs.input_selection.outputs.selected_python_for_tls) }}
-        exclude: # Keras does not support Python 3.12
-          - model_name: "keras/mnist"
-            python_version: "3.12"
-          - model_name: "keras/jax/mnist"
-            python_version: "3.12"
-          - model_name: "keras/torch/mnist" 
-            python_version: "3.12"
-
-      fail-fast: false # do not immediately fail if one of the combinations fail
-
-    env:
-      MODEL_NAME: ${{ matrix.model_name }}
-      PYTHON_VERSION: ${{ matrix.python_version }}
-
-    steps:
-      - name: Checkout OpenFL repository
-        id: checkout_openfl
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.COMMIT_ID }}
-
-      - name: Pre test run
-        uses: ./.github/actions/tr_pre_test_run
-        if: ${{ always() }}
-
-      - name: Run Task Runner E2E tests with TLS
-        id: run_tests
-        run: |
-          python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
-          -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
-          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
-          echo "Task runner end to end test run completed"
-
-      - name: Post test run
-        uses: ./.github/actions/tr_post_test_run
-        if: ${{ always() }}
-        with:
-          test_type: "With_TLS"
-
-  test_without_tls:
-    name: Without TLS
-    needs: input_selection
-    if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_without_tls'
-    runs-on: ubuntu-22.04
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_non_tls) }}
-        python_version: ${{ fromJson(needs.input_selection.outputs.selected_python_for_non_tls) }}
-        exclude: # Keras does not support Python 3.12
-          - model_name: "keras/mnist"
-            python_version: "3.12"
-          - model_name: "keras/jax/mnist"
-            python_version: "3.12"
-          - model_name: "keras/torch/mnist" 
-            python_version: "3.12"
-      fail-fast: false # do not immediately fail if one of the combinations fail
-
-    env:
-      MODEL_NAME: ${{ matrix.model_name }}
-      PYTHON_VERSION: ${{ matrix.python_version }}
-
-    steps:
-      - name: Checkout OpenFL repository
-        id: checkout_openfl
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.COMMIT_ID }}
-
-      - name: Pre test run
-        uses: ./.github/actions/tr_pre_test_run
-        if: ${{ always() }}
-
-      - name: Run Task Runner E2E tests without TLS
-        id: run_tests
-        run: |
-          python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
-          -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
-          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_tls
-          echo "Task runner end to end test run completed"
-
-      - name: Post test run
-        uses: ./.github/actions/tr_post_test_run
-        if: ${{ always() }}
-        with:
-          test_type: "Without_TLS"
-
-  test_without_client_auth:
-    name: Without Client Auth
-    needs: input_selection
-    if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_without_client_auth'
-    runs-on: ubuntu-22.04
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_no_client_auth) }}
-        python_version: ${{ fromJson(needs.input_selection.outputs.selected_python_for_no_client_auth) }}
-        exclude: # Keras does not support Python 3.12
-          - model_name: "keras/mnist"
-            python_version: "3.12"
-          - model_name: "keras/jax/mnist"
-            python_version: "3.12"
-          - model_name: "keras/torch/mnist" 
-            python_version: "3.12"
-      fail-fast: false # do not immediately fail if one of the combinations fail
-
-    env:
-      MODEL_NAME: ${{ matrix.model_name }}
-      PYTHON_VERSION: ${{ matrix.python_version }}
-
-    steps:
-      - name: Checkout OpenFL repository
-        id: checkout_openfl
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.COMMIT_ID }}
-
-      - name: Pre test run
-        uses: ./.github/actions/tr_pre_test_run
-        if: ${{ always() }}
-
-      - name: Run Task Runner E2E tests without TLS
-        id: run_tests
-        run: |
-          python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
-          -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
-          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_client_auth
-          echo "Task runner end to end test run completed"
-
-      - name: Post test run
-        uses: ./.github/actions/tr_post_test_run
-        if: ${{ always() }}
-        with:
-          test_type: 'Without_Client_Auth'
-
-  test_memory_logs:
-    name: With Memory Logs
-    needs: input_selection
-    if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_memory_logs'
-    runs-on: ubuntu-22.04
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_memory_logs) }}
-        python_version: ${{ fromJson(needs.input_selection.outputs.selected_python_for_memory_logs) }}
-        exclude: # Keras does not support Python 3.12
-          - model_name: "keras/mnist"
-            python_version: "3.12"
-          - model_name: "keras/jax/mnist"
-            python_version: "3.12"
-          - model_name: "keras/torch/mnist" 
-            python_version: "3.12"
-      fail-fast: false # do not immediately fail if one of the combinations fail
-
-    env:
-      MODEL_NAME: ${{ matrix.model_name }}
-      PYTHON_VERSION: ${{ matrix.python_version }}
-
-    steps:
-      - name: Checkout OpenFL repository
-        id: checkout_openfl
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.COMMIT_ID }}
-
-      - name: Pre test run
-        uses: ./.github/actions/tr_pre_test_run
-        if: ${{ always() }}
-
-      - name: Run Task Runner E2E tests with TLS and memory logs
-        id: run_tests
-        run: |
-          python -m pytest -s tests/end_to_end/test_suites/memory_logs_tests.py \
-          -k test_log_memory_usage_basic --model_name ${{ env.MODEL_NAME }} \
-          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} \
-          --log_memory_usage
-          echo "Task runner memory logs test run completed"
-
-      - name: Post test run
-        uses: ./.github/actions/tr_post_test_run
-        if: ${{ always() }}
-        with:
-          test_type: "With_Memory_Logs"
-
-  test_straggler_check:
-    name: With TLS (torch/mnist_straggler_check, 3.10)
-    runs-on: ubuntu-22.04
-    timeout-minutes: 30
     if: |
       (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch') ||
-      (github.event.pull_request.draft == false) ||
-      (needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_straggler_check')
-
-    env:
-      MODEL_NAME: "torch/mnist_straggler_check"
-      PYTHON_VERSION: "3.10"
-
-    steps:
-      - name: Checkout OpenFL repository
-        id: checkout_openfl
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.COMMIT_ID }}
-
-      - name: Pre test run
-        uses: ./.github/actions/tr_pre_test_run
-        if: ${{ always() }}
-
-      - name: Run Straggler Handling Interface Test
-        id: run_tests
-        run: |
-          python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
-          -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
-          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
-          echo "Straggler handling test run completed"
-
-      - name: Post test run
-        uses: ./.github/actions/tr_post_test_run
-        if: ${{ always() }}
-        with:
-          test_type: "With_TLS"
-
-  test_eden_compression:
-    name: With TLS (torch/mnist_eden_compression, 3.10)
+      (github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-22.04
     timeout-minutes: 30
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch') ||
-      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'eden_compression')) || (needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_eden_compression')
 
     env:
-      MODEL_NAME: "torch/mnist_eden_compression"
-      PYTHON_VERSION: "3.10"
+      MODEL_NAME: ${{ matrix.model_name }}
+      PYTHON_VERSION: ${{ matrix.python_version }}
 
     steps:
       - name: Checkout OpenFL repository
@@ -380,20 +93,334 @@ jobs:
         with:
           ref: ${{ env.COMMIT_ID }}
 
-      - name: Pre test run
-        uses: ./.github/actions/tr_pre_test_run
-        if: ${{ always() }}
-
-      - name: Run Eden Compression Test
-        id: run_tests
+      - name: Print CALLING_WORKFLOW
         run: |
-          python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
-          -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
-          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
-          echo "Eden compression test run completed"
+          echo "Calling workflow: ${{ env.CALLING_WORKFLOW }}"
 
-      - name: Post test run
-        uses: ./.github/actions/tr_post_test_run
-        if: ${{ always() }}
-        with:
-          test_type: "With_TLS"
+  # input_selection:
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch') ||
+  #     (github.event.pull_request.draft == false)
+  #   name: Input value selection
+  #   runs-on: ubuntu-22.04
+  #   outputs:
+  #     # Output all the variables related to models and python versions to be used in the matrix strategy
+  #     # for different jobs, however their usage depends on the selected job.
+  #     selected_jobs: ${{ steps.input_selection.outputs.jobs_to_run }}
+  #     selected_models_for_tls: ${{ steps.input_selection.outputs.models_for_tls }}
+  #     selected_python_for_tls: ${{ steps.input_selection.outputs.python_for_tls }}
+  #     selected_models_for_non_tls: ${{ steps.input_selection.outputs.models_for_non_tls }}
+  #     selected_models_for_no_client_auth: ${{ steps.input_selection.outputs.models_for_no_client_auth }}
+  #     selected_models_for_memory_logs: ${{ steps.input_selection.outputs.models_for_memory_logs }}
+  #     selected_python_for_non_tls: ${{ steps.input_selection.outputs.python_for_non_tls }}
+  #     selected_python_for_no_client_auth: ${{ steps.input_selection.outputs.python_for_no_client_auth }}
+  #     selected_python_for_memory_logs: ${{ steps.input_selection.outputs.python_for_memory_logs }}
+  #   steps:
+  #     - name: Job to select input values
+  #       id: input_selection
+  #       run: |
+  #         # ---------------------------------------------------------------
+  #         # Models like XGBoost (xgb_higgs) and torch/histology require runners with higher memory and CPU to run.
+  #         # Thus these models are excluded from the matrix for now.
+  #         # Default combination if no input is provided (i.e. 'all' is selected).
+  #         # * TLS - models [keras/torch/mnist, keras/jax/mnist] and python versions [3.10, 3.11]
+  #         # * Non-TLS - models [torch/mnist] and python version [3.12]
+  #         # * No client auth - models [keras/mnist] and python version [3.10]
+  #         # * Memory logs - models [torch/mnist] and python version [3.11]
+  #         # ---------------------------------------------------------------
+  #         echo "jobs_to_run=${{ env.JOBS_TO_RUN }}" >> "$GITHUB_OUTPUT"
+
+  #         if [ "${{ env.MODEL_NAME }}" == "all" ]; then
+  #           echo "models_for_tls=[\"keras/torch/mnist\", \"keras/jax/mnist\"]" >> "$GITHUB_OUTPUT"
+  #           echo "models_for_non_tls=[\"torch/mnist\"]" >> "$GITHUB_OUTPUT"
+  #           echo "models_for_no_client_auth=[\"keras/mnist\"]" >> "$GITHUB_OUTPUT"
+  #           echo "models_for_memory_logs=[\"torch/mnist\"]" >> "$GITHUB_OUTPUT"
+  #         else
+  #           echo "models_for_tls=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
+  #           echo "models_for_non_tls=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
+  #           echo "models_for_no_client_auth=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
+  #           echo "models_for_memory_logs=[\"${{env.MODEL_NAME}}\"]" >> "$GITHUB_OUTPUT"
+  #         fi
+  #         if [ "${{ env.PYTHON_VERSION }}" == "all" ]; then
+  #           echo "python_for_tls=[\"3.10\", \"3.11\", \"3.12\"]" >> "$GITHUB_OUTPUT"
+  #           echo "python_for_non_tls=[\"3.12\"]" >> "$GITHUB_OUTPUT"
+  #           echo "python_for_no_client_auth=[\"3.10\"]" >> "$GITHUB_OUTPUT"
+  #           echo "python_for_memory_logs=[\"3.11\"]" >> "$GITHUB_OUTPUT"
+  #         else
+  #           echo "python_for_tls=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
+  #           echo "python_for_non_tls=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
+  #           echo "python_for_no_client_auth=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
+  #           echo "python_for_memory_logs=[\"${{env.PYTHON_VERSION}}\"]" >> "$GITHUB_OUTPUT"
+  #         fi
+
+  # test_with_tls:
+  #   name: With TLS
+  #   needs: input_selection
+  #   if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_with_tls'
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: 30
+  #   strategy:
+  #     matrix:
+  #       model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_tls) }}
+  #       python_version: ${{ fromJson(needs.input_selection.outputs.selected_python_for_tls) }}
+  #       exclude: # Keras does not support Python 3.12
+  #         - model_name: "keras/mnist"
+  #           python_version: "3.12"
+  #         - model_name: "keras/jax/mnist"
+  #           python_version: "3.12"
+  #         - model_name: "keras/torch/mnist" 
+  #           python_version: "3.12"
+
+  #     fail-fast: false # do not immediately fail if one of the combinations fail
+
+  #   env:
+  #     MODEL_NAME: ${{ matrix.model_name }}
+  #     PYTHON_VERSION: ${{ matrix.python_version }}
+
+  #   steps:
+  #     - name: Checkout OpenFL repository
+  #       id: checkout_openfl
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ env.COMMIT_ID }}
+
+  #     - name: Pre test run
+  #       uses: ./.github/actions/tr_pre_test_run
+  #       if: ${{ always() }}
+
+  #     - name: Run Task Runner E2E tests with TLS
+  #       id: run_tests
+  #       run: |
+  #         python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+  #         -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
+  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
+  #         echo "Task runner end to end test run completed"
+
+  #     - name: Post test run
+  #       uses: ./.github/actions/tr_post_test_run
+  #       if: ${{ always() }}
+  #       with:
+  #         test_type: "With_TLS"
+
+  # test_without_tls:
+  #   name: Without TLS
+  #   needs: input_selection
+  #   if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_without_tls'
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: 30
+  #   strategy:
+  #     matrix:
+  #       model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_non_tls) }}
+  #       python_version: ${{ fromJson(needs.input_selection.outputs.selected_python_for_non_tls) }}
+  #       exclude: # Keras does not support Python 3.12
+  #         - model_name: "keras/mnist"
+  #           python_version: "3.12"
+  #         - model_name: "keras/jax/mnist"
+  #           python_version: "3.12"
+  #         - model_name: "keras/torch/mnist" 
+  #           python_version: "3.12"
+  #     fail-fast: false # do not immediately fail if one of the combinations fail
+
+  #   env:
+  #     MODEL_NAME: ${{ matrix.model_name }}
+  #     PYTHON_VERSION: ${{ matrix.python_version }}
+
+  #   steps:
+  #     - name: Checkout OpenFL repository
+  #       id: checkout_openfl
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ env.COMMIT_ID }}
+
+  #     - name: Pre test run
+  #       uses: ./.github/actions/tr_pre_test_run
+  #       if: ${{ always() }}
+
+  #     - name: Run Task Runner E2E tests without TLS
+  #       id: run_tests
+  #       run: |
+  #         python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+  #         -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
+  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_tls
+  #         echo "Task runner end to end test run completed"
+
+  #     - name: Post test run
+  #       uses: ./.github/actions/tr_post_test_run
+  #       if: ${{ always() }}
+  #       with:
+  #         test_type: "Without_TLS"
+
+  # test_without_client_auth:
+  #   name: Without Client Auth
+  #   needs: input_selection
+  #   if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_without_client_auth'
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: 30
+  #   strategy:
+  #     matrix:
+  #       model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_no_client_auth) }}
+  #       python_version: ${{ fromJson(needs.input_selection.outputs.selected_python_for_no_client_auth) }}
+  #       exclude: # Keras does not support Python 3.12
+  #         - model_name: "keras/mnist"
+  #           python_version: "3.12"
+  #         - model_name: "keras/jax/mnist"
+  #           python_version: "3.12"
+  #         - model_name: "keras/torch/mnist" 
+  #           python_version: "3.12"
+  #     fail-fast: false # do not immediately fail if one of the combinations fail
+
+  #   env:
+  #     MODEL_NAME: ${{ matrix.model_name }}
+  #     PYTHON_VERSION: ${{ matrix.python_version }}
+
+  #   steps:
+  #     - name: Checkout OpenFL repository
+  #       id: checkout_openfl
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ env.COMMIT_ID }}
+
+  #     - name: Pre test run
+  #       uses: ./.github/actions/tr_pre_test_run
+  #       if: ${{ always() }}
+
+  #     - name: Run Task Runner E2E tests without TLS
+  #       id: run_tests
+  #       run: |
+  #         python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+  #         -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
+  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_client_auth
+  #         echo "Task runner end to end test run completed"
+
+  #     - name: Post test run
+  #       uses: ./.github/actions/tr_post_test_run
+  #       if: ${{ always() }}
+  #       with:
+  #         test_type: 'Without_Client_Auth'
+
+  # test_memory_logs:
+  #   name: With Memory Logs
+  #   needs: input_selection
+  #   if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_memory_logs'
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: 30
+  #   strategy:
+  #     matrix:
+  #       model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_memory_logs) }}
+  #       python_version: ${{ fromJson(needs.input_selection.outputs.selected_python_for_memory_logs) }}
+  #       exclude: # Keras does not support Python 3.12
+  #         - model_name: "keras/mnist"
+  #           python_version: "3.12"
+  #         - model_name: "keras/jax/mnist"
+  #           python_version: "3.12"
+  #         - model_name: "keras/torch/mnist" 
+  #           python_version: "3.12"
+  #     fail-fast: false # do not immediately fail if one of the combinations fail
+
+  #   env:
+  #     MODEL_NAME: ${{ matrix.model_name }}
+  #     PYTHON_VERSION: ${{ matrix.python_version }}
+
+  #   steps:
+  #     - name: Checkout OpenFL repository
+  #       id: checkout_openfl
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ env.COMMIT_ID }}
+
+  #     - name: Pre test run
+  #       uses: ./.github/actions/tr_pre_test_run
+  #       if: ${{ always() }}
+
+  #     - name: Run Task Runner E2E tests with TLS and memory logs
+  #       id: run_tests
+  #       run: |
+  #         python -m pytest -s tests/end_to_end/test_suites/memory_logs_tests.py \
+  #         -k test_log_memory_usage_basic --model_name ${{ env.MODEL_NAME }} \
+  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} \
+  #         --log_memory_usage
+  #         echo "Task runner memory logs test run completed"
+
+  #     - name: Post test run
+  #       uses: ./.github/actions/tr_post_test_run
+  #       if: ${{ always() }}
+  #       with:
+  #         test_type: "With_Memory_Logs"
+
+  # test_straggler_check:
+  #   name: With TLS (torch/mnist_straggler_check, 3.10)
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: 30
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch') ||
+  #     (github.event.pull_request.draft == false) ||
+  #     (needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_straggler_check')
+
+  #   env:
+  #     MODEL_NAME: "torch/mnist_straggler_check"
+  #     PYTHON_VERSION: "3.10"
+
+  #   steps:
+  #     - name: Checkout OpenFL repository
+  #       id: checkout_openfl
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ env.COMMIT_ID }}
+
+  #     - name: Pre test run
+  #       uses: ./.github/actions/tr_pre_test_run
+  #       if: ${{ always() }}
+
+  #     - name: Run Straggler Handling Interface Test
+  #       id: run_tests
+  #       run: |
+  #         python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+  #         -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
+  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
+  #         echo "Straggler handling test run completed"
+
+  #     - name: Post test run
+  #       uses: ./.github/actions/tr_post_test_run
+  #       if: ${{ always() }}
+  #       with:
+  #         test_type: "With_TLS"
+
+  # test_eden_compression:
+  #   name: With TLS (torch/mnist_eden_compression, 3.10)
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: 30
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch') ||
+  #     (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'eden_compression')) || (needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_eden_compression')
+
+  #   env:
+  #     MODEL_NAME: "torch/mnist_eden_compression"
+  #     PYTHON_VERSION: "3.10"
+
+  #   steps:
+  #     - name: Checkout OpenFL repository
+  #       id: checkout_openfl
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ env.COMMIT_ID }}
+
+  #     - name: Pre test run
+  #       uses: ./.github/actions/tr_pre_test_run
+  #       if: ${{ always() }}
+
+  #     - name: Run Eden Compression Test
+  #       id: run_tests
+  #       run: |
+  #         python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+  #         -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
+  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
+  #         echo "Eden compression test run completed"
+
+  #     - name: Post test run
+  #       uses: ./.github/actions/tr_post_test_run
+  #       if: ${{ always() }}
+  #       with:
+  #         test_type: "With_TLS"

--- a/.github/workflows/task_runner_fedeval_e2e.yml
+++ b/.github/workflows/task_runner_fedeval_e2e.yml
@@ -9,6 +9,9 @@ on:
       commit_id:
         required: false
         type: string
+      calling_workflow:
+        required: false
+        type: string
   workflow_dispatch:
     inputs:
       num_rounds:
@@ -30,6 +33,7 @@ env:
   NUM_ROUNDS: ${{ inputs.num_rounds || '5' }}
   NUM_COLLABORATORS: ${{ inputs.num_collaborators || '2' }}
   COMMIT_ID: ${{ inputs.commit_id || github.sha }} # use commit_id from the calling workflow
+  CALLING_WORKFLOW: ${{ inputs.calling_workflow || github.workflow }} # use calling workflow name
 
 jobs:
   test_with_tls:
@@ -39,13 +43,6 @@ jobs:
       (github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-22.04
     timeout-minutes: 30
-    strategy:
-      matrix:
-        # Models like XGBoost (xgb_higgs) and torch/histology require runners with higher memory and CPU to run.
-        # Thus these models are excluded from the matrix for now.
-        model_name: ["torch/mnist", "keras/mnist", "keras/jax/mnist", "keras/torch/mnist"]
-        python_version: ["3.10"]
-      fail-fast: false # do not immediately fail if one of the combinations fail
 
     env:
       MODEL_NAME: ${{ matrix.model_name }}
@@ -58,108 +55,138 @@ jobs:
         with:
           ref: ${{ env.COMMIT_ID }}
 
-      - name: Pre test run
-        uses: ./.github/actions/tr_pre_test_run
-        if: ${{ always() }}
-
-      - name: Run Task Runner E2E tests with TLS
-        id: run_tests
+      - name: Print CALLING_WORKFLOW
         run: |
-          python -m pytest -s tests/end_to_end/test_suites/tr_with_fedeval_tests.py \
-          -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
-          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
-          echo "Task runner end to end test run completed"
+          echo "Calling workflow: ${{ env.CALLING_WORKFLOW }}"
 
-      - name: Post test run
-        uses: ./.github/actions/tr_post_test_run
-        if: ${{ always() }}
-        with:
-          test_type: "FedEval_With_TLS"
+  # test_with_tls:
+  #   name: With TLS
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: 30
+  #   strategy:
+  #     matrix:
+  #       # Models like XGBoost (xgb_higgs) and torch/histology require runners with higher memory and CPU to run.
+  #       # Thus these models are excluded from the matrix for now.
+  #       model_name: ["torch/mnist", "keras/mnist", "keras/jax/mnist", "keras/torch/mnist"]
+  #       python_version: ["3.10"]
+  #     fail-fast: false # do not immediately fail if one of the combinations fail
 
-  test_without_tls:
-    name: Without TLS
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    runs-on: ubuntu-22.04
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        # Testing this scenario only for torch/mnist model and python 3.10
-        # If required, this can be extended to other models and python versions
-        model_name: ["torch/mnist"]
-        python_version: ["3.10"]
-      fail-fast: false # do not immediately fail if one of the combinations fail
+  #   env:
+  #     MODEL_NAME: ${{ matrix.model_name }}
+  #     PYTHON_VERSION: ${{ matrix.python_version }}
 
-    env:
-      MODEL_NAME: ${{ matrix.model_name }}
-      PYTHON_VERSION: ${{ matrix.python_version }}
+  #   steps:
+  #     - name: Checkout OpenFL repository
+  #       id: checkout_openfl
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ env.COMMIT_ID }}
 
-    steps:
-      - name: Checkout OpenFL repository
-        id: checkout_openfl
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.COMMIT_ID }}
+  #     - name: Pre test run
+  #       uses: ./.github/actions/tr_pre_test_run
+  #       if: ${{ always() }}
 
-      - name: Pre test run
-        uses: ./.github/actions/tr_pre_test_run
-        if: ${{ always() }}
+  #     - name: Run Task Runner E2E tests with TLS
+  #       id: run_tests
+  #       run: |
+  #         python -m pytest -s tests/end_to_end/test_suites/tr_with_fedeval_tests.py \
+  #         -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
+  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
+  #         echo "Task runner end to end test run completed"
 
-      - name: Run Task Runner E2E tests without TLS
-        id: run_tests
-        run: |
-          python -m pytest -s tests/end_to_end/test_suites/tr_with_fedeval_tests.py \
-          -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
-          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_tls
-          echo "Task runner end to end test run completed"
+  #     - name: Post test run
+  #       uses: ./.github/actions/tr_post_test_run
+  #       if: ${{ always() }}
+  #       with:
+  #         test_type: "FedEval_With_TLS"
 
-      - name: Post test run
-        uses: ./.github/actions/tr_post_test_run
-        if: ${{ always() }}
-        with:
-          test_type: "FedEval_Without_TLS"
+  # test_without_tls:
+  #   name: Without TLS
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: 30
+  #   strategy:
+  #     matrix:
+  #       # Testing this scenario only for torch/mnist model and python 3.10
+  #       # If required, this can be extended to other models and python versions
+  #       model_name: ["torch/mnist"]
+  #       python_version: ["3.10"]
+  #     fail-fast: false # do not immediately fail if one of the combinations fail
 
-  test_without_client_auth:
-    name: Without Client Auth
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')
-    runs-on: ubuntu-22.04
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        # Testing this scenario for keras/mnist model and python 3.10
-        # If required, this can be extended to other models and python versions
-        model_name: ["keras/mnist"]
-        python_version: ["3.10"]
-      fail-fast: false # do not immediately fail if one of the combinations fail
+  #   env:
+  #     MODEL_NAME: ${{ matrix.model_name }}
+  #     PYTHON_VERSION: ${{ matrix.python_version }}
 
-    env:
-      MODEL_NAME: ${{ matrix.model_name }}
-      PYTHON_VERSION: ${{ matrix.python_version }}
+  #   steps:
+  #     - name: Checkout OpenFL repository
+  #       id: checkout_openfl
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ env.COMMIT_ID }}
 
-    steps:
-      - name: Checkout OpenFL repository
-        id: checkout_openfl
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.COMMIT_ID }}
+  #     - name: Pre test run
+  #       uses: ./.github/actions/tr_pre_test_run
+  #       if: ${{ always() }}
 
-      - name: Pre test run
-        uses: ./.github/actions/tr_pre_test_run
-        if: ${{ always() }}
+  #     - name: Run Task Runner E2E tests without TLS
+  #       id: run_tests
+  #       run: |
+  #         python -m pytest -s tests/end_to_end/test_suites/tr_with_fedeval_tests.py \
+  #         -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
+  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_tls
+  #         echo "Task runner end to end test run completed"
 
-      - name: Run Task Runner E2E tests without TLS
-        id: run_tests
-        run: |
-          python -m pytest -s tests/end_to_end/test_suites/tr_with_fedeval_tests.py \
-          -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
-          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_client_auth
-          echo "Task runner end to end test run completed"
+  #     - name: Post test run
+  #       uses: ./.github/actions/tr_post_test_run
+  #       if: ${{ always() }}
+  #       with:
+  #         test_type: "FedEval_Without_TLS"
 
-      - name: Post test run
-        uses: ./.github/actions/tr_post_test_run
-        if: ${{ always() }}
-        with:
-          test_type: "FedEval_Without_Client_Auth"
+  # test_without_client_auth:
+  #   name: Without Client Auth
+  #   if: |
+  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+  #     (github.event_name == 'workflow_dispatch')
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: 30
+  #   strategy:
+  #     matrix:
+  #       # Testing this scenario for keras/mnist model and python 3.10
+  #       # If required, this can be extended to other models and python versions
+  #       model_name: ["keras/mnist"]
+  #       python_version: ["3.10"]
+  #     fail-fast: false # do not immediately fail if one of the combinations fail
+
+  #   env:
+  #     MODEL_NAME: ${{ matrix.model_name }}
+  #     PYTHON_VERSION: ${{ matrix.python_version }}
+
+  #   steps:
+  #     - name: Checkout OpenFL repository
+  #       id: checkout_openfl
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ env.COMMIT_ID }}
+
+  #     - name: Pre test run
+  #       uses: ./.github/actions/tr_pre_test_run
+  #       if: ${{ always() }}
+
+  #     - name: Run Task Runner E2E tests without TLS
+  #       id: run_tests
+  #       run: |
+  #         python -m pytest -s tests/end_to_end/test_suites/tr_with_fedeval_tests.py \
+  #         -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
+  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_client_auth
+  #         echo "Task runner end to end test run completed"
+
+  #     - name: Post test run
+  #       uses: ./.github/actions/tr_post_test_run
+  #       if: ${{ always() }}
+  #       with:
+  #         test_type: "FedEval_Without_Client_Auth"

--- a/.github/workflows/task_runner_fedeval_e2e.yml
+++ b/.github/workflows/task_runner_fedeval_e2e.yml
@@ -36,23 +36,31 @@ env:
   CALLING_WORKFLOW: ${{ inputs.calling_workflow || github.workflow }} # use calling workflow name
 
 jobs:
-  set_calling_workflow:
-    name: Set calling workflow
+  set_wf_and_model:
+    name: Set calling workflow and models to run
     if: |
       (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
       (github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-22.04
     outputs:
-      calling_workflow: ${{ steps.set_calling_workflow.outputs.calling_workflow }}
+      calling_workflow: ${{ steps.set_wf_and_model.outputs.calling_workflow }}
+      models: ${{ steps.set_wf_and_model.outputs.models }}
     steps:
       - name: Set calling workflow
-        id: set_calling_workflow
+        id: set_wf_and_model
         run: |
           echo "calling_workflow=${{ env.CALLING_WORKFLOW }}" >> "$GITHUB_OUTPUT"
+          if [ "${{ env.CALLING_WORKFLOW }}" != "pr" ]; then
+            echo "Run all the models for non PR scenario"
+            echo "models=[\"keras/mnist\", \"keras/torch/mnist\", \"keras/jax/mnist\", \"torch/mnist\"]" >> "$GITHUB_OUTPUT"
+          else
+            echo "Run only keras/mnist model for PR scenario"
+            echo "models=[\"keras/mnist\"]" >> "$GITHUB_OUTPUT"
+          fi
 
   test_with_tls:
     name: With TLS
-    needs: set_calling_workflow
+    needs: set_wf_and_model
     if: |
       (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
       (github.event_name == 'workflow_dispatch')
@@ -62,7 +70,7 @@ jobs:
       matrix:
         # Models like XGBoost (xgb_higgs) and torch/histology require runners with higher memory and CPU to run.
         # Thus these models are excluded from the matrix for now.
-        model_name: ["torch/mnist", "keras/mnist", "keras/jax/mnist", "keras/torch/mnist"]
+        model_name: ${{ fromJson(needs.set_wf_and_model.outputs.models) }}
         python_version: ["3.10"]
       fail-fast: false # do not immediately fail if one of the combinations fail
 
@@ -97,10 +105,10 @@ jobs:
 
   test_without_tls:
     name: Without TLS
-    needs: set_calling_workflow
+    needs: set_wf_and_model
     if: |
       ((github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')) && (needs.set_calling_workflow.outputs.calling_workflow != 'pr')
+      (github.event_name == 'workflow_dispatch')) && (needs.set_wf_and_model.outputs.calling_workflow != 'pr')
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
@@ -142,10 +150,10 @@ jobs:
 
   test_without_client_auth:
     name: Without Client Auth
-    needs: set_calling_workflow
+    needs: set_wf_and_model
     if: |
       ((github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')) && (needs.set_calling_workflow.outputs.calling_workflow != 'pr')
+      (github.event_name == 'workflow_dispatch')) && (needs.set_wf_and_model.outputs.calling_workflow != 'pr')
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/task_runner_fedeval_e2e.yml
+++ b/.github/workflows/task_runner_fedeval_e2e.yml
@@ -64,6 +64,10 @@ jobs:
         # Thus these models are excluded from the matrix for now.
         model_name: ["torch/mnist", "keras/mnist", "keras/jax/mnist", "keras/torch/mnist"]
         python_version: ["3.10"]
+        include:
+        - model_name: ["torch/mnist", "keras/mnist", "keras/jax/mnist", "keras/torch/mnist"]
+          python_version: ["3.10"]
+          if: ${{ needs.set_calling_workflow.outputs.calling_workflow != 'pr' }}
         exclude:
         - model_name: ["torch/mnist", "keras/jax/mnist", "keras/torch/mnist"]
           python_version: ["3.10"]

--- a/.github/workflows/task_runner_fedeval_e2e.yml
+++ b/.github/workflows/task_runner_fedeval_e2e.yml
@@ -64,14 +64,6 @@ jobs:
         # Thus these models are excluded from the matrix for now.
         model_name: ["torch/mnist", "keras/mnist", "keras/jax/mnist", "keras/torch/mnist"]
         python_version: ["3.10"]
-        include:
-        - model_name: ["torch/mnist", "keras/mnist", "keras/jax/mnist", "keras/torch/mnist"]
-          python_version: ["3.10"]
-          if: ${{ needs.set_calling_workflow.outputs.calling_workflow != 'pr' }}
-        exclude:
-        - model_name: ["torch/mnist", "keras/jax/mnist", "keras/torch/mnist"]
-          python_version: ["3.10"]
-          if : ${{ needs.set_calling_workflow.outputs.calling_workflow == 'pr' }}
       fail-fast: false # do not immediately fail if one of the combinations fail
 
     env:

--- a/.github/workflows/task_runner_fedeval_e2e.yml
+++ b/.github/workflows/task_runner_fedeval_e2e.yml
@@ -62,10 +62,10 @@ jobs:
       matrix:
         # Models like XGBoost (xgb_higgs) and torch/histology require runners with higher memory and CPU to run.
         # Thus these models are excluded from the matrix for now.
-        - model_name: ["torch/mnist", "keras/mnist", "keras/jax/mnist", "keras/torch/mnist"]
-          python_version: ["3.10"]
-          if : ${{ needs.set_calling_workflow.outputs.calling_workflow != 'pr' }}
-        - model_name: ["keras/mnist"]
+        model_name: ["torch/mnist", "keras/mnist", "keras/jax/mnist", "keras/torch/mnist"]
+        python_version: ["3.10"]
+        exclude:
+        - model_name: ["torch/mnist", "keras/jax/mnist", "keras/torch/mnist"]
           python_version: ["3.10"]
           if : ${{ needs.set_calling_workflow.outputs.calling_workflow == 'pr' }}
       fail-fast: false # do not immediately fail if one of the combinations fail

--- a/.github/workflows/task_runner_fedeval_e2e.yml
+++ b/.github/workflows/task_runner_fedeval_e2e.yml
@@ -36,31 +36,32 @@ env:
   CALLING_WORKFLOW: ${{ inputs.calling_workflow || github.workflow }} # use calling workflow name
 
 jobs:
-  set_wf_and_model:
-    name: Set calling workflow and models to run
+  # Set calling workflow and models to run as outputs as env cannot be used in the if condition of the jobs
+  input_selection:
+    name: Input value selection
     if: |
       (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
       (github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-22.04
     outputs:
-      calling_workflow: ${{ steps.set_wf_and_model.outputs.calling_workflow }}
-      models: ${{ steps.set_wf_and_model.outputs.models }}
+      calling_workflow: ${{ steps.input_selection.outputs.calling_workflow }}
+      models_for_tls: ${{ steps.input_selection.outputs.models_for_tls }}
     steps:
       - name: Set calling workflow
-        id: set_wf_and_model
+        id: input_selection
         run: |
           echo "calling_workflow=${{ env.CALLING_WORKFLOW }}" >> "$GITHUB_OUTPUT"
           if [ "${{ env.CALLING_WORKFLOW }}" != "pr" ]; then
             echo "Run all the models for non PR scenario"
-            echo "models=[\"keras/mnist\", \"keras/torch/mnist\", \"keras/jax/mnist\", \"torch/mnist\"]" >> "$GITHUB_OUTPUT"
+            echo "models_for_tls=[\"keras/mnist\", \"keras/torch/mnist\", \"keras/jax/mnist\", \"torch/mnist\"]" >> "$GITHUB_OUTPUT"
           else
             echo "Run only keras/mnist model for PR scenario"
-            echo "models=[\"keras/mnist\"]" >> "$GITHUB_OUTPUT"
+            echo "models_for_tls=[\"keras/mnist\"]" >> "$GITHUB_OUTPUT"
           fi
 
   test_with_tls:
     name: With TLS
-    needs: set_wf_and_model
+    needs: input_selection
     if: |
       (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
       (github.event_name == 'workflow_dispatch')
@@ -70,7 +71,7 @@ jobs:
       matrix:
         # Models like XGBoost (xgb_higgs) and torch/histology require runners with higher memory and CPU to run.
         # Thus these models are excluded from the matrix for now.
-        model_name: ${{ fromJson(needs.set_wf_and_model.outputs.models) }}
+        model_name: ${{ fromJson(needs.input_selection.outputs.models_for_tls) }}
         python_version: ["3.10"]
       fail-fast: false # do not immediately fail if one of the combinations fail
 
@@ -105,10 +106,10 @@ jobs:
 
   test_without_tls:
     name: Without TLS
-    needs: set_wf_and_model
+    needs: input_selection
     if: |
       ((github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')) && (needs.set_wf_and_model.outputs.calling_workflow != 'pr')
+      (github.event_name == 'workflow_dispatch')) && (needs.input_selection.outputs.calling_workflow != 'pr')
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
@@ -150,10 +151,10 @@ jobs:
 
   test_without_client_auth:
     name: Without Client Auth
-    needs: set_wf_and_model
+    needs: input_selection
     if: |
       ((github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch')) && (needs.set_wf_and_model.outputs.calling_workflow != 'pr')
+      (github.event_name == 'workflow_dispatch')) && (needs.input_selection.outputs.calling_workflow != 'pr')
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/task_runner_fedeval_e2e.yml
+++ b/.github/workflows/task_runner_fedeval_e2e.yml
@@ -36,13 +36,39 @@ env:
   CALLING_WORKFLOW: ${{ inputs.calling_workflow || github.workflow }} # use calling workflow name
 
 jobs:
+  set_calling_workflow:
+    name: Set calling workflow
+    if: |
+      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-22.04
+    outputs:
+      calling_workflow: ${{ steps.set_calling_workflow.outputs.calling_workflow }}
+    steps:
+      - name: Set calling workflow
+        id: set_calling_workflow
+        run: |
+          echo "calling_workflow=${{ env.CALLING_WORKFLOW }}" >> "$GITHUB_OUTPUT"
+
   test_with_tls:
     name: With TLS
+    needs: set_calling_workflow
     if: |
       (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
       (github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-22.04
     timeout-minutes: 30
+    strategy:
+      matrix:
+        # Models like XGBoost (xgb_higgs) and torch/histology require runners with higher memory and CPU to run.
+        # Thus these models are excluded from the matrix for now.
+        - model_name: ["torch/mnist", "keras/mnist", "keras/jax/mnist", "keras/torch/mnist"]
+          python_version: ["3.10"]
+          if : ${{ needs.set_calling_workflow.outputs.calling_workflow != 'pr' }}
+        - model_name: ["keras/mnist"]
+          python_version: ["3.10"]
+          if : ${{ needs.set_calling_workflow.outputs.calling_workflow == 'pr' }}
+      fail-fast: false # do not immediately fail if one of the combinations fail
 
     env:
       MODEL_NAME: ${{ matrix.model_name }}
@@ -55,138 +81,110 @@ jobs:
         with:
           ref: ${{ env.COMMIT_ID }}
 
-      - name: Print CALLING_WORKFLOW
+      - name: Pre test run
+        uses: ./.github/actions/tr_pre_test_run
+        if: ${{ always() }}
+
+      - name: Run Task Runner E2E tests with TLS
+        id: run_tests
         run: |
-          echo "Calling workflow: ${{ env.CALLING_WORKFLOW }}"
+          python -m pytest -s tests/end_to_end/test_suites/tr_with_fedeval_tests.py \
+          -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
+          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
+          echo "Task runner end to end test run completed"
 
-  # test_with_tls:
-  #   name: With TLS
-  #   if: |
-  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-  #     (github.event_name == 'workflow_dispatch')
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 30
-  #   strategy:
-  #     matrix:
-  #       # Models like XGBoost (xgb_higgs) and torch/histology require runners with higher memory and CPU to run.
-  #       # Thus these models are excluded from the matrix for now.
-  #       model_name: ["torch/mnist", "keras/mnist", "keras/jax/mnist", "keras/torch/mnist"]
-  #       python_version: ["3.10"]
-  #     fail-fast: false # do not immediately fail if one of the combinations fail
+      - name: Post test run
+        uses: ./.github/actions/tr_post_test_run
+        if: ${{ always() }}
+        with:
+          test_type: "FedEval_With_TLS"
 
-  #   env:
-  #     MODEL_NAME: ${{ matrix.model_name }}
-  #     PYTHON_VERSION: ${{ matrix.python_version }}
+  test_without_tls:
+    name: Without TLS
+    needs: set_calling_workflow
+    if: |
+      ((github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')) && (needs.set_calling_workflow.outputs.calling_workflow != 'pr')
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        # Testing this scenario only for torch/mnist model and python 3.10
+        # If required, this can be extended to other models and python versions
+        model_name: ["torch/mnist"]
+        python_version: ["3.10"]
+      fail-fast: false # do not immediately fail if one of the combinations fail
 
-  #   steps:
-  #     - name: Checkout OpenFL repository
-  #       id: checkout_openfl
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ env.COMMIT_ID }}
+    env:
+      MODEL_NAME: ${{ matrix.model_name }}
+      PYTHON_VERSION: ${{ matrix.python_version }}
 
-  #     - name: Pre test run
-  #       uses: ./.github/actions/tr_pre_test_run
-  #       if: ${{ always() }}
+    steps:
+      - name: Checkout OpenFL repository
+        id: checkout_openfl
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.COMMIT_ID }}
 
-  #     - name: Run Task Runner E2E tests with TLS
-  #       id: run_tests
-  #       run: |
-  #         python -m pytest -s tests/end_to_end/test_suites/tr_with_fedeval_tests.py \
-  #         -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
-  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }}
-  #         echo "Task runner end to end test run completed"
+      - name: Pre test run
+        uses: ./.github/actions/tr_pre_test_run
+        if: ${{ always() }}
 
-  #     - name: Post test run
-  #       uses: ./.github/actions/tr_post_test_run
-  #       if: ${{ always() }}
-  #       with:
-  #         test_type: "FedEval_With_TLS"
+      - name: Run Task Runner E2E tests without TLS
+        id: run_tests
+        run: |
+          python -m pytest -s tests/end_to_end/test_suites/tr_with_fedeval_tests.py \
+          -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
+          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_tls
+          echo "Task runner end to end test run completed"
 
-  # test_without_tls:
-  #   name: Without TLS
-  #   if: |
-  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-  #     (github.event_name == 'workflow_dispatch')
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 30
-  #   strategy:
-  #     matrix:
-  #       # Testing this scenario only for torch/mnist model and python 3.10
-  #       # If required, this can be extended to other models and python versions
-  #       model_name: ["torch/mnist"]
-  #       python_version: ["3.10"]
-  #     fail-fast: false # do not immediately fail if one of the combinations fail
+      - name: Post test run
+        uses: ./.github/actions/tr_post_test_run
+        if: ${{ always() }}
+        with:
+          test_type: "FedEval_Without_TLS"
 
-  #   env:
-  #     MODEL_NAME: ${{ matrix.model_name }}
-  #     PYTHON_VERSION: ${{ matrix.python_version }}
+  test_without_client_auth:
+    name: Without Client Auth
+    needs: set_calling_workflow
+    if: |
+      ((github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
+      (github.event_name == 'workflow_dispatch')) && (needs.set_calling_workflow.outputs.calling_workflow != 'pr')
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        # Testing this scenario for keras/mnist model and python 3.10
+        # If required, this can be extended to other models and python versions
+        model_name: ["keras/mnist"]
+        python_version: ["3.10"]
+      fail-fast: false # do not immediately fail if one of the combinations fail
 
-  #   steps:
-  #     - name: Checkout OpenFL repository
-  #       id: checkout_openfl
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ env.COMMIT_ID }}
+    env:
+      MODEL_NAME: ${{ matrix.model_name }}
+      PYTHON_VERSION: ${{ matrix.python_version }}
 
-  #     - name: Pre test run
-  #       uses: ./.github/actions/tr_pre_test_run
-  #       if: ${{ always() }}
+    steps:
+      - name: Checkout OpenFL repository
+        id: checkout_openfl
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.COMMIT_ID }}
 
-  #     - name: Run Task Runner E2E tests without TLS
-  #       id: run_tests
-  #       run: |
-  #         python -m pytest -s tests/end_to_end/test_suites/tr_with_fedeval_tests.py \
-  #         -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
-  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_tls
-  #         echo "Task runner end to end test run completed"
+      - name: Pre test run
+        uses: ./.github/actions/tr_pre_test_run
+        if: ${{ always() }}
 
-  #     - name: Post test run
-  #       uses: ./.github/actions/tr_post_test_run
-  #       if: ${{ always() }}
-  #       with:
-  #         test_type: "FedEval_Without_TLS"
+      - name: Run Task Runner E2E tests without TLS
+        id: run_tests
+        run: |
+          python -m pytest -s tests/end_to_end/test_suites/tr_with_fedeval_tests.py \
+          -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
+          --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_client_auth
+          echo "Task runner end to end test run completed"
 
-  # test_without_client_auth:
-  #   name: Without Client Auth
-  #   if: |
-  #     (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-  #     (github.event_name == 'workflow_dispatch')
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 30
-  #   strategy:
-  #     matrix:
-  #       # Testing this scenario for keras/mnist model and python 3.10
-  #       # If required, this can be extended to other models and python versions
-  #       model_name: ["keras/mnist"]
-  #       python_version: ["3.10"]
-  #     fail-fast: false # do not immediately fail if one of the combinations fail
-
-  #   env:
-  #     MODEL_NAME: ${{ matrix.model_name }}
-  #     PYTHON_VERSION: ${{ matrix.python_version }}
-
-  #   steps:
-  #     - name: Checkout OpenFL repository
-  #       id: checkout_openfl
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ env.COMMIT_ID }}
-
-  #     - name: Pre test run
-  #       uses: ./.github/actions/tr_pre_test_run
-  #       if: ${{ always() }}
-
-  #     - name: Run Task Runner E2E tests without TLS
-  #       id: run_tests
-  #       run: |
-  #         python -m pytest -s tests/end_to_end/test_suites/tr_with_fedeval_tests.py \
-  #         -m task_runner_basic --model_name ${{ env.MODEL_NAME }} \
-  #         --num_rounds ${{ env.NUM_ROUNDS }} --num_collaborators ${{ env.NUM_COLLABORATORS }} --disable_client_auth
-  #         echo "Task runner end to end test run completed"
-
-  #     - name: Post test run
-  #       uses: ./.github/actions/tr_post_test_run
-  #       if: ${{ always() }}
-  #       with:
-  #         test_type: "FedEval_Without_Client_Auth"
+      - name: Post test run
+        uses: ./.github/actions/tr_post_test_run
+        if: ${{ always() }}
+        with:
+          test_type: "FedEval_Without_Client_Auth"


### PR DESCRIPTION
## Summary
1. To pass `calling_workflow` input from PQ and PR workflows to be able to include/exclude models or skip/run the jobs in the called workflows.
2. To include TaskRunner FedEval testcase in PR pipeline.

## Type of Change (Mandatory)
Specify the type of change being made. 
- E2E framework - Feature enhancement  

## Description (Mandatory)
1. Added `calling_workflow` as input under `workflow_call` of Task Runner E2E Basic and FedEval workflows and handling of this flag.
3. Provided `pr` and `pq` as `calling_workflow` from PR and PQ pipeline respectively.
4. In Task Runner FedEval, if the flag is `pr`, running for `keras/mnist` model only otherwise all the models.

## Testing

PR pipeline - https://github.com/securefederatedai/openfl/actions/runs/14467278893
PQ pipeline - https://github.com/noopurintel/openfl/actions/runs/14467252991 (FedEval is expected to fail due to #1533 )
