### PR TITLE
Revert "End of round callback adjustment (#1568)"

### DIFF
--- a/openfl/component/aggregator/aggregator.py
+++ b/openfl/component/aggregator/aggregator.py
@@ -1148,16 +1148,16 @@ class Aggregator:
         # Once all of the task results have been processed
         self._end_of_round_check_done[self.round_number] = True
 
+        # End of round callbacks.
+        # todo handle case when aggregator restarted before callback was successful
+        self.callbacks.on_round_end(self.round_number, logs)
+
         # Save the latest model
         if not self.assigner.is_task_group_evaluation():
             logger.info("Saving round %s model...", self.round_number)
             self._save_model(self.round_number, self.last_state_path)
         else:
             logger.info("Skipping model save for round %s in evaluation mode.", self.round_number)
-
-        # End of round callbacks.
-        # todo handle case when aggregator restarted before callback was successful
-        self.callbacks.on_round_end(self.round_number, logs)
 
         self.round_number += 1
 
@@ -1171,8 +1171,6 @@ class Aggregator:
         # TODO This needs to be fixed!
         if self._time_to_quit():
             logger.info("Experiment Completed. Cleaning up...")
-            # End of experiment callbacks.
-            self.callbacks.on_experiment_end()
         else:
             logger.info("Starting round %s...", self.round_number)
             # https://github.com/securefederatedai/openfl/pull/1195#discussion_r1879479537


### PR DESCRIPTION
## Summary
Noticing increased intermittent failures in PR pipelines and consistent failures in the [PQ pipeline](https://github.com/securefederatedai/openfl/actions/workflows/pq_pipeline.yml). The issues seem correlated with the introduction of PR #1568, so I suggest reverting it for now. Doing so appears to improve the PR pipeline at least - likely the PQ pipeline too.

## Type of Change (Mandatory)
- Bug fix  

## Description (Mandatory)
This PR reverts commit e848af18a8f5eb75716599c8e4d0adb175c38213.

## Testing
CI