### PR TITLE
TaskRunner FedEval - fetch model score from metric file instead of tensor db

### DIFF
--- a/.github/workflows/gandlf.yml
+++ b/.github/workflows/gandlf.yml
@@ -41,6 +41,7 @@ jobs:
         pip install torch==2.3.1+cpu torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu
         pip install paramiko
         pip install .
+        pip install -r test-requirements.txt
 
     - name: Create gandlf and results directories
       run: |

--- a/openfl/component/aggregator/aggregator.py
+++ b/openfl/component/aggregator/aggregator.py
@@ -367,7 +367,7 @@ class Aggregator:
 
         if file_path == self.best_state_path:
             self.best_tensor_dict = tensor_dict
-        
+
         if file_path == self.last_state_path:
             # Transaction to persist/delete all data needed to increment the round
             if self.persistent_db:
@@ -383,7 +383,7 @@ class Aggregator:
                     round_number,
                 )
             self.last_tensor_dict = tensor_dict
-            
+
         self.model = utils.construct_model_proto(
             tensor_dict, round_number, self.compression_pipeline
         )
@@ -1158,7 +1158,7 @@ class Aggregator:
             self._save_model(self.round_number, self.last_state_path)
         else:
             logger.info("Skipping model save for round %s in evaluation mode.", self.round_number)
-            
+
         self.round_number += 1
 
         # resetting stragglers for task for a new round

--- a/tests/end_to_end/test_suites/tr_with_fedeval_tests.py
+++ b/tests/end_to_end/test_suites/tr_with_fedeval_tests.py
@@ -36,7 +36,7 @@ def test_eval_federation_via_native(request, fx_federation_tr):
 
     # Set the best model path in request. It is used during plan initialization for evaluation step
     request.config.best_model_path = os.path.join(fx_federation_tr.aggregator.workspace_path, "save", "best.pbuf")
-    
+
     best_model_score = fed_helper.get_best_agg_score(database_file=fx_federation_tr.aggregator.tensor_db_file)
     log.info(f"Model score post {request.config.num_rounds} rounds: {best_model_score}")
 
@@ -59,7 +59,7 @@ def test_eval_federation_via_native(request, fx_federation_tr):
 
     # verify that the model score is similar to the previous model score max of 0.001% difference
     assert abs(best_model_score - best_model_score_eval) <= TOLERANCE, "Model score is not similar to the previous score"
-    
+
     # If we reach here, the evaluation federation ran successfully
     log.info("Evaluation federation completed successfully")
 
@@ -95,7 +95,7 @@ def test_eval_federation_via_dockerized_workspace(request, fx_federation_tr_dws)
 
     # Start the evaluation federation
     assert fed_helper.run_federation_for_dws(new_fed_obj, use_tls=request.config.use_tls)
-    
+
     # Verify the completion of the evaluation federation run
     assert fed_helper.verify_federation_run_completion(
         new_fed_obj,

--- a/tests/end_to_end/test_suites/tr_with_fedeval_tests.py
+++ b/tests/end_to_end/test_suites/tr_with_fedeval_tests.py
@@ -53,7 +53,7 @@ def test_eval_federation_via_native(request, fx_federation_tr):
         num_rounds=1,
     ), "Evaluation federation completion failed"
 
-    metric_file = os.path.join(new_fed_obj.aggregator.worspace_path, "logs", "aggregator_metrics.txt")
+    metric_file = os.path.join(new_fed_obj.aggregator.workspace_path, "logs", "aggregator_metrics.txt")
     best_model_score_eval = fed_helper.get_best_agg_score(agg_metric_file=metric_file)
     log.info(f"Model score post {request.config.num_rounds} rounds: {best_model_score}")
 
@@ -103,7 +103,7 @@ def test_eval_federation_via_dockerized_workspace(request, fx_federation_tr_dws)
         num_rounds=1,
     ), "Evaluation federation completion failed"
 
-    metric_file = os.path.join(new_fed_obj.aggregator.worspace_path, "logs", "aggregator_metrics.txt")
+    metric_file = os.path.join(new_fed_obj.aggregator.workspace_path, "logs", "aggregator_metrics.txt")
     best_model_score_eval = fed_helper.get_best_agg_score(agg_metric_file=metric_file)
     log.info(f"Model score post {request.config.num_rounds} rounds: {best_model_score}")
 

--- a/tests/end_to_end/test_suites/tr_with_fedeval_tests.py
+++ b/tests/end_to_end/test_suites/tr_with_fedeval_tests.py
@@ -14,6 +14,8 @@ from tests.end_to_end.utils.tr_workspace import create_tr_workspace, create_tr_d
 
 log = logging.getLogger(__name__)
 
+TOLERANCE = 0.00001
+
 @pytest.mark.task_runner_basic
 def test_eval_federation_via_native(request, fx_federation_tr):
     """
@@ -35,6 +37,9 @@ def test_eval_federation_via_native(request, fx_federation_tr):
     # Set the best model path in request. It is used during plan initialization for evaluation step
     request.config.best_model_path = os.path.join(fx_federation_tr.aggregator.workspace_path, "save", "best.pbuf")
     
+    best_model_score = fed_helper.get_best_agg_score(database_file=fx_federation_tr.aggregator.tensor_db_file)
+    log.info(f"Model score post {request.config.num_rounds} rounds: {best_model_score}")
+
     # Create new workspace with evaluation scope
     new_fed_obj = create_tr_workspace(request, eval_scope=True)
 
@@ -47,6 +52,13 @@ def test_eval_federation_via_native(request, fx_federation_tr):
         test_env=request.config.test_env,
         num_rounds=1,
     ), "Evaluation federation completion failed"
+
+    metric_file = os.path.join(new_fed_obj.aggregator.worspace_path, "logs", "aggregator_metrics.txt")
+    best_model_score_eval = fed_helper.get_best_agg_score(agg_metric_file=metric_file)
+    log.info(f"Model score post {request.config.num_rounds} rounds: {best_model_score}")
+
+    # verify that the model score is similar to the previous model score max of 0.001% difference
+    assert abs(best_model_score - best_model_score_eval) <= TOLERANCE, "Model score is not similar to the previous score"
     
     # If we reach here, the evaluation federation ran successfully
     log.info("Evaluation federation completed successfully")
@@ -75,6 +87,9 @@ def test_eval_federation_via_dockerized_workspace(request, fx_federation_tr_dws)
     # Set the best model path in request. It is used during plan initialization for evaluation step
     request.config.best_model_path = os.path.join(fx_federation_tr_dws.aggregator.workspace_path, "save", "best.pbuf")
 
+    best_model_score = fed_helper.get_best_agg_score(database_file=fx_federation_tr_dws.aggregator.tensor_db_file)
+    log.info(f"Model score post {request.config.num_rounds} rounds: {best_model_score}")
+
     # Create new workspace with evaluation scope
     new_fed_obj = create_tr_dws_workspace(request, eval_scope=True)
 
@@ -87,6 +102,13 @@ def test_eval_federation_via_dockerized_workspace(request, fx_federation_tr_dws)
         test_env=request.config.test_env,
         num_rounds=1,
     ), "Evaluation federation completion failed"
-    
+
+    metric_file = os.path.join(new_fed_obj.aggregator.worspace_path, "logs", "aggregator_metrics.txt")
+    best_model_score_eval = fed_helper.get_best_agg_score(agg_metric_file=metric_file)
+    log.info(f"Model score post {request.config.num_rounds} rounds: {best_model_score}")
+
+    # verify that the model score is similar to the previous model score max of 0.001% difference
+    assert abs(best_model_score - best_model_score_eval) <= TOLERANCE, "Model score is not similar to the previous score"
+
     # If we reach here, the evaluation federation ran successfully
     log.info("Dockerized evaluation federation completed successfully")

--- a/tests/end_to_end/utils/constants.py
+++ b/tests/end_to_end/utils/constants.py
@@ -57,3 +57,4 @@ COL_END_MSG = "Received shutdown signal"
 
 COL_CERTIFY_CMD = "fx collaborator certify --import 'agg_to_col_{}_signed_cert.zip'"
 EXCEPTION = "Exception"
+AGG_METRIC_MODEL_ACCURACY_KEY = "aggregator/aggregated_model_validation/accuracy"

--- a/tests/end_to_end/utils/federation_helper.py
+++ b/tests/end_to_end/utils/federation_helper.py
@@ -1028,19 +1028,20 @@ def get_best_agg_score(database_file=None, agg_metric_file=None):
         return db_helper.get_key_value_from_db("best_score", database_file)
     else:
         try:
-            last_value = None
             with open(agg_metric_file, 'r') as file:
                 for line in file:
                     if constants.AGG_METRIC_MODEL_ACCURACY_KEY in line:
                         # Extract the value after the key
                         parts = line.strip().split()
                         if len(parts) > 1:
-                            last_value = parts[-1]  # Assuming the value is the last part of the line
-                            break
+                            value = parts[-1]
+                            # Consider only the numeric part of the value
+                            value = re.sub(r'[^\d.-]', '', value)
+                            return float(value)
+            raise ValueError(f"Key '{constants.AGG_METRIC_MODEL_ACCURACY_KEY}' not found in the file {agg_metric_file}")
         except Exception as e:
             log.error(f"Failed to read the metrics file: {e}")
             raise e
-        return last_value
 
 
 def validate_round_increment(inp_round, database_file, total_rounds, timeout=300, sleep_interval=5):

--- a/tests/end_to_end/utils/federation_helper.py
+++ b/tests/end_to_end/utils/federation_helper.py
@@ -1011,15 +1011,36 @@ def get_current_round(database_file: str) -> int:
     return int(db_helper.get_key_value_from_db("round_number", database_file))
 
 
-def get_best_agg_score(database_file: str) -> float:
+def get_best_agg_score(database_file=None, agg_metric_file=None):
     """
-    Get the best aggregated score from the database file
+    Get the best aggregated score from the database file or aggregator metrics file
     Args:
-        database_file (str): Database file
+        database_file (str): Database file. Optional.
+        agg_metric_file (str): Aggregator metrics file. Optional.
     Returns:
         float: Best aggregated score
     """
-    return db_helper.get_key_value_from_db("best_score", database_file)
+    # If both the params are not present, raise exception
+    if not database_file and not agg_metric_file:
+        raise ValueError("Either database_file or agg_metric_file should be provided")
+
+    if database_file:
+        return db_helper.get_key_value_from_db("best_score", database_file)
+    else:
+        try:
+            last_value = None
+            with open(metric_file, 'r') as file:
+                for line in file:
+                    if constants.AGG_METRIC_MODEL_ACCURACY_KEY in line:
+                        # Extract the value after the key
+                        parts = line.strip().split()
+                        if len(parts) > 1:
+                            last_value = parts[-1]  # Assuming the value is the last part of the line
+                            break
+        except Exception as e:
+            log.error(f"Failed to read the metrics file: {e}")
+            raise e
+        return last_value
 
 
 def validate_round_increment(inp_round, database_file, total_rounds, timeout=300, sleep_interval=5):

--- a/tests/end_to_end/utils/federation_helper.py
+++ b/tests/end_to_end/utils/federation_helper.py
@@ -1029,7 +1029,7 @@ def get_best_agg_score(database_file=None, agg_metric_file=None):
     else:
         try:
             last_value = None
-            with open(metric_file, 'r') as file:
+            with open(agg_metric_file, 'r') as file:
                 for line in file:
                     if constants.AGG_METRIC_MODEL_ACCURACY_KEY in line:
                         # Extract the value after the key

--- a/tests/end_to_end/utils/federation_helper.py
+++ b/tests/end_to_end/utils/federation_helper.py
@@ -20,6 +20,7 @@ import tests.end_to_end.utils.exceptions as ex
 import tests.end_to_end.utils.interruption_helper as intr_helper
 import tests.end_to_end.utils.ssh_helper as ssh
 from tests.end_to_end.models import collaborator as col_model
+from tests.end_to_end.utils.generate_report import convert_to_json
 
 log = logging.getLogger(__name__)
 home_dir = Path().home()
@@ -1027,21 +1028,12 @@ def get_best_agg_score(database_file=None, agg_metric_file=None):
     if database_file:
         return db_helper.get_key_value_from_db("best_score", database_file)
     else:
-        try:
-            with open(agg_metric_file, 'r') as file:
-                for line in file:
-                    if constants.AGG_METRIC_MODEL_ACCURACY_KEY in line:
-                        # Extract the value after the key
-                        parts = line.strip().split()
-                        if len(parts) > 1:
-                            value = parts[-1]
-                            # Consider only the numeric part of the value
-                            value = re.sub(r'[^\d.-]', '', value)
-                            return float(value)
-            raise ValueError(f"Key '{constants.AGG_METRIC_MODEL_ACCURACY_KEY}' not found in the file {agg_metric_file}")
-        except Exception as e:
-            log.error(f"Failed to read the metrics file: {e}")
-            raise e
+        json_file = convert_to_json(agg_metric_file)
+        best_score = json_file[-1].get(constants.AGG_METRIC_MODEL_ACCURACY_KEY)
+        if best_score:
+            return float(best_score)
+        else:
+            raise ValueError("Best score not found in the aggregator metrics file")
 
 
 def validate_round_increment(inp_round, database_file, total_rounds, timeout=300, sleep_interval=5):


### PR DESCRIPTION
## Summary
To fetch the best model score from aggregator metric file instead of tensor db.
Reason - With this PR - https://github.com/securefederatedai/openfl/pull/1538, the score is not saved for evaluation mode, thus no tensor.db in picture.

## Type of Change (Mandatory)
Specify the type of change being made. 
- E2E federated evaluation logic change

## Description (Mandatory)
Same as mentioned in the summary.

## Testing
PR pipeline contains relevant test cases including recently added FedEval test.