### PR TITLE
Enhancement in pypi publish

### DIFF
--- a/.github/scripts/nightly_version.sh
+++ b/.github/scripts/nightly_version.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 set -e
 
-TEST_PYPI=$(grep -oP '^TEST_PYPI=\K.*' $GITHUB_ENV)
-
-if [ "$TEST_PYPI" ]; then
+if [ ${TEST_PYPI} ]; then
     old_version=$(curl -s https://test.pypi.org/pypi/openfl-nightly/json | python -c "import sys, json; print(json.load(sys.stdin)['info']['version']);")
 else
     old_version=$(curl -s https://pypi.org/pypi/openfl-nightly/json | python -c "import sys, json; print(json.load(sys.stdin)['info']['version']);")

--- a/.github/scripts/nightly_version.sh
+++ b/.github/scripts/nightly_version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if [ "${TEST_PYPI}" == "true" ]; then
+if [ "${TEST_PYPI}" = true ]; then
     echo "Using Test PyPI"
     old_version=$(curl -s https://test.pypi.org/pypi/openfl-nightly/json | python -c "import sys, json; print(json.load(sys.stdin)['info']['version']);")
 else

--- a/.github/scripts/nightly_version.sh
+++ b/.github/scripts/nightly_version.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+if [ "$TEST_PYPI" ]; then
+    old_version=$(curl -s https://test.pypi.org/pypi/openfl-nightly/json | python -c "import sys, json; print(json.load(sys.stdin)['info']['version']);")
+else
+    old_version=$(curl -s https://pypi.org/pypi/openfl-nightly/json | python -c "import sys, json; print(json.load(sys.stdin)['info']['version']);")
+fi
+
+echo "OLD_VERSION=${old_version}" >> $GITHUB_ENV
+
+version=$(grep -oP "(?<=version=')[^']+" setup.py)
+date_suffix=$(date +%Y%m%d)
+new_version="${version}${date_suffix}"
+
+# Truncate last digit of old_version and compare with new_version
+truncated_old_version=$(echo "${OLD_VERSION}" | sed 's/.$//')
+if [ "${truncated_old_version}" = "${new_version}" ]; then
+    # Increment the last digit of old_version
+    last_digit=$(echo "${OLD_VERSION}" | grep -o '.$')
+    incremented_last_digit=$((last_digit + 1))
+    new_version="${new_version}${incremented_last_digit}"
+else
+    # Append 0 as the last digit
+    new_version="${new_version}0"
+fi
+
+echo "Final NEW_VERSION=${new_version}"
+
+# get URL with commit hash
+base_url="https://github.com/securefederatedai/openfl/tree/"
+full_url="${base_url}${COMMIT_ID}"
+echo "Repository URL: $full_url"
+
+sed -i 's/name=.*/name="openfl-nightly",/' setup.py
+sed -i "s/version=.*/version='$new_version',/" setup.py
+sed -i 's/Development Status :: 5 - Production\/Stable/Development Status :: 4 - Beta/' setup.py
+sed -i "s|'Source Code': '.*'|'Source Code': '${full_url}'|g" setup.py
+
+echo "NEW_VERSION=${new_version}" >> $GITHUB_ENV

--- a/.github/scripts/nightly_version.sh
+++ b/.github/scripts/nightly_version.sh
@@ -2,6 +2,7 @@
 set -e
 
 if [ ${TEST_PYPI} ]; then
+    echo "Using Test PyPI"
     old_version=$(curl -s https://test.pypi.org/pypi/openfl-nightly/json | python -c "import sys, json; print(json.load(sys.stdin)['info']['version']);")
 else
     old_version=$(curl -s https://pypi.org/pypi/openfl-nightly/json | python -c "import sys, json; print(json.load(sys.stdin)['info']['version']);")
@@ -13,15 +14,18 @@ version=$(grep -oP "(?<=version=')[^']+" setup.py)
 date_suffix=$(date +%Y%m%d)
 new_version="${version}${date_suffix}"
 
-# Truncate last digit of old_version and compare with new_version
-truncated_old_version=$(echo "${OLD_VERSION}" | sed 's/.$//')
-if [ "${truncated_old_version}" = "${new_version}" ]; then
+# Remove the last digit of old_version after the last character
+truncated_old_version=$(echo "${old_version}" | sed 's/.$//')
+echo "Truncated old version: $truncated_old_version"
+echo "New version: $new_version"
+if [ "${truncated_old_version}" == "${new_version}" ]; then
     # Increment the last digit of old_version
-    last_digit=$(echo "${OLD_VERSION}" | grep -o '.$')
+    last_digit=$(echo "${old_version}" | grep -o '.$')
     incremented_last_digit=$((last_digit + 1))
     new_version="${new_version}${incremented_last_digit}"
 else
     # Append 0 as the last digit
+    echo "No version present for current date"
     new_version="${new_version}0"
 fi
 

--- a/.github/scripts/nightly_version.sh
+++ b/.github/scripts/nightly_version.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 set -e
 
+TEST_PYPI=$(grep -oP '^TEST_PYPI=\K.*' $GITHUB_ENV)
+
 if [ "$TEST_PYPI" ]; then
     old_version=$(curl -s https://test.pypi.org/pypi/openfl-nightly/json | python -c "import sys, json; print(json.load(sys.stdin)['info']['version']);")
 else
     old_version=$(curl -s https://pypi.org/pypi/openfl-nightly/json | python -c "import sys, json; print(json.load(sys.stdin)['info']['version']);")
 fi
 
-echo "OLD_VERSION=${old_version}" >> $GITHUB_ENV
+echo "Old version: $old_version"
 
 version=$(grep -oP "(?<=version=')[^']+" setup.py)
 date_suffix=$(date +%Y%m%d)

--- a/.github/scripts/nightly_version.sh
+++ b/.github/scripts/nightly_version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if [ ${TEST_PYPI} ]; then
+if [ "${TEST_PYPI}" == "true" ]; then
     echo "Using Test PyPI"
     old_version=$(curl -s https://test.pypi.org/pypi/openfl-nightly/json | python -c "import sys, json; print(json.load(sys.stdin)['info']['version']);")
 else

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -74,6 +74,7 @@ jobs:
         echo "OpenFL version is $(pip list | grep openfl)" 
         python3 -m pip uninstall -y openfl openfl-nightly
         python3 -m pip install ${{ env.OPENFL_NIGHTLY_WHL_FILE }}
+        python3 -m pip install -r test-requirements.txt
         python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
         -m task_runner_basic --model_name "keras/mnist" \
         --num_rounds 1 --num_collaborators 1

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -52,12 +52,13 @@ jobs:
         echo "Repository URL: $full_url"
         version=$(grep -oP "(?<=version=')[^']+" setup.py)
         date_suffix=$(date +%Y%m%d)
-        new_version="${version}${date_suffix}0"
+        new_version="${version}${date_suffix}-0"
         sed -i 's/name=.*/name="openfl-nightly",/' setup.py
         sed -i "s/version=.*/version='$new_version',/" setup.py
         sed -i 's/Development Status :: 5 - Production\/Stable/Development Status :: 4 - Beta/' setup.py
         sed -i "s|'Source Code': '.*'|'Source Code': '${full_url}'|g" setup.py
         echo "NEW_VERSION=${new_version}" >> $GITHUB_ENV
+        echo ${{env.TEST_PYPI}} ${{inputs.test_pypi}}
 
     - name: Build package
       id: build_package
@@ -68,32 +69,45 @@ jobs:
         echo "OPENFL_NIGHTLY_WHL_FILE=$(ls dist/*.whl)" >> $GITHUB_ENV
         echo "Package built successfully!"
 
+    - name: Verify package installation with E2E test
+      id: verify_package_installation
+      run: |
+        echo "OpenFL version is $(pip list | grep openfl)" 
+        python3 -m pip uninstall -y openfl openfl-nightly
+        python3 -m pip install ${{ env.OPENFL_NIGHTLY_WHL_FILE }}
+        python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+        -m task_runner_basic --model_name "keras/mnist" \
+        --num_rounds 1 --num_collaborators 1
+        echo "Verified the package installation successfully!"
+
     - name: Upload package to PyPI
       run: |
-        if [ "${{ env.TEST_PYPI }}" == "true" ]; then
+        if [ "${{ env.TEST_PYPI }}" ]; then
           python3 -m twine upload dist/openfl_nightly* --verbose -u __token__ -p ${{ secrets.TEST_PYPI_API_TOKEN }} --repository-url https://test.pypi.org/legacy/
           echo "Package published to Test PyPI successfully!"
         else
           python3 -m twine upload dist/openfl_nightly* --verbose -u __token__ -p ${{ secrets.PYPI_API_TOKEN }}
           echo "Package published to PyPI successfully!"
         fi
+
     - name: Install built package
       id: install_package_using_wheel
       run: |
         python3 -m pip uninstall -y openfl openfl-nightly
-        if [ "${{ env.TEST_PYPI }}" == "true" ]; then
+        if [ "${{ env.TEST_PYPI }}" ]; then
           python3 -m pip install -i https://test.pypi.org/simple/ openfl-nightly==${{ env.NEW_VERSION }}
         else
           python3 -m pip install openfl-nightly==${{ env.NEW_VERSION }}
         fi
         python3 -m pip install -r test-requirements.txt
+
     - name: Verify package installation with E2E test
       id: verify_package_installation
       run: |
         echo "OpenFL version is $(pip list | grep openfl)" 
         python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
         -m task_runner_basic --model_name "keras/mnist" \
-        --num_rounds 1 --num_collaborators 2
+        --num_rounds 1 --num_collaborators 1
         echo "Verified the package installation successfully!"
 
     - name: Print package information

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -52,7 +52,7 @@ jobs:
         echo "Repository URL: $full_url"
         version=$(grep -oP "(?<=version=')[^']+" setup.py)
         date_suffix=$(date +%Y%m%d)
-        new_version="${version}${date_suffix}-0"
+        new_version="${version}${date_suffix}0"
         sed -i 's/name=.*/name="openfl-nightly",/' setup.py
         sed -i "s/version=.*/version='$new_version',/" setup.py
         sed -i 's/Development Status :: 5 - Production\/Stable/Development Status :: 4 - Beta/' setup.py

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -18,9 +18,14 @@ on:
         required: false
         type: string
         description: "Commit ID to use for the nightly build"
+      test_pypi:
+        required: false
+        type: boolean
+        description: "Use Test PyPI instead of PyPI"
 
 env:
   COMMIT_ID: ${{ inputs.commit_id || github.sha }} # use commit_id from the calling workflow
+  TEST_PYPI: ${{ inputs.test_pypi || false }} # use test_pypi from the calling workflow
 
 permissions:
   id-token: write
@@ -42,12 +47,17 @@ jobs:
     - name: Modify setup.py for nightly build
       run: |
         echo "Creating package..."
+        base_url="https://github.com/securefederatedai/openfl/tree/"
+        full_url="${base_url}${{ env.COMMIT_ID }}"
+        echo "Repository URL: $full_url"
         version=$(grep -oP "(?<=version=')[^']+" setup.py)
         date_suffix=$(date +%Y%m%d)
         new_version="${version}${date_suffix}"
         sed -i 's/name=.*/name="openfl-nightly",/' setup.py
         sed -i "s/version=.*/version='$new_version',/" setup.py
         sed -i 's/Development Status :: 5 - Production\/Stable/Development Status :: 4 - Beta/' setup.py
+        sed -i "s|'Source Code': '.*'|'Source Code': '${full_url}'|g" setup.py
+        echo "NEW_VERSION=${new_version}" >> $GITHUB_ENV
 
     - name: Build package
       id: build_package
@@ -58,27 +68,34 @@ jobs:
         echo "OPENFL_NIGHTLY_WHL_FILE=$(ls dist/*.whl)" >> $GITHUB_ENV
         echo "Package built successfully!"
 
+    - name: Upload package to PyPI
+      run: |
+        if [ "${{ env.TEST_PYPI }}" == "true" ]; then
+          python3 -m twine upload dist/openfl_nightly* --verbose -u __token__ -p ${{ secrets.TEST_PYPI_API_TOKEN }} --repository-url https://test.pypi.org/legacy/
+          echo "Package published to Test PyPI successfully!"
+        else
+          python3 -m twine upload dist/openfl_nightly* --verbose -u __token__ -p ${{ secrets.PYPI_API_TOKEN }}
+          echo "Package published to PyPI successfully!"
+        fi
     - name: Install built package
       id: install_package_using_wheel
       run: |
         python3 -m pip uninstall -y openfl openfl-nightly
-        python3 -m pip install ${{ env.OPENFL_NIGHTLY_WHL_FILE }}
+        if [ "${{ env.TEST_PYPI }}" == "true" ]; then
+              python3 -m pip install -i https://test.pypi.org/simple/ openfl-nightly==${{ env.NEW_VERSION }}
+        else
+          python3 -m pip install openfl-nightly==${{ env.NEW_VERSION }}
+        fi
         python3 -m pip install -r test-requirements.txt
-        echo "Installed the built wheel file successfully!"
-
+        echo "Installed the built wheel file from Test PyPI successfully!"
     - name: Verify package installation with E2E test
       id: verify_package_installation
       run: |
-        echo "OpenFL version is $(pip list | grep openfl)"
+        echo "OpenFL version is $(pip list | grep openfl)" 
         python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
         -m task_runner_basic --model_name "keras/mnist" \
         --num_rounds 1 --num_collaborators 2
         echo "Verified the package installation successfully!"
-
-    - name: Upload package to PyPI
-      run: |
-        python3 -m twine upload dist/openfl_nightly* --verbose -u __token__ -p ${{ secrets.PYPI_API_TOKEN }}
-        echo "Package published successfully!"
 
     - name: Print package information
       run: |

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -48,11 +48,11 @@ jobs:
       run: |
         echo "Creating package..."
         base_url="https://github.com/securefederatedai/openfl/tree/"
-        full_url="${base_url}${{ env.COMMIT_ID }}.0"
+        full_url="${base_url}${{ env.COMMIT_ID }}"
         echo "Repository URL: $full_url"
         version=$(grep -oP "(?<=version=')[^']+" setup.py)
         date_suffix=$(date +%Y%m%d)
-        new_version="${version}${date_suffix}"
+        new_version="${version}${date_suffix}.0"
         sed -i 's/name=.*/name="openfl-nightly",/' setup.py
         sed -i "s/version=.*/version='$new_version',/" setup.py
         sed -i 's/Development Status :: 5 - Production\/Stable/Development Status :: 4 - Beta/' setup.py

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -63,7 +63,7 @@ jobs:
         python3 -m pip uninstall -y openfl openfl-nightly
         python3 -m pip install ${{ env.OPENFL_NIGHTLY_WHL_FILE }}
         python3 -m pip install -r test-requirements.txt
-        python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+        python3 -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
         -m task_runner_basic --model_name "keras/mnist" \
         --num_rounds 1 --num_collaborators 1
         echo "Verified the package installation successfully!"
@@ -92,7 +92,7 @@ jobs:
     - name: Verify package installation after pushing to PyPI
       run: |
         echo "OpenFL version is $(pip list | grep openfl)" 
-        python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+        python3 -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
         -m task_runner_basic --model_name "keras/mnist" \
         --num_rounds 1 --num_collaborators 1
         echo "Verified the package installation successfully!"

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -52,7 +52,7 @@ jobs:
         echo "Repository URL: $full_url"
         version=$(grep -oP "(?<=version=')[^']+" setup.py)
         date_suffix=$(date +%Y%m%d)
-        new_version="${version}${date_suffix}.0"
+        new_version="${version}${date_suffix}0"
         sed -i 's/name=.*/name="openfl-nightly",/' setup.py
         sed -i "s/version=.*/version='$new_version',/" setup.py
         sed -i 's/Development Status :: 5 - Production\/Stable/Development Status :: 4 - Beta/' setup.py

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -52,7 +52,7 @@ jobs:
         echo "Repository URL: $full_url"
         version=$(grep -oP "(?<=version=')[^']+" setup.py)
         date_suffix=$(date +%Y%m%d)
-        new_version="${version}${date_suffix}0"
+        new_version="${version}${date_suffix}"
         sed -i 's/name=.*/name="openfl-nightly",/' setup.py
         sed -i "s/version=.*/version='$new_version',/" setup.py
         sed -i 's/Development Status :: 5 - Production\/Stable/Development Status :: 4 - Beta/' setup.py

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -44,22 +44,10 @@ jobs:
       with:
         ref: ${{ env.COMMIT_ID }}
 
-    - name: Modify setup.py for nightly build
+    - name: Set version and other Metadata in setup.py
       run: |
-        echo "Creating package..."
-        base_url="https://github.com/securefederatedai/openfl/tree/"
-        full_url="${base_url}${{ env.COMMIT_ID }}"
-        echo "Repository URL: $full_url"
-        version=$(grep -oP "(?<=version=')[^']+" setup.py)
-        date_suffix=$(date +%Y%m%d)
-        new_version="${version}${date_suffix}"
-        sed -i 's/name=.*/name="openfl-nightly",/' setup.py
-        sed -i "s/version=.*/version='$new_version',/" setup.py
-        sed -i 's/Development Status :: 5 - Production\/Stable/Development Status :: 4 - Beta/' setup.py
-        sed -i "s|'Source Code': '.*'|'Source Code': '${full_url}'|g" setup.py
-        echo "NEW_VERSION=${new_version}" >> $GITHUB_ENV
-        echo ${{env.TEST_PYPI}} ${{inputs.test_pypi}}
-
+        bash .github/scripts/nightly_version.sh
+        
     - name: Build package
       id: build_package
       run: |

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -48,7 +48,7 @@ jobs:
       run: |
         echo "Creating package..."
         base_url="https://github.com/securefederatedai/openfl/tree/"
-        full_url="${base_url}${{ env.COMMIT_ID }}"
+        full_url="${base_url}${{ env.COMMIT_ID }}.0"
         echo "Repository URL: $full_url"
         version=$(grep -oP "(?<=version=')[^']+" setup.py)
         date_suffix=$(date +%Y%m%d)
@@ -82,12 +82,11 @@ jobs:
       run: |
         python3 -m pip uninstall -y openfl openfl-nightly
         if [ "${{ env.TEST_PYPI }}" == "true" ]; then
-              python3 -m pip install -i https://test.pypi.org/simple/ openfl-nightly==${{ env.NEW_VERSION }}
+          python3 -m pip install -i https://test.pypi.org/simple/ openfl-nightly==${{ env.NEW_VERSION }}
         else
           python3 -m pip install openfl-nightly==${{ env.NEW_VERSION }}
         fi
         python3 -m pip install -r test-requirements.txt
-        echo "Installed the built wheel file from Test PyPI successfully!"
     - name: Verify package installation with E2E test
       id: verify_package_installation
       run: |

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -70,7 +70,7 @@ jobs:
 
     - name: Upload package to PyPI
       run: |
-        if [ "${{ env.TEST_PYPI }}" ]; then
+        if [ "${{ env.TEST_PYPI }}" = true]; then
           python3 -m twine upload dist/openfl_nightly* --verbose -u __token__ -p ${{ secrets.TEST_PYPI_API_TOKEN }} --repository-url https://test.pypi.org/legacy/
           echo "Package published to Test PyPI successfully!"
         else
@@ -82,7 +82,7 @@ jobs:
       id: install_package_using_wheel
       run: |
         python3 -m pip uninstall -y openfl openfl-nightly
-        if [ "${{ env.TEST_PYPI }}" ]; then
+        if [ "${{ env.TEST_PYPI }}" = true ]; then
           python3 -m pip install -i https://test.pypi.org/simple/ openfl-nightly==${{ env.NEW_VERSION }}
         else
           python3 -m pip install openfl-nightly==${{ env.NEW_VERSION }}

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Set version and other Metadata in setup.py
       run: |
         bash .github/scripts/nightly_version.sh
-        
+
     - name: Build package
       id: build_package
       run: |
@@ -57,7 +57,7 @@ jobs:
         echo "OPENFL_NIGHTLY_WHL_FILE=$(ls dist/*.whl)" >> $GITHUB_ENV
         echo "Package built successfully!"
 
-    - name: Verify package installation with E2E test
+    - name: Verify package installation before pushing to PyPI
       run: |
         echo "OpenFL version is $(pip list | grep openfl)" 
         python3 -m pip uninstall -y openfl openfl-nightly
@@ -89,7 +89,7 @@ jobs:
         fi
         python3 -m pip install -r test-requirements.txt
 
-    - name: Verify package installation with E2E test
+    - name: Verify package installation after pushing to PyPI
       run: |
         echo "OpenFL version is $(pip list | grep openfl)" 
         python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -70,7 +70,6 @@ jobs:
         echo "Package built successfully!"
 
     - name: Verify package installation with E2E test
-      id: verify_package_installation
       run: |
         echo "OpenFL version is $(pip list | grep openfl)" 
         python3 -m pip uninstall -y openfl openfl-nightly
@@ -102,7 +101,6 @@ jobs:
         python3 -m pip install -r test-requirements.txt
 
     - name: Verify package installation with E2E test
-      id: verify_package_installation
       run: |
         echo "OpenFL version is $(pip list | grep openfl)" 
         python -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -70,7 +70,7 @@ jobs:
 
     - name: Upload package to PyPI
       run: |
-        if [ "${{ env.TEST_PYPI }}" = true]; then
+        if [ "${{ env.TEST_PYPI }}" == "true" ]; then
           python3 -m twine upload dist/openfl_nightly* --verbose -u __token__ -p ${{ secrets.TEST_PYPI_API_TOKEN }} --repository-url https://test.pypi.org/legacy/
           echo "Package published to Test PyPI successfully!"
         else
@@ -82,7 +82,7 @@ jobs:
       id: install_package_using_wheel
       run: |
         python3 -m pip uninstall -y openfl openfl-nightly
-        if [ "${{ env.TEST_PYPI }}" = true ]; then
+        if [ "${{ env.TEST_PYPI }}" == "true" ]; then
           python3 -m pip install -i https://test.pypi.org/simple/ openfl-nightly==${{ env.NEW_VERSION }}
         else
           python3 -m pip install openfl-nightly==${{ env.NEW_VERSION }}

--- a/openfl/component/aggregator/aggregator.py
+++ b/openfl/component/aggregator/aggregator.py
@@ -1148,16 +1148,16 @@ class Aggregator:
         # Once all of the task results have been processed
         self._end_of_round_check_done[self.round_number] = True
 
-        # End of round callbacks.
-        # todo handle case when aggregator restarted before callback was successful
-        self.callbacks.on_round_end(self.round_number, logs)
-
         # Save the latest model
         if not self.assigner.is_task_group_evaluation():
             logger.info("Saving round %s model...", self.round_number)
             self._save_model(self.round_number, self.last_state_path)
         else:
             logger.info("Skipping model save for round %s in evaluation mode.", self.round_number)
+
+        # End of round callbacks.
+        # todo handle case when aggregator restarted before callback was successful
+        self.callbacks.on_round_end(self.round_number, logs)
 
         self.round_number += 1
 
@@ -1171,6 +1171,8 @@ class Aggregator:
         # TODO This needs to be fixed!
         if self._time_to_quit():
             logger.info("Experiment Completed. Cleaning up...")
+            # End of experiment callbacks.
+            self.callbacks.on_experiment_end()
         else:
             logger.info("Starting round %s...", self.round_number)
             # https://github.com/securefederatedai/openfl/pull/1195#discussion_r1879479537


### PR DESCRIPTION
## Summary
Enhancement and improvement in pypi publish,

## Type of Change (Mandatory)
Specify the type of change being made. 
- Feature enhancement  


## Description (Mandatory)
1. Adding commit hash in the source so that one can get exact commit-id for which Pypi hash is created. <img width="756" alt="image" src="https://github.com/user-attachments/assets/19a6958d-be48-4309-bf7a-55b065ed0327" />
2. Introduces a new input (**test_pypi**). It will help someone to understand implication in downstream as well. By this, one can push package in testpypi option from their PR branch. And test with that package downstream applications like openfl-security.

3. **Improvement** - Testing the package post push in respective repository.
4. As discussed below in comments - 
There is requirement to add multiple push on same date in case of any hotfix. To achieve the same, changed the versioning format from 
1.9.0.dev<date> ---> 1.9.0.dev<date>0 for openfl-nightly 
Reason of above format - Due to PEP440 restrictions "." or "-" is not supported after 1.9.0.dev<date>.
To decide the new_version
1st I verify old_version with suggested new_version if same I add 1 to last digit of old_version.
**"+"** Pypi is not allowing in its version.

As I result for same date version will be like 
<img width="1045" alt="image" src="https://github.com/user-attachments/assets/793ee70a-c357-466c-989e-ef3736475783" />


## Testing
Tested against Test Pypi - 
https://github.com/payalcha/openfl/actions/runs/14713844986 


<!-- ## Additional Information
[Any additional information that reviewers should be aware of.] -->