### PR TITLE
Fixing bandit issue in parse_task_runner_logs.py

### DIFF
--- a/.github/config/parse_task_runner_logs.py
+++ b/.github/config/parse_task_runner_logs.py
@@ -46,9 +46,9 @@ def run_trufflehog(log_file):
     """
     try:
         # Run TruffleHog with JSON output and capture the output
-        cmd = f'trufflehog filesystem {log_file} --no-update --json'
+        cmd = ["trufflehog", "filesystem", log_file, "--no-update", "--json"]
         result = subprocess.run(
-            cmd, capture_output=True, shell=True, text=True, timeout=30, check=True
+            cmd, capture_output=True, text=True, timeout=30, check=True
         )
         # Extract the last JSON object from the output
         lines = result.stderr.strip().split("\n")


### PR DESCRIPTION
## Summary
Remove shell=True to fix bandit issue.

## Type of Change (Mandatory)
Specify the type of change being made. 
 - Bug fix  

## Description (Mandatory)
Bandit fix - Recorded in the Bandit run 
<img width="1712" alt="image" src="https://github.com/user-attachments/assets/d68bcff8-f2ec-4b64-acf2-cbbd1f785007" />


## Testing
PR pipeline.
Task_Runner_Secret_SSL_E2E  - https://github.com/payalcha/openfl/actions/runs/14487811894

Post fix -
<img width="1710" alt="image" src="https://github.com/user-attachments/assets/7e97e262-88b6-4195-8605-b89a8419876f" />


<!-- ## Additional Information
[Any additional information that reviewers should be aware of.] -->