### PR TITLE
TaskRunner E2E - Added missing `needs` for straggler and eden jobs

### DIFF
--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -326,11 +326,7 @@ jobs:
     needs: input_selection
     runs-on: ubuntu-22.04
     timeout-minutes: 30
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch') ||
-      (github.event.pull_request.draft == false) ||
-      (needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_straggler_check')
+    if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_straggler_check'
 
     env:
       MODEL_NAME: "torch/mnist_straggler_check"
@@ -366,10 +362,7 @@ jobs:
     needs: input_selection
     runs-on: ubuntu-22.04
     timeout-minutes: 30
-    if: |
-      (github.event_name == 'schedule' && github.repository_owner == 'securefederatedai') ||
-      (github.event_name == 'workflow_dispatch') ||
-      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'eden_compression')) || (needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_eden_compression')
+    if: contains(github.event.pull_request.labels.*.name, 'eden_compression')) || (needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_eden_compression')
 
     env:
       MODEL_NAME: "torch/mnist_eden_compression"

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -362,7 +362,7 @@ jobs:
     needs: input_selection
     runs-on: ubuntu-22.04
     timeout-minutes: 30
-    if: contains(github.event.pull_request.labels.*.name, 'eden_compression')) || (needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_eden_compression')
+    if: contains(github.event.pull_request.labels.*.name, 'eden_compression') || (needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_eden_compression')
 
     env:
       MODEL_NAME: "torch/mnist_eden_compression"

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -323,6 +323,7 @@ jobs:
 
   test_straggler_check:
     name: With TLS (torch/mnist_straggler_check, 3.10)
+    needs: input_selection
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     if: |
@@ -362,6 +363,7 @@ jobs:
 
   test_eden_compression:
     name: With TLS (torch/mnist_eden_compression, 3.10)
+    needs: input_selection
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     if: |

--- a/openfl/component/aggregator/aggregator.py
+++ b/openfl/component/aggregator/aggregator.py
@@ -1216,7 +1216,7 @@ class Aggregator:
             self.collaborators_done.append(collaborator_name)
             logger.info(
                 f"Round {self.round_number}: Collaborators that have completed all tasks: "
-                f"{self.collaborators_done}"
+                f"{sorted(self.collaborators_done)}"
             )
 
     def stop(self, failed_collaborator: str = None) -> None:

--- a/openfl/component/aggregator/aggregator.py
+++ b/openfl/component/aggregator/aggregator.py
@@ -1216,7 +1216,7 @@ class Aggregator:
             self.collaborators_done.append(collaborator_name)
             logger.info(
                 f"Round {self.round_number}: Collaborators that have completed all tasks: "
-                f"{sorted(self.collaborators_done)}"
+                f"{self.collaborators_done}"
             )
 
     def stop(self, failed_collaborator: str = None) -> None:

--- a/tests/end_to_end/utils/federation_helper.py
+++ b/tests/end_to_end/utils/federation_helper.py
@@ -340,9 +340,16 @@ def _verify_completion_for_participant(
         with open(participant.res_file, "r") as file:
             lines = [line.strip() for line in file.readlines()]
 
-        # Get the no of lines (based on the number of collaborators) to verify the completion message
-        reverse_index = 10 if (num_collaborators < 5) else (num_collaborators + 5)
-        content = list(filter(str.rstrip, lines))[-reverse_index:] if len(lines) >= reverse_index else lines
+        # Get the desired no of lines from the log file
+        if num_collaborators < 5:
+            reverse_index = 10
+        else:
+            # For more than 5 collaborators, set the index to 10 + number of collaborators
+            # This is to ensure that we get the completion message for all the collaborators
+            reverse_index = num_collaborators + 5
+
+        # Get the required lines from the log file
+        content = lines[-reverse_index:]
 
         # Print last line of the log file on screen to track the progress
         log.info(f"Last line in {participant.name} log: {lines[-1:]}")

--- a/tests/end_to_end/utils/federation_helper.py
+++ b/tests/end_to_end/utils/federation_helper.py
@@ -349,7 +349,10 @@ def _verify_completion_for_participant(
             reverse_index = num_collaborators + 5
 
         # Get the required lines from the log file
-        content = lines[-reverse_index:]
+        if len(lines) >= reverse_index:
+            content = lines[-reverse_index:]
+        else:
+            content = lines
 
         # Print last line of the log file on screen to track the progress
         log.info(f"Last line in {participant.name} log: {lines[-1:]}")

--- a/tests/end_to_end/utils/federation_helper.py
+++ b/tests/end_to_end/utils/federation_helper.py
@@ -295,6 +295,7 @@ def verify_federation_run_completion(fed_obj, test_env, num_rounds):
             _verify_completion_for_participant,
             participant,
             num_rounds,
+            num_collaborators=len(fed_obj.collaborators),
         )
         for participant in fed_obj.collaborators + [fed_obj.aggregator]
     ]
@@ -309,13 +310,14 @@ def verify_federation_run_completion(fed_obj, test_env, num_rounds):
 
 
 def _verify_completion_for_participant(
-    participant, num_rounds, time_for_each_round=100
+    participant, num_rounds, num_collaborators, time_for_each_round=100
 ):
     """
     Verify the completion of the process for the participant
     Args:
         participant (object): Participant object
         num_rounds (int): Number of rounds
+        num_collaborators (int): Number of collaborators
         time_for_each_round (int): Time for each round
     Returns:
         bool: True if successful, else False
@@ -338,8 +340,9 @@ def _verify_completion_for_participant(
         with open(participant.res_file, "r") as file:
             lines = [line.strip() for line in file.readlines()]
 
-        # Below change is done to handle warnings coming in end of runs
-        content = list(filter(str.rstrip, lines))[-10:] if len(lines) >= 10 else lines
+        # Get the no of lines (based on the number of collaborators) to verify the completion message
+        reverse_index = num_collaborators + 5
+        content = list(filter(str.rstrip, lines))[-reverse_index:] if len(lines) >= reverse_index else lines
 
         # Print last line of the log file on screen to track the progress
         log.info(f"Last line in {participant.name} log: {lines[-1:]}")

--- a/tests/end_to_end/utils/federation_helper.py
+++ b/tests/end_to_end/utils/federation_helper.py
@@ -341,7 +341,7 @@ def _verify_completion_for_participant(
             lines = [line.strip() for line in file.readlines()]
 
         # Get the no of lines (based on the number of collaborators) to verify the completion message
-        reverse_index = num_collaborators + 5
+        reverse_index = 10 if (num_collaborators < 5) else (num_collaborators + 5)
         content = list(filter(str.rstrip, lines))[-reverse_index:] if len(lines) >= reverse_index else lines
 
         # Print last line of the log file on screen to track the progress


### PR DESCRIPTION
## Summary
TaskRunner E2E - Added missing needs for straggler and eden jobs.

## Type of Change (Mandatory)
Specify the type of change being made. 
- E2E automation gap fix

## Description (Mandatory)

1. In TaskRunner workflow contains these jobs:

- input_selection (doesn't run anything but assign the params to be used)
- test_with_tls
- test_without_tls
- test_without_client_auth
- test_memory_logs
- test_straggler_check
- test_eden_compression
          
Although the straggler and eden compression jobs have an `if` condition based on `input_selection` job, but the `needs` entry itself was missing. 
Consequence - even when specific job was selected, these two jobs were also picked up unnecessarily. 

4. Another change - we read aggregator and collaborator logs to check if the federation run has completed. So far, we were picking last 10 lines; but while testing with a bit large set of collaborators - say >=10, the actual message was sometimes getting missed out from last 10 lines leading to time out. Now I am considering the no of collaborators to come up with <last_n_lines> value.

## Testing

Before the change
Task Runner with 10 collaborators and only "with_tls" job selected - https://github.com/noopurintel/openfl/actions/runs/14511015377/job/40709506485#step:4:670   -- extra 2 jobs ran and they timed out because the expected message wasn't present in last 10 lines.

After the change
Task Runner with 30 collaborators and only "with_tls" job selected - https://github.com/noopurintel/openfl/actions/runs/14511843426    -- only TLS job ran and process completed.

After addressing the review comments:

[With 4 collaborators](https://github.com/noopurintel/openfl/actions/runs/14536183318)
[With 30 collaborators](https://github.com/noopurintel/openfl/actions/runs/14536495735)