### PR TITLE
Removing the references of federated-evaluation/aggregator.yaml

### DIFF
--- a/openfl-workspace/torch/mnist_fed_eval/plan/plan.yaml
+++ b/openfl-workspace/torch/mnist_fed_eval/plan/plan.yaml
@@ -2,7 +2,7 @@
 # Licensed subject to the terms of the separately executed evaluation license agreement between Intel Corporation and you.
 
 aggregator :
-  defaults : plan/defaults/federated-evaluation/aggregator.yaml
+  defaults : plan/defaults/aggregator.yaml
   template : openfl.component.Aggregator
   settings :
     init_state_path     : save/torch_cnn_mnist_init.pbuf

--- a/openfl-workspace/workspace/plan/defaults/federated-evaluation/aggregator.yaml
+++ b/openfl-workspace/workspace/plan/defaults/federated-evaluation/aggregator.yaml
@@ -1,7 +1,0 @@
-template : openfl.component.Aggregator
-settings :
-    db_store_rounds : 2
-    write_logs      : true
-    ######### Default rounds to 1 for evaluation #############
-    rounds_to_train     : 1
-    ##########################################################


### PR DESCRIPTION
## Summary
Removing the references of federated-evaluation/aggregator.yaml

## Type of Change (Mandatory)
Specify the type of change being made. 
- Bug fix  Issue https://github.com/securefederatedai/openfl/issues/1377 


## Description (Mandatory)
As with latest change in federated evaluation, we dont need a separate aggreagtor.yaml, hence removing it.

## Testing
Tested locally
