### PR TITLE
Edar/datasets in experiment

### DIFF
--- a/openfl-workspace/torch/histology_s3/.workspace
+++ b/openfl-workspace/torch/histology_s3/.workspace
@@ -1,0 +1,2 @@
+current_plan_name: default
+

--- a/openfl-workspace/torch/histology_s3/data/collaborator1/datasources.json
+++ b/openfl-workspace/torch/histology_s3/data/collaborator1/datasources.json
@@ -1,0 +1,22 @@
+{
+  "s3_ds1": {
+    "params": {
+      "access_key_env_name": "MINIO_ROOT_USER_2",
+      "endpoint": "http://localhost:9000",
+      "secret_key_env_name": "MINIO_ROOT_PASSWORD",
+      "secret_name": "vault_secret_name2",
+      "uri": "s3://my-bucket-2/"
+    },
+    "type": "s3"
+  },
+  "s3_ds2": {
+    "params": {
+      "access_key_env_name": "MINIO_ROOT_USER",
+      "endpoint": "http://localhost:9000",
+      "secret_key_env_name": "MINIO_ROOT_PASSWORD",
+      "secret_name": "vault_secret_name1",
+      "uri": "s3://my-bucket/"
+    },
+    "type": "s3"
+  }
+}

--- a/openfl-workspace/torch/histology_s3/data/collaborator2/datasources.json
+++ b/openfl-workspace/torch/histology_s3/data/collaborator2/datasources.json
@@ -1,0 +1,12 @@
+{
+  "s3_ds3": {
+    "params": {
+      "access_key_env_name": "MINIO_ROOT_USER",
+      "endpoint": "http://localhost:9000",
+      "secret_key_env_name": "MINIO_ROOT_PASSWORD",
+      "secret_name": "vault_secret_name1",
+      "uri": "s3://my-bucket/"
+    },
+    "type": "s3"
+  }
+}

--- a/openfl-workspace/torch/histology_s3/plan/cols.yaml
+++ b/openfl-workspace/torch/histology_s3/plan/cols.yaml
@@ -1,0 +1,4 @@
+# Copyright (C) 2025 Intel Corporation
+# Licensed subject to the terms of the separately executed evaluation license agreement between Intel Corporation and you.
+
+collaborators:

--- a/openfl-workspace/torch/histology_s3/plan/data.yaml
+++ b/openfl-workspace/torch/histology_s3/plan/data.yaml
@@ -1,0 +1,2 @@
+# Copyright (C) 2025 Intel Corporation
+# Licensed subject to the terms of the separately executed evaluation license agreement between Intel Corporation and you.

--- a/openfl-workspace/torch/histology_s3/plan/plan.yaml
+++ b/openfl-workspace/torch/histology_s3/plan/plan.yaml
@@ -1,0 +1,41 @@
+# Copyright (C) 2025 Intel Corporation
+# Licensed subject to the terms of the separately executed evaluation license agreement between Intel Corporation and you.
+
+aggregator :
+  defaults : plan/defaults/aggregator.yaml
+  template : openfl.component.Aggregator
+  settings :
+    init_state_path : save/torch_cnn_histology_init.pbuf
+    best_state_path : save/torch_cnn_histology_best.pbuf
+    last_state_path : save/torch_cnn_histology_last.pbuf
+    rounds_to_train : 2
+
+collaborator :
+  defaults : plan/defaults/collaborator.yaml
+  template : openfl.component.Collaborator
+  settings :
+    use_delta_updates    : false
+    opt_treatment    : RESET
+
+data_loader :
+  template : src.dataloader.PyTorchHistologyVerifiableDataLoader
+  settings :
+    collaborator_count : 2
+    data_group_name    : histology
+    batch_size         : 32
+
+task_runner:
+  defaults : plan/defaults/task_runner.yaml
+  template: src.taskrunner.PyTorchCNN
+
+network:
+  defaults: plan/defaults/network.yaml
+
+tasks:
+  defaults: plan/defaults/tasks_torch.yaml
+
+assigner:
+  defaults: plan/defaults/assigner.yaml
+
+compression_pipeline :
+  defaults : plan/defaults/compression_pipeline.yaml

--- a/openfl-workspace/torch/histology_s3/requirements.txt
+++ b/openfl-workspace/torch/histology_s3/requirements.txt
@@ -1,0 +1,4 @@
+setuptools>=65.5.1
+torch==2.7.0
+torchvision==0.22.0
+boto3>=1.37.19

--- a/openfl-workspace/torch/histology_s3/src/__init__.py
+++ b/openfl-workspace/torch/histology_s3/src/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""You may copy this file as the starting point of your own model."""

--- a/openfl-workspace/torch/histology_s3/src/dataloader.py
+++ b/openfl-workspace/torch/histology_s3/src/dataloader.py
@@ -1,0 +1,213 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""You may copy this file as the starting point of your own model."""
+
+from collections.abc import Iterable
+from logging import getLogger
+import os
+import sys
+
+
+from openfl.federated import PyTorchDataLoader
+import numpy as np
+from openfl.federated.data.sources.torch.verifiable_map_style_image_folder import VerifiableImageFolder
+from openfl.federated.data.sources.data_sources_json_parser import DataSourcesJsonParser
+from openfl.utilities.path_check import is_directory_traversal
+import torch
+from torch.utils.data import random_split
+from torchvision.transforms import ToTensor
+
+
+logger = getLogger(__name__)
+
+
+class PyTorchHistologyVerifiableDataLoader(PyTorchDataLoader):
+    """PyTorch data loader for Histology dataset."""
+
+    def __init__(self, data_path, batch_size, **kwargs):
+        """Instantiate the data object.
+
+        Args:
+            data_path: The file path to the data
+            batch_size: The batch size of the data loader
+            **kwargs: Additional arguments, passed to super init
+             and load_mnist_shard
+        """
+        super().__init__(batch_size, random_seed=0, **kwargs)
+
+        # Set Histology-specific default attributes
+        self.feature_shape = [3, 150, 150]
+        self.num_classes = 8
+
+        # If data_path is None, this is being used for model initialization only
+        if data_path is None:
+            logger.info("Initializing dataloader for model creation only (no data loading)")
+            return
+
+        verifible_dataset_info = self.get_verifiable_dataset_info(data_path)
+
+        hash_file_path = os.path.join(data_path, "hash.txt")
+        verify_dataset_items = False
+        if os.path.isfile(hash_file_path):
+            logger.info(f"Found hash file at: {hash_file_path}. Verifying dataset...")
+            verify_dataset_items = True
+            with open(hash_file_path, "r", encoding="utf-8") as file:
+                hash_value = file.read()
+            dataset_valid = verifible_dataset_info.verify_dataset(root_hash=hash_value)
+            if not dataset_valid:
+                logger.error("The dataset is not valid.")
+                sys.exit(1)
+            else:
+                logger.info("The dataset is valid.")
+
+        _, num_classes, X_train, y_train, X_valid, y_valid = load_histology_shard(
+            verifible_dataset_info=verifible_dataset_info, verify_dataset_items=verify_dataset_items, **kwargs)
+
+        self.X_train = X_train
+        self.y_train = y_train
+        self.X_valid = X_valid
+        self.y_valid = y_valid
+
+        self.num_classes = num_classes
+
+
+    def get_feature_shape(self):
+        """Returns the shape of an example feature array.
+
+        Returns:
+            list: The shape of an example feature array [3, 150, 150] for Histology images.
+        """
+        return self.feature_shape
+
+    def get_num_classes(self):
+        """Returns the number of classes for classification tasks.
+
+        Returns:
+            int: The number of classes (8 for Histology dataset).
+        """
+        return self.num_classes
+
+    def get_verifiable_dataset_info(self, data_path):
+        """
+        Parse dataset information from `datasources.json` in the given directory.
+
+        Args:
+            data_path (str): Path to the directory containing `datasources.json`.
+
+        Returns:
+            VerifiableDatasetInfo: Parsed dataset information.
+
+        Raises:
+            SystemExit: If `data_path` is invalid or missing `datasources.json`.
+        """
+        """Return the verifiable dataset info object for the given data sources."""
+        if data_path and is_directory_traversal(data_path):
+            logger.error("Data path is out of the openfl workspace scope.")
+        if not os.path.isdir(data_path):
+            logger.error("The data path must be a directory.")
+            sys.exit(1)
+
+        datasources_json_path = os.path.join(data_path, "datasources.json")
+        if not os.path.isfile(datasources_json_path):
+            logger.error("The directory must contain a file named 'datasources.json' at the first level.")
+            sys.exit(1)
+        with open(datasources_json_path, "r", encoding="utf-8") as file:
+            data = file.read()
+        return DataSourcesJsonParser.parse(data)
+
+
+class HistologyDataset(VerifiableImageFolder):
+    """Colorectal Histology Dataset."""
+
+    def __init__(self, **kwargs) -> None:
+        """Initialize."""
+        super().__init__(**kwargs)
+
+    def __getitem__(self, index):
+        """Allow getting items by slice index."""
+        if isinstance(index, Iterable):
+            return [super().__getitem__(i) for i in index]
+        else:
+            return super().__getitem__(index)
+
+
+def _load_raw_data(verifiable_dataset_info, verify_dataset_items=False, train_split_ratio=0.8, **kwargs):
+    """
+    Load the raw data by shard.
+
+    Returns tuples of the dataset shard divided into training and validation.
+
+    Args:
+        data_path (str): The path to the dataset.
+
+    Returns:
+        2 tuples: (image, label) of the training, validation dataset
+    """
+    dataset = HistologyDataset(
+        vds=verifiable_dataset_info,
+        transform=ToTensor(),
+        verify_dataset_items=verify_dataset_items
+    )
+    n_train = int(train_split_ratio * len(dataset))
+    n_valid = len(dataset) - n_train
+    ds_train, ds_val = random_split(
+        dataset, lengths=[n_train, n_valid], generator=torch.manual_seed(0))
+
+    # create the shards
+    X_train, y_train = list(zip(*ds_train))
+    X_train, y_train = np.stack(X_train), np.array(y_train)
+
+    X_valid, y_valid = list(zip(*ds_val))
+    X_valid, y_valid = np.stack(X_valid), np.array(y_valid)
+
+    return (X_train, y_train), (X_valid, y_valid)
+
+
+
+def load_histology_shard(verifible_dataset_info, verify_dataset_items,
+                         categorical=False, channels_last=False, **kwargs):
+    """
+    Load the Histology dataset.
+
+    Args:
+        data_path (str): path to data directory
+        categorical (bool): True = convert the labels to one-hot encoded
+         vectors (Default = True)
+        channels_last (bool): True = The input images have the channels
+         last (Default = True)
+        **kwargs: Additional parameters to pass to the function
+
+    Returns:
+        list: The input shape
+        int: The number of classes
+        numpy.ndarray: The training data
+        numpy.ndarray: The training labels
+        numpy.ndarray: The validation data
+        numpy.ndarray: The validation labels
+    """
+    img_rows, img_cols = 150, 150
+    num_classes = 8
+
+    (X_train, y_train), (X_valid, y_valid) = _load_raw_data(verifible_dataset_info, verify_dataset_items, **kwargs)
+
+    if channels_last:
+        X_train = X_train.reshape(X_train.shape[0], img_rows, img_cols, 3)
+        X_valid = X_valid.reshape(X_valid.shape[0], img_rows, img_cols, 3)
+        input_shape = (img_rows, img_cols, 3)
+    else:
+        X_train = X_train.reshape(X_train.shape[0], 3, img_rows, img_cols)
+        X_valid = X_valid.reshape(X_valid.shape[0], 3, img_rows, img_cols)
+        input_shape = (3, img_rows, img_cols)
+
+    logger.info(f'Histology > X_train Shape : {X_train.shape}')
+    logger.info(f'Histology > y_train Shape : {y_train.shape}')
+    logger.info(f'Histology > Train Samples : {X_train.shape[0]}')
+    logger.info(f'Histology > Valid Samples : {X_valid.shape[0]}')
+
+    if categorical:
+        # convert class vectors to binary class matrices
+        y_train = np.eye(num_classes)[y_train]
+        y_valid = np.eye(num_classes)[y_valid]
+
+    return input_shape, num_classes, X_train, y_train, X_valid, y_valid

--- a/openfl-workspace/torch/histology_s3/src/taskrunner.py
+++ b/openfl-workspace/torch/histology_s3/src/taskrunner.py
@@ -1,0 +1,140 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""You may copy this file as the starting point of your own model."""
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim as optim
+from typing import Iterator, Tuple
+
+from openfl.federated import PyTorchTaskRunner
+from openfl.utilities import Metric
+
+
+class PyTorchCNN(PyTorchTaskRunner):
+    """
+    Simple CNN for classification.
+
+    PyTorchTaskRunner inherits from nn.module, so you can define your model
+    in the same way that you would for PyTorch
+    """
+
+    def __init__(self, device="cpu", **kwargs):
+        """Initialize.
+
+        Args:
+            device: The hardware device to use for training (Default = "cpu")
+            **kwargs: Additional arguments to pass to the function
+
+        """
+        super().__init__(device=device, **kwargs)
+
+        # Define the model
+        channel = self.data_loader.get_feature_shape()[0]  # (channel, dim1, dim2)
+        self.conv1 = nn.Conv2d(channel, 16, kernel_size=3, stride=1, padding=1)
+        self.conv2 = nn.Conv2d(16, 32, kernel_size=3, stride=1, padding=1)
+        self.conv3 = nn.Conv2d(32, 64, kernel_size=3, stride=1, padding=1)
+        self.conv4 = nn.Conv2d(64, 128, kernel_size=3, stride=1, padding=1)
+        self.conv5 = nn.Conv2d(128 + 32, 256, kernel_size=3, stride=1, padding=1)
+        self.conv6 = nn.Conv2d(256, 512, kernel_size=3, stride=1, padding=1)
+        self.conv7 = nn.Conv2d(512 + 128 + 32, 256, kernel_size=3, stride=1, padding=1)
+        self.conv8 = nn.Conv2d(256, 512, kernel_size=3, stride=1, padding=1)
+        self.fc1 = nn.Linear(1184 * 9 * 9, 128)
+        self.fc2 = nn.Linear(128, 8)
+
+        # `self.optimizer` must be set for optimizer weights to be federated
+        self.optimizer = optim.Adam(self.parameters(), lr=1e-3)
+
+        # Set the loss function
+        self.loss_fn = F.cross_entropy
+
+    def forward(self, x):
+        """Forward pass of the model.
+
+        Args:
+            x: Data input to the model for the forward pass
+        """
+        x = F.relu(self.conv1(x))
+        x = F.relu(self.conv2(x))
+        maxpool = F.max_pool2d(x, 2, 2)
+
+        x = F.relu(self.conv3(maxpool))
+        x = F.relu(self.conv4(x))
+        concat = torch.cat([maxpool, x], dim=1)
+        maxpool = F.max_pool2d(concat, 2, 2)
+
+        x = F.relu(self.conv5(maxpool))
+        x = F.relu(self.conv6(x))
+        concat = torch.cat([maxpool, x], dim=1)
+        maxpool = F.max_pool2d(concat, 2, 2)
+
+        x = F.relu(self.conv7(maxpool))
+        x = F.relu(self.conv8(x))
+        concat = torch.cat([maxpool, x], dim=1)
+        maxpool = F.max_pool2d(concat, 2, 2)
+
+        x = maxpool.flatten(start_dim=1)
+        x = F.dropout(self.fc1(x), p=0.5)
+        x = self.fc2(x)
+        return x
+
+    def train_(
+        self, train_dataloader: Iterator[Tuple[np.ndarray, np.ndarray]]
+    ) -> Metric:
+        """Train single epoch.
+
+        Override this function in order to use custom training.
+
+        Args:
+            batch_generator: Train dataset batch generator. Yields (samples, targets) tuples of
+            size = `self.data_loader.batch_size`.
+        Returns:
+            Metric: An object containing name and np.ndarray value.
+        """
+        losses = []
+        for data, target in train_dataloader:
+            data, target = torch.tensor(data).to(self.device), torch.tensor(target).to(
+                self.device
+            )
+            self.optimizer.zero_grad()
+            output = self(data)
+            loss = self.loss_fn(output, target)
+            loss.backward()
+            self.optimizer.step()
+            losses.append(loss.detach().cpu().numpy())
+        loss = np.mean(losses)
+        return Metric(name=self.loss_fn.__name__, value=np.array(loss))
+
+    def validate_(
+        self, validation_dataloader: Iterator[Tuple[np.ndarray, np.ndarray]]
+    ) -> Metric:
+        """
+        Perform validation on PyTorch Model
+
+        Override this function for your own custom validation function
+
+        Args:
+            validation_data_loader: Validation dataset batch generator.
+                                    Yields (samples, targets) tuples.
+        Returns:
+            Metric: An object containing name and np.ndarray value
+        """
+
+        total_samples = 0
+        val_score = 0
+        with torch.no_grad():
+            for data, target in validation_dataloader:
+                samples = target.shape[0]
+                total_samples += samples
+                data, target = torch.tensor(data).to(self.device), torch.tensor(
+                    target
+                ).to(self.device, dtype=torch.int64)
+                output = self(data)
+                # get the index of the max log-probability
+                pred = output.argmax(dim=1)
+                val_score += pred.eq(target).sum().cpu().numpy()
+
+        accuracy = val_score / total_samples
+        return Metric(name="accuracy", value=np.array(accuracy))

--- a/openfl/federated/data/sources/__init__.py
+++ b/openfl/federated/data/sources/__init__.py
@@ -1,8 +1,3 @@
 # Copyright 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 """This package contains utilities for verifying datasets."""
-
-from openfl.federated.data.sources.data_source import DataSource, DataSourceType
-from openfl.federated.data.sources.local_data_source import LocalDataSource
-from openfl.federated.data.sources.s3_data_source import S3DataSource
-from openfl.federated.data.sources.verifiable_dataset_info import VerifiableDatasetInfo

--- a/openfl/federated/data/sources/azure_blob_data_source.py
+++ b/openfl/federated/data/sources/azure_blob_data_source.py
@@ -2,11 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import hashlib
+import logging
+from importlib import util
 from typing import Callable
 
-from azure.storage.blob import BlobServiceClient
-
 from openfl.federated.data.sources.data_source import DataSource, DataSourceType
+
+logging.getLogger("azure").setLevel(logging.WARNING)
+logging.getLogger("azure.storage").setLevel(logging.WARNING)
 
 
 class AzureBlobDataSource(DataSource):
@@ -14,12 +17,21 @@ class AzureBlobDataSource(DataSource):
 
     def __init__(
         self,
+        name: str,
         connection_string: str,
         container_name: str,
         folder_prefix="",
         hash_func: Callable[..., "hashlib._Hash"] = hashlib.sha384,
     ):
-        super().__init__(DataSourceType.AZURE_BLOB)
+        # Check if azure.storage.blob is installed.
+        if util.find_spec("azure.storage.blob") is None:
+            raise Exception(
+                "'azure-storage-blob' not installed."
+                "This package is necessary for interacting with Azure Blob Storage."
+            )
+        from azure.storage.blob import BlobServiceClient
+
+        super().__init__(DataSourceType.AZURE_BLOB, name)
         self.connection_string = connection_string
         self.container_name = container_name
         self.folder_prefix = folder_prefix
@@ -54,6 +66,7 @@ class AzureBlobDataSource(DataSource):
     def from_dict(cls, ds_dict: dict):
         hash_func = getattr(hashlib, ds_dict.get("hash_func", "sha384"), None)
         return cls(
+            name=ds_dict["name"],
             connection_string=ds_dict["connection_string"],
             container_name=ds_dict["container_name"],
             hash_func=hash_func,

--- a/openfl/federated/data/sources/data_source.py
+++ b/openfl/federated/data/sources/data_source.py
@@ -23,7 +23,7 @@ class DataSource(ABC):
     Base class for different types of data sources.
 
     Attributes:
-        type (str): The storage type of the data source
+        type (DataSourceType): The storage type of the data source
         name (str): The name of the data source
     """
 

--- a/openfl/federated/data/sources/data_source.py
+++ b/openfl/federated/data/sources/data_source.py
@@ -24,16 +24,19 @@ class DataSource(ABC):
 
     Attributes:
         type (str): The storage type of the data source
+        name (str): The name of the data source
     """
 
-    def __init__(self, type: DataSourceType):
+    def __init__(self, type: DataSourceType, name: str):
         """
         Initialize a DataSource.
 
         Args:
             type (DataSourceType): The storage type of the data source.
+            name (str): The name of the data source.
         """
         self.type = type
+        self.name = name
 
     @abstractmethod
     def compute_file_hash(self, path: str) -> str:

--- a/openfl/federated/data/sources/data_sources_json_parser.py
+++ b/openfl/federated/data/sources/data_sources_json_parser.py
@@ -1,0 +1,111 @@
+# Copyright 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+
+import json
+import os
+from pathlib import Path
+
+from openfl.federated.data.sources.azure_blob_data_source import AzureBlobDataSource
+from openfl.federated.data.sources.local_data_source import LocalDataSource
+from openfl.federated.data.sources.s3_data_source import S3DataSource
+from openfl.federated.data.sources.verifiable_dataset_info import VerifiableDatasetInfo
+from openfl.utilities.path_check import is_directory_traversal
+
+
+class DataSourcesJsonParser:
+    @staticmethod
+    def parse(json_string: str) -> VerifiableDatasetInfo:
+        """
+        Parse a JSON string into a dictionary.
+
+        Args:
+            json_string (str): The JSON string to parse.
+
+        Returns:
+            VerifiableDatasetInfo: An instance of VerifiableDatasetInfo containing
+            the parsed data sources.
+        """
+        try:
+            data = json.loads(json_string)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid JSON format: {e}")
+
+        datasources = DataSourcesJsonParser.process_data_sources(data)
+        if not datasources:
+            raise ValueError("No data sources were found.")
+        return VerifiableDatasetInfo(
+            data_sources=datasources,
+            label="",
+        )
+
+    @staticmethod
+    def process_data_sources(data):
+        """Process and validate data sources."""
+        cwd = os.getcwd()
+        datasources = []
+        for source_name, source_info in data.items():
+            source_type = source_info.get("type", None)
+            if source_type is None:
+                raise ValueError(f"Missing 'type' key in data source configuration: {source_info}")
+            params = source_info.get("params", {})
+            if source_type == "local":
+                datasources.append(
+                    DataSourcesJsonParser.process_local_source(source_name, params, cwd)
+                )
+            elif source_type == "s3":
+                datasources.append(DataSourcesJsonParser.process_s3_source(source_name, params))
+            elif source_type == "azure_blob":
+                datasources.append(
+                    DataSourcesJsonParser.process_azure_blob_source(source_name, params)
+                )
+        return [ds for ds in datasources if ds]
+
+    @staticmethod
+    def process_local_source(source_name, params, cwd):
+        """Process a local data source."""
+        path = params.get("path", None)
+        if not path:
+            raise ValueError(f"Missing 'path' parameter for local data source '{source_name}'")
+        abs_path = os.path.abspath(path)
+        rel_path = os.path.relpath(abs_path, cwd)
+        if rel_path and not is_directory_traversal(rel_path):
+            return LocalDataSource(source_name, rel_path, base_path=Path("."))
+        else:
+            raise ValueError(f"Invalid path for local data source '{source_name}': {path}.")
+
+    @staticmethod
+    def process_s3_source(source_name, params):
+        """Process an S3 data source."""
+        required_fields = ["uri", "access_key_env_name", "secret_key_env_name", "secret_name"]
+        missing_fields = set(required_fields) - set(params.keys())
+        if missing_fields:
+            raise Exception(
+                f"Missing required fields: {', '.join(missing_fields)} "
+                f"for S3 data source '{source_name}'"
+            )
+        return S3DataSource(
+            name=source_name,
+            uri=params["uri"],
+            endpoint=params.get("endpoint") or None,
+            access_key_env_name=params["access_key_env_name"],
+            secret_key_env_name=params["secret_key_env_name"],
+            secret_name=params["secret_name"],
+        )
+
+    @staticmethod
+    def process_azure_blob_source(source_name, params):
+        """Process an Azure Blob data source."""
+        required_fields = ["connection_string", "container_name"]
+        missing_fields = set(required_fields) - set(params.keys())
+        if missing_fields:
+            raise Exception(
+                f"Missing required fields: {', '.join(missing_fields)} "
+                f"for Azure Blob data source '{source_name}'"
+            )
+        return AzureBlobDataSource(
+            name=source_name,
+            connection_string=params["connection_string"],
+            container_name=params["container_name"],
+            folder_prefix=params.get("folder_prefix") or "",
+        )

--- a/openfl/federated/data/sources/local_data_source.py
+++ b/openfl/federated/data/sources/local_data_source.py
@@ -16,6 +16,7 @@ class LocalDataSource(DataSource):
 
     def __init__(
         self,
+        name: str,
         source_path: Path,
         base_path,
         hash_func: Callable[..., "hashlib._Hash"] = sha384,
@@ -25,17 +26,19 @@ class LocalDataSource(DataSource):
         Initialize a LocalDataSource object.
 
         Args:
+            name (str): The name of the data source.
             source_path (Path): The path to the source data, relative to base_path.
             base_path (Path): The base path to the data source.
             hash_func (Callable[..., hashlib._Hash]): The hash function from hashlib
             to use to hash the data.
             max_dataset_size (int): The maximum size of the dataset in GB.
         """
-        super().__init__(DataSourceType.LOCAL)
+        super().__init__(DataSourceType.LOCAL, name)
         self.source_path = Path(source_path)
         if not super().is_valid_hash_function(hash_func):
             raise ValueError(
-                f"Invalid hash function: {hash_func.__name__}. Must be a hashlib function."
+                f"Data source {self.name}: Invalid hash function: {hash_func.__name__}."
+                 " Must be a hashlib function."
             )
         self.hash_func = hash_func
         self.max_dataset_size = max_dataset_size
@@ -58,8 +61,8 @@ class LocalDataSource(DataSource):
                         total_size_gb = total_size_bytes / (1024**3)
                         if total_size_gb > self.max_dataset_size:
                             raise ValueError(
-                                f"Total dataset size: {total_size_gb:.2f} GB exceeds "
-                                f"{self.max_dataset_size} GB"
+                                f"Data source {self.name}: Total dataset size: {total_size_gb:.2f}"
+                                f" GB exceeds {self.max_dataset_size} GB"
                             )
                     yield str(file_path)
 
@@ -69,8 +72,8 @@ class LocalDataSource(DataSource):
                 total_size_gb = total_size_bytes / (1024**3)
                 if total_size_gb > self.max_dataset_size:
                     raise ValueError(
-                        f"Total dataset size: {total_size_gb:.2f} GB exceeds "
-                        f"{self.max_dataset_size} GB"
+                        f"Data source {self.name}: Total dataset size: {total_size_gb:.2f}"
+                        f" GB exceeds {self.max_dataset_size} GB"
                     )
             yield str(full_path)
 
@@ -94,6 +97,7 @@ class LocalDataSource(DataSource):
         hash_func = getattr(hashlib, ds_dict.get("hash_func", "sha384"), None)
         max_dataset_size = ds_dict.get("max_dataset_size", 0)
         return cls(
+            name=ds_dict["name"],
             source_path=source_path,
             base_path=base_path,
             hash_func=hash_func,

--- a/openfl/federated/data/sources/local_data_source.py
+++ b/openfl/federated/data/sources/local_data_source.py
@@ -38,7 +38,7 @@ class LocalDataSource(DataSource):
         if not super().is_valid_hash_function(hash_func):
             raise ValueError(
                 f"Data source {self.name}: Invalid hash function: {hash_func.__name__}."
-                 " Must be a hashlib function."
+                " Must be a hashlib function."
             )
         self.hash_func = hash_func
         self.max_dataset_size = max_dataset_size

--- a/openfl/federated/data/sources/s3_data_source.py
+++ b/openfl/federated/data/sources/s3_data_source.py
@@ -3,10 +3,9 @@
 
 import hashlib
 import os
+from importlib import util
 from typing import Generator
 from urllib.parse import urlparse
-
-import boto3
 
 from openfl.federated.data.sources.data_source import DataSource, DataSourceType
 
@@ -24,6 +23,12 @@ class S3DataSource(DataSource):
         secret_name=None,
         hash_func=None,
     ):
+        if util.find_spec("boto3") is None:
+            raise Exception(
+                "'boto3' not installed.This package is necessary for interacting with AWS services."
+            )
+        import boto3
+
         super().__init__(DataSourceType.S3, name)
         self.uri = uri
         self.endpoint = endpoint

--- a/openfl/federated/data/sources/s3_data_source.py
+++ b/openfl/federated/data/sources/s3_data_source.py
@@ -16,6 +16,7 @@ class S3DataSource(DataSource):
 
     def __init__(
         self,
+        name,
         uri: str,
         endpoint=None,
         access_key_env_name=None,
@@ -23,7 +24,7 @@ class S3DataSource(DataSource):
         secret_name=None,
         hash_func=None,
     ):
-        super().__init__(DataSourceType.S3)
+        super().__init__(DataSourceType.S3, name)
         self.uri = uri
         self.endpoint = endpoint
         self.access_key_env_name = access_key_env_name
@@ -88,6 +89,7 @@ class S3DataSource(DataSource):
         else:
             hash_func = None
         return cls(
+            name=ds_dict["name"],
             uri=ds_dict["uri"],
             endpoint=ds_dict.get("endpoint", None),
             access_key_env_name=ds_dict.get("access_key_env_name", None),

--- a/openfl/federated/data/sources/torch/__init__.py
+++ b/openfl/federated/data/sources/torch/__init__.py
@@ -2,10 +2,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """This package contains utilities for PyTorch verifying datasets."""
-
-from openfl.federated.data.sources.torch.verifiable_map_style_dataset import (
-    VerifiableMapStyleDataset,
-)
-from openfl.federated.data.sources.torch.verifiable_map_style_image_folder import (
-    VerifiableImageFolder,
-)

--- a/openfl/federated/data/sources/verifiable_dataset_info.py
+++ b/openfl/federated/data/sources/verifiable_dataset_info.py
@@ -107,6 +107,7 @@ class VerifiableDatasetInfo:
             "label": self.label,
             "metadata": self.metadata,
             "dataset_format": "concise_dataset",
+            "name": self.data_sources[0].name,
         }
         if self.data_sources[0].type == DataSourceType.S3:
             s3_dict = self.data_sources[0].to_dict()
@@ -150,7 +151,7 @@ class VerifiableDatasetInfo:
             )
         else:
             return VerifiableDatasetInfo(
-                [LocalDataSource(source_path=".", base_path=base_path)],
+                [LocalDataSource(name=data_dict.get("name", None), source_path=".", base_path=base_path)],
                 label=data_dict["label"],
                 metadata=data_dict["metadata"],
                 root_hash=data_dict["dataset_id"],

--- a/openfl/federated/data/sources/verifiable_dataset_info.py
+++ b/openfl/federated/data/sources/verifiable_dataset_info.py
@@ -151,7 +151,11 @@ class VerifiableDatasetInfo:
             )
         else:
             return VerifiableDatasetInfo(
-                [LocalDataSource(name=data_dict.get("name", None), source_path=".", base_path=base_path)],
+                [
+                    LocalDataSource(
+                        name=data_dict.get("name", None), source_path=".", base_path=base_path
+                    )
+                ],
                 label=data_dict["label"],
                 metadata=data_dict["metadata"],
                 root_hash=data_dict["dataset_id"],

--- a/openfl/interface/collaborator.py
+++ b/openfl/interface/collaborator.py
@@ -22,6 +22,7 @@ from openfl.cryptography.ca import sign_certificate
 from openfl.cryptography.io import get_csr_hash, read_crt, read_csr, read_key, write_crt, write_key
 from openfl.cryptography.participant import generate_csr
 from openfl.federated import Plan
+from openfl.federated.data.sources.data_sources_json_parser import DataSourcesJsonParser
 from openfl.interface.cli_helper import CERT_DIR
 from openfl.utilities.path_check import is_directory_traversal
 from openfl.utilities.utils import rmtree
@@ -221,6 +222,49 @@ def register_data_path(collaborator_name, data_path=None, silent=False):
         with open(data_yaml, "w", encoding="utf-8") as f:
             for key, val in d.items():
                 f.write(f"{key}{separator}{val}\n")
+
+
+@collaborator.command(name="calchash")
+@option(
+    "-j",
+    "--data_path",
+    type=ClickPath(exists=True),
+    help=(
+        "Path to directory containing sources.json file defining the data sources of the dataset. "
+        "This file should contain a JSON object with the data sources to be registered. For 'local'"
+        " type, 'params' must include: 'path'. For 's3' type, 'params' must include: 'uri', "
+        "'access_key_env_name', 'secret_key_env_name', 'secret_name', and optionally 'endpoint'."
+    ),
+)
+def calchash(data_path):
+    """Generates a hash for the dataset whose data sources are defined in `datasources.json`.
+
+    The hash, saved as `hash.txt` in the same directory, can later
+    be used in custom data loaders to validate and track dataset consistency.
+    """
+
+    if data_path and is_directory_traversal(data_path):
+        logger.error("Data path is out of the openfl workspace scope.")
+        sys.exit(1)
+    if not os.path.isdir(data_path):
+        logger.error("The data path must be a directory.")
+        sys.exit(1)
+
+    datasources_json_path = os.path.join(data_path, "datasources.json")
+    if not os.path.isfile(datasources_json_path):
+        logger.error(
+            "The directory must contain a file named 'datasources.json' at the first level."
+        )
+        sys.exit(1)
+    with open(datasources_json_path, "r", encoding="utf-8") as file:
+        data = file.read()
+    vds = DataSourcesJsonParser.parse(data)
+    root_hash = vds.create_dataset_hash()
+    hash_file_path = os.path.join(data_path, "hash.txt")
+    with open(hash_file_path, "w", encoding="utf-8") as hash_file:
+        hash_file.write(root_hash)
+
+    logger.info(f"Dataset hash calculated and saved to {hash_file_path}. Hash: {root_hash}")
 
 
 @collaborator.command(name="generate-cert-request")

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -10,7 +10,7 @@ fpdf2==2.8.2
 papermill==2.6.0
 pyfakefs==5.8.0
 torch==2.7.0
-boto3==1.37.19
+boto3>=1.37.19
 moto==5.1.1
 torchvision==0.22.0
 azure-storage-blob==12.25.1

--- a/tests/openfl/federated/data/test_azure_blob_data_source.py
+++ b/tests/openfl/federated/data/test_azure_blob_data_source.py
@@ -22,7 +22,7 @@ def mocked_azure_blob_ds():
     ]
     file_contents = {f: f"file content of file #{i}".encode() for i, f in enumerate(files)}
 
-    with patch("openfl.federated.data.sources.azure_blob_data_source.BlobServiceClient") as mock_service_cls:
+    with patch("azure.storage.blob.BlobServiceClient") as mock_service_cls:
         # Mock container and blob service
         mock_service = MagicMock()
         mock_container = MagicMock()
@@ -61,6 +61,7 @@ def mocked_azure_blob_ds():
 def test_enumerate_files(mocked_azure_blob_ds):
     connection_string, container_name, expected_files, _ = mocked_azure_blob_ds
     datasource = AzureBlobDataSource(
+            name="abds",
             connection_string=connection_string,
             container_name=container_name,
         )
@@ -70,6 +71,7 @@ def test_enumerate_files(mocked_azure_blob_ds):
 def test_compute_file_hash(mocked_azure_blob_ds):
     connection_string, container_name, files, file_contents = mocked_azure_blob_ds
     datasource = AzureBlobDataSource(
+            name="abds",
             connection_string=connection_string,
             container_name=container_name,
         )
@@ -82,6 +84,7 @@ def test_from_dict(mocked_azure_blob_ds):
     connection_string, container_name, _, _ = mocked_azure_blob_ds
 
     ds_dict = {
+        "name": "abds",
         "connection_string": connection_string,
         "container_name": container_name,
         "hash_func": "sha384"
@@ -96,6 +99,7 @@ def test_from_dict(mocked_azure_blob_ds):
 def test_files_content(mocked_azure_blob_ds):
     connection_string, container_name, files, file_contents = mocked_azure_blob_ds
     datasource = AzureBlobDataSource(
+            name="abds",
             connection_string=connection_string,
             container_name=container_name,
         )
@@ -107,6 +111,7 @@ def test_folder_prefix(mocked_azure_blob_ds):
     connection_string, container_name, files, _ = mocked_azure_blob_ds
     folder_prefix = "folder1/"
     datasource = AzureBlobDataSource(
+            name="abds",
             connection_string=connection_string,
             container_name=container_name,
             folder_prefix=folder_prefix,

--- a/tests/openfl/federated/data/test_s3_data_source.py
+++ b/tests/openfl/federated/data/test_s3_data_source.py
@@ -34,7 +34,7 @@ def mock_s3_bucket():
 @pytest.fixture
 def s3_data_source(mock_s3_bucket):
     """Creates an S3DataSource instance for the test bucket."""
-    return S3DataSource(f"s3://{mock_s3_bucket}/")
+    return S3DataSource("s3ds", f"s3://{mock_s3_bucket}/")
 
 def test_enumerate_files(s3_data_source, mock_s3_bucket):
     """Test that enumerate_files returns full S3 URIs."""
@@ -84,7 +84,7 @@ def test_compute_file_hash_default(s3_data_source, mock_s3_bucket):
 @pytest.fixture
 def s3_data_source_with_hash(mock_s3_bucket):
     """Creates an S3DataSource instance with a custom hash function."""
-    return S3DataSource(f"s3://{mock_s3_bucket}/", hash_func=sha384)
+    return S3DataSource("s3ds", f"s3://{mock_s3_bucket}/", hash_func=sha384)
 
 
 def test_compute_file_hash_with_function(s3_data_source_with_hash, mock_s3_bucket):

--- a/tests/openfl/federated/data/test_verifiable_dataset.py
+++ b/tests/openfl/federated/data/test_verifiable_dataset.py
@@ -170,7 +170,7 @@ def copy_subtree(fs, existing_dir_path, new_dir_tree):
 def test_one_local_datasource(local_data_sources):
     ds1, _ = local_data_sources
     base_path, relative_paths = split_to_base_and_relative_paths([ds1])
-    datasources = [LocalDataSource(source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
+    datasources = [LocalDataSource(name= "lds", source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
     verifiable = VerifiableDatasetInfo(data_sources=datasources, label="my_dataset", metadata="md")
     hash = verifiable.create_dataset_hash()
     assert isinstance(hash, str), f"Expected str, got {type(hash)}"
@@ -181,7 +181,7 @@ def test_one_local_datasource(local_data_sources):
 def test_two_local_datasource(local_data_sources):
     ds1, ds2 = local_data_sources
     base_path, relative_paths = split_to_base_and_relative_paths([ds1, ds2])
-    datasources = [LocalDataSource(source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
+    datasources = [LocalDataSource(name= "lds", source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
     verifiable = VerifiableDatasetInfo(data_sources=datasources, label="my_dataset", metadata="md")
     hash = verifiable.create_dataset_hash()
     assert isinstance(hash, str), f"Expected str, got {type(hash)}"
@@ -192,7 +192,7 @@ def test_two_local_datasource(local_data_sources):
 def test_one_local_datasource_one_folder(local_data_sources):
     ds1, _ = local_data_sources
     base_path, relative_paths = split_to_base_and_relative_paths([ds1 / "1"])
-    datasources = [LocalDataSource(source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
+    datasources = [LocalDataSource(name= "lds", source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
     verifiable = VerifiableDatasetInfo(data_sources=datasources, label="my_dataset", metadata="md")
     hash = verifiable.create_dataset_hash()
     assert isinstance(hash, str), f"Expected str, got {type(hash)}"
@@ -203,7 +203,7 @@ def test_one_local_datasource_one_folder(local_data_sources):
 def test_one_local_datasource_one_file(local_data_sources):
     ds1, _ = local_data_sources
     base_path, relative_paths = split_to_base_and_relative_paths([ds1 / "1" / "file2.txt"])
-    datasources = [LocalDataSource(source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
+    datasources = [LocalDataSource(name= "lds", source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
     verifiable = VerifiableDatasetInfo(data_sources=datasources, label="my_dataset", metadata="md")
     hash = verifiable.create_dataset_hash()
     assert isinstance(hash, str), f"Expected str, got {type(hash)}"
@@ -214,7 +214,7 @@ def test_one_local_datasource_one_file(local_data_sources):
 def test_two_local_datasource_two_dirs(local_data_sources):
     ds1, ds2 = local_data_sources
     base_path, relative_paths = split_to_base_and_relative_paths([ds1 / "1", ds2 / "1"])
-    datasources = [LocalDataSource(source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
+    datasources = [LocalDataSource(name= "lds", source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
     verifiable = VerifiableDatasetInfo(data_sources=datasources, label="my_dataset", metadata="md")
     hash = verifiable.create_dataset_hash()
     assert isinstance(hash, str), f"Expected str, got {type(hash)}"
@@ -225,7 +225,7 @@ def test_two_local_datasource_two_dirs(local_data_sources):
 def test_two_local_datasource_two_files(local_data_sources):
     ds1, ds2 = local_data_sources
     base_path, relative_paths = split_to_base_and_relative_paths([ds1 / "1" / "file2.txt", ds2 / "1" / "file2.txt"])
-    datasources = [LocalDataSource(source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
+    datasources = [LocalDataSource(name= "lds", source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
     verifiable = VerifiableDatasetInfo(data_sources=datasources, label="my_dataset", metadata="md")
     hash = verifiable.create_dataset_hash()
     assert isinstance(hash, str), f"Expected str, got {type(hash)}"
@@ -236,7 +236,7 @@ def test_two_local_datasource_two_files(local_data_sources):
 def test_one_local_datasource_two_files(local_data_sources):
     ds1, _ = local_data_sources
     base_path, relative_paths = split_to_base_and_relative_paths([ds1 / "1" / "file1.txt", ds1 / "1" / "file2.txt"])
-    datasources = [LocalDataSource(source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
+    datasources = [LocalDataSource(name= "lds", source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
     verifiable = VerifiableDatasetInfo(data_sources=datasources, label="my_dataset", metadata="md")
     hash = verifiable.create_dataset_hash()
     assert isinstance(hash, str), f"Expected str, got {type(hash)}"
@@ -247,7 +247,7 @@ def test_one_local_datasource_two_files(local_data_sources):
 def test_two_local_datasource_different_base_path(fs, local_data_sources):
     ds1, ds2 = local_data_sources
     base_path, relative_paths = split_to_base_and_relative_paths([ds1, ds2])
-    datasources = [LocalDataSource(source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
+    datasources = [LocalDataSource(name= "lds", source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
     verifiable = VerifiableDatasetInfo(data_sources=datasources, label="my_dataset", metadata="md")
     # Copy the datasources to a new location to have a different base_path
     new_base = Path("/new_test_data")
@@ -264,7 +264,7 @@ def test_two_local_datasource_different_base_path(fs, local_data_sources):
 def test_two_local_datasource_use_saved_hash(local_data_sources):
     ds1, ds2 = local_data_sources
     base_path, relative_paths = split_to_base_and_relative_paths([ds1, ds2])
-    datasources = [LocalDataSource(source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
+    datasources = [LocalDataSource(name= "lds", source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
     verifiable = VerifiableDatasetInfo(data_sources=datasources, label="my_dataset", metadata="md")
     hash = verifiable.create_dataset_hash()
     assert isinstance(hash, str), f"Expected str, got {type(hash)}"
@@ -281,7 +281,7 @@ def test_two_local_datasource_with_symlink(fs, local_data_sources):
     fs.create_symlink(symlink_ds1, real_ds1)  # Create symlink to real_ds1
     base_path, relative_paths = split_to_base_and_relative_paths([symlink_ds1, ds2])
     assert relative_paths[0] == real_ds1.name
-    datasources = [LocalDataSource(source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
+    datasources = [LocalDataSource(name= "lds", source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
     verifiable = VerifiableDatasetInfo(data_sources=datasources, label="my_dataset", metadata="md")
     dataset_hash = verifiable.create_dataset_hash()
     assert isinstance(dataset_hash, str), f"Expected str, got {type(dataset_hash)}"
@@ -295,7 +295,7 @@ def test_two_local_datasource_different_base_path_with_symlink(fs, local_data_so
     fs.create_symlink(symlink_ds1, real_ds1)  # Create symlink to real_ds1
     base_path, relative_paths = split_to_base_and_relative_paths([symlink_ds1, ds2])
     assert relative_paths[0] == real_ds1.name
-    datasources = [LocalDataSource(source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
+    datasources = [LocalDataSource(name= "lds", source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
     verifiable = VerifiableDatasetInfo(data_sources=datasources, label="my_dataset", metadata="md")
     # Copy the datasources to a new location to have a different base_path
     new_base = Path("/new_test_data")
@@ -312,7 +312,7 @@ def test_two_local_datasource_different_base_path_with_symlink(fs, local_data_so
 def test_one_local_datasource_verify_single_file(local_data_sources):
     ds1, _ = local_data_sources
     base_path, relative_paths = split_to_base_and_relative_paths([ds1])
-    datasources = [LocalDataSource(source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
+    datasources = [LocalDataSource(name= "lds", source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
     verifiable = VerifiableDatasetInfo(data_sources=datasources, label="my_dataset", metadata="md")
     hash = verifiable.create_dataset_hash()
     assert isinstance(hash, str), f"Expected str, got {type(hash)}"
@@ -327,7 +327,7 @@ def test_one_local_datasource_verify_single_file(local_data_sources):
 def test_two_local_datasource_verify_single_file(local_data_sources):
     ds1, ds2 = local_data_sources
     base_path, relative_paths = split_to_base_and_relative_paths([ds1, ds2])
-    datasources = [LocalDataSource(source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
+    datasources = [LocalDataSource(name= "lds", source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
     verifiable = VerifiableDatasetInfo(data_sources=datasources, label="my_dataset", metadata="md")
     hash = verifiable.create_dataset_hash()
     assert isinstance(hash, str), f"Expected str, got {type(hash)}"
@@ -342,7 +342,7 @@ def test_two_local_datasource_verify_single_file(local_data_sources):
 def test_two_local_datasource_non_defalt_args(local_data_sources):
     ds1, ds2 = local_data_sources
     base_path, relative_paths = split_to_base_and_relative_paths([ds1, ds2])
-    datasources = [LocalDataSource(source_path=rel_path, base_path=base_path, hash_func=sha256, max_dataset_size=500) for rel_path in relative_paths]
+    datasources = [LocalDataSource(name= "lds", source_path=rel_path, base_path=base_path, hash_func=sha256, max_dataset_size=500) for rel_path in relative_paths]
     verifiable = VerifiableDatasetInfo(data_sources=datasources, label="my_dataset", metadata="md")
     hash = verifiable.create_dataset_hash()
     assert isinstance(hash, str), f"Expected str, got {type(hash)}"
@@ -356,7 +356,7 @@ def test_two_local_datasource_non_defalt_args(local_data_sources):
 
 def test_one_s3_data_source(mock_s3_buckets):
     bucket1, _ = mock_s3_buckets
-    ds1 = S3DataSource(f"s3://{bucket1}/folder1")
+    ds1 = S3DataSource("s3ds", f"s3://{bucket1}/folder1")
     verifiable = VerifiableDatasetInfo(data_sources=[ds1], label="my_dataset", metadata="md")
     hash = verifiable.create_dataset_hash()
     assert isinstance(hash, str), f"Expected str, got {type(hash)}"
@@ -366,8 +366,8 @@ def test_one_s3_data_source(mock_s3_buckets):
 
 def test_two_s3_datasource(mock_s3_buckets):
     bucket1, bucket2 = mock_s3_buckets
-    ds1 = S3DataSource(f"s3://{bucket1}/folder1")
-    ds2 = S3DataSource(f"s3://{bucket2}/dir1")
+    ds1 = S3DataSource("s3ds", f"s3://{bucket1}/folder1")
+    ds2 = S3DataSource("s3ds", f"s3://{bucket2}/dir1")
     verifiable = VerifiableDatasetInfo(data_sources=[ds1, ds2], label="my_dataset", metadata="md")
     hash = verifiable.create_dataset_hash()
     assert isinstance(hash, str), f"Expected str, got {type(hash)}"
@@ -377,7 +377,7 @@ def test_two_s3_datasource(mock_s3_buckets):
 
 def test_one_s3_datasource_one_file(mock_s3_buckets):
     bucket1, _ = mock_s3_buckets
-    ds1 = S3DataSource(f"s3://{bucket1}/folder1/file1.txt")
+    ds1 = S3DataSource("s3ds", f"s3://{bucket1}/folder1/file1.txt")
     verifiable = VerifiableDatasetInfo(data_sources=[ds1], label="my_dataset", metadata="md")
     hash = verifiable.create_dataset_hash()
     assert isinstance(hash, str), f"Expected str, got {type(hash)}"
@@ -387,8 +387,8 @@ def test_one_s3_datasource_one_file(mock_s3_buckets):
 
 def test_two_s3_datasource_use_saved_hash(mock_s3_buckets):
     bucket1, bucket2 = mock_s3_buckets
-    ds1 = S3DataSource(f"s3://{bucket1}/folder1")
-    ds2 = S3DataSource(f"s3://{bucket2}/dir1")
+    ds1 = S3DataSource("s3ds", f"s3://{bucket1}/folder1")
+    ds2 = S3DataSource("s3ds", f"s3://{bucket2}/dir1")
     verifiable = VerifiableDatasetInfo(data_sources=[ds1, ds2], label="my_dataset", metadata="md")
     hash = verifiable.create_dataset_hash()
     assert isinstance(hash, str), f"Expected str, got {type(hash)}"
@@ -399,7 +399,7 @@ def test_two_s3_datasource_use_saved_hash(mock_s3_buckets):
 
 def test_one_s3_datasource_one_file_hash_func(mock_s3_buckets):
     bucket1, _ = mock_s3_buckets
-    ds1 = S3DataSource(f"s3://{bucket1}/folder1/file1.txt", hash_func=sha384)
+    ds1 = S3DataSource("s3ds", f"s3://{bucket1}/folder1/file1.txt", hash_func=sha384)
     verifiable = VerifiableDatasetInfo(data_sources=[ds1], label="my_dataset", metadata="md")
     hash = verifiable.create_dataset_hash()
     assert isinstance(hash, str), f"Expected str, got {type(hash)}"
@@ -409,8 +409,8 @@ def test_one_s3_datasource_one_file_hash_func(mock_s3_buckets):
 
 def test_two_s3_datasource_hash_func_use_saved_hash(mock_s3_buckets):
     bucket1, bucket2 = mock_s3_buckets
-    ds1 = S3DataSource(f"s3://{bucket1}/folder1", hash_func=sha384)
-    ds2 = S3DataSource(f"s3://{bucket2}/dir1", hash_func=sha384)
+    ds1 = S3DataSource("s3ds", f"s3://{bucket1}/folder1", hash_func=sha384)
+    ds2 = S3DataSource("s3ds", f"s3://{bucket2}/dir1", hash_func=sha384)
     verifiable = VerifiableDatasetInfo(data_sources=[ds1, ds2], label="my_dataset", metadata="md")
     hash = verifiable.create_dataset_hash()
     assert isinstance(hash, str), f"Expected str, got {type(hash)}"
@@ -421,7 +421,7 @@ def test_two_s3_datasource_hash_func_use_saved_hash(mock_s3_buckets):
 
 def test_one_s3_datasource_verify_single_file(mock_s3_buckets):
     bucket1, _ = mock_s3_buckets
-    ds1 = S3DataSource(f"s3://{bucket1}/folder1")
+    ds1 = S3DataSource("s3ds", f"s3://{bucket1}/folder1")
     verifiable = VerifiableDatasetInfo(data_sources=[ds1], label="my_dataset", metadata="md")
     hash = verifiable.create_dataset_hash()
     assert isinstance(hash, str), f"Expected str, got {type(hash)}"

--- a/tests/openfl/federated/data/test_verifiable_dataset.py
+++ b/tests/openfl/federated/data/test_verifiable_dataset.py
@@ -110,7 +110,7 @@ def mock_azure_blob():
         file_contents = {f: f"file content of file #{i} in container {c_idx + 1}, path: {f}".encode() for i, f in enumerate(files)}
         file_contents_list.append(file_contents)
 
-    with patch("openfl.federated.data.sources.azure_blob_data_source.BlobServiceClient") as mock_service_cls:
+    with patch("azure.storage.blob.BlobServiceClient") as mock_service_cls:
         service_mocks = []
 
         for files, file_contents in zip(files_per_container, file_contents_list):
@@ -435,7 +435,7 @@ def test_one_s3_datasource_verify_single_file(mock_s3_buckets):
 
 def test_one_azure_blob_data_source(mock_azure_blob):
     container1, _ = mock_azure_blob
-    ds1 = AzureBlobDataSource(container1["connection_string"], container1["container_name"])
+    ds1 = AzureBlobDataSource("abds", container1["connection_string"], container1["container_name"])
     verifiable = VerifiableDatasetInfo(data_sources=[ds1], label="my_dataset", metadata="md")
     hash = verifiable.create_dataset_hash()
     assert isinstance(hash, str), f"Expected str, got {type(hash)}"
@@ -445,8 +445,8 @@ def test_one_azure_blob_data_source(mock_azure_blob):
 
 def test_two_azure_blob_datasource(mock_azure_blob):
     container1, container2 = mock_azure_blob
-    ds1 = AzureBlobDataSource(container1["connection_string"], container1["container_name"])
-    ds2 = AzureBlobDataSource(container2["connection_string"], container2["container_name"])
+    ds1 = AzureBlobDataSource("abds", container1["connection_string"], container1["container_name"])
+    ds2 = AzureBlobDataSource("abds", container2["connection_string"], container2["container_name"])
     verifiable = VerifiableDatasetInfo(data_sources=[ds1, ds2], label="my_dataset", metadata="md")
     hash = verifiable.create_dataset_hash()
     assert isinstance(hash, str), f"Expected str, got {type(hash)}"
@@ -456,8 +456,8 @@ def test_two_azure_blob_datasource(mock_azure_blob):
 
 def test_two_azure_blob_datasource_use_saved_hash(mock_azure_blob):
     container1, container2 = mock_azure_blob
-    ds1 = AzureBlobDataSource(container1["connection_string"], container1["container_name"])
-    ds2 = AzureBlobDataSource(container2["connection_string"], container2["container_name"])
+    ds1 = AzureBlobDataSource("abds", container1["connection_string"], container1["container_name"])
+    ds2 = AzureBlobDataSource("abds", container2["connection_string"], container2["container_name"])
     verifiable = VerifiableDatasetInfo(data_sources=[ds1, ds2], label="my_dataset", metadata="md")
     hash = verifiable.create_dataset_hash()
     assert isinstance(hash, str), f"Expected str, got {type(hash)}"
@@ -468,7 +468,7 @@ def test_two_azure_blob_datasource_use_saved_hash(mock_azure_blob):
 
 def test_one_azure_blob_datasource_one_file_hash_func(mock_azure_blob):
     container1, _ = mock_azure_blob
-    ds1 = AzureBlobDataSource(container1["connection_string"], container1["container_name"], sha256)
+    ds1 = AzureBlobDataSource("abds", container1["connection_string"], container1["container_name"], sha256)
     verifiable = VerifiableDatasetInfo(data_sources=[ds1], label="my_dataset", metadata="md")
     hash = verifiable.create_dataset_hash()
     assert isinstance(hash, str), f"Expected str, got {type(hash)}"
@@ -478,8 +478,8 @@ def test_one_azure_blob_datasource_one_file_hash_func(mock_azure_blob):
 
 def test_two_azure_blob_datasource_hash_func_use_saved_hash(mock_azure_blob):
     container1, container2 = mock_azure_blob
-    ds1 = AzureBlobDataSource(container1["connection_string"], container1["container_name"], sha256)
-    ds2 = AzureBlobDataSource(container2["connection_string"], container2["container_name"], sha256)
+    ds1 = AzureBlobDataSource("abds", container1["connection_string"], container1["container_name"], sha256)
+    ds2 = AzureBlobDataSource("abds", container2["connection_string"], container2["container_name"], sha256)
     verifiable = VerifiableDatasetInfo(data_sources=[ds1, ds2], label="my_dataset", metadata="md")
     hash = verifiable.create_dataset_hash()
     assert isinstance(hash, str), f"Expected str, got {type(hash)}"
@@ -490,7 +490,7 @@ def test_two_azure_blob_datasource_hash_func_use_saved_hash(mock_azure_blob):
 
 def test_one_azure_blob_datasource_verify_single_file(mock_azure_blob):
     container1, _ = mock_azure_blob
-    ds1 = AzureBlobDataSource(container1["connection_string"], container1["container_name"])
+    ds1 = AzureBlobDataSource("abds", container1["connection_string"], container1["container_name"])
     verifiable = VerifiableDatasetInfo(data_sources=[ds1], label="my_dataset", metadata="md")
     hash = verifiable.create_dataset_hash()
     assert isinstance(hash, str), f"Expected str, got {type(hash)}"
@@ -505,11 +505,11 @@ def test_one_azure_blob_datasource_verify_single_file(mock_azure_blob):
 def test_azure_blob_and_local_datasources(local_data_sources, mock_azure_blob):
     local_path1, local_path2 = local_data_sources
     base_path, relative_paths = split_to_base_and_relative_paths([local_path1, local_path2])
-    local_ds1 = LocalDataSource(source_path=relative_paths[0], base_path=base_path)
-    local_ds2 = LocalDataSource(source_path=relative_paths[1], base_path=base_path)
+    local_ds1 = LocalDataSource(name="lds", source_path=relative_paths[0], base_path=base_path)
+    local_ds2 = LocalDataSource(name="lds", source_path=relative_paths[1], base_path=base_path)
     container1, container2 = mock_azure_blob
-    azure_ds1 = AzureBlobDataSource(container1["connection_string"], container1["container_name"])
-    azure_ds2 = AzureBlobDataSource(container2["connection_string"], container2["container_name"])
+    azure_ds1 = AzureBlobDataSource("abds", container1["connection_string"], container1["container_name"])
+    azure_ds2 = AzureBlobDataSource("abds", container2["connection_string"], container2["container_name"])
     verifiable = VerifiableDatasetInfo(data_sources=[local_ds1, azure_ds1, local_ds2, azure_ds2], label="my_dataset", metadata="md")
     hash = verifiable.create_dataset_hash()
     assert isinstance(hash, str), f"Expected str, got {type(hash)}"

--- a/tests/openfl/federated/data/test_verifiable_map_style.py
+++ b/tests/openfl/federated/data/test_verifiable_map_style.py
@@ -425,7 +425,7 @@ def mock_azure_blob():
         {f: img_data for f in files}
         for files in files_per_container
     ]
-    with patch("openfl.federated.data.sources.azure_blob_data_source.BlobServiceClient") as mock_service_cls:
+    with patch("azure.storage.blob.BlobServiceClient") as mock_service_cls:
         service_mocks = []
 
         for files, file_contents in zip(files_per_container, file_contents_list):
@@ -467,8 +467,8 @@ def mock_azure_blob():
 
 def test_azure_blob_image_folder_map_style_datasource(mock_azure_blob):
     container1, container2 = mock_azure_blob
-    ds1 = AzureBlobDataSource(container1["connection_string"], container1["container_name"])
-    ds2 = AzureBlobDataSource(container2["connection_string"], container2["container_name"])
+    ds1 = AzureBlobDataSource("abds", container1["connection_string"], container1["container_name"])
+    ds2 = AzureBlobDataSource("abds", container2["connection_string"], container2["container_name"])
     datasources = [ds1, ds2]
     verifiable_dataset_info = VerifiableDatasetInfo(
         data_sources=datasources,
@@ -489,8 +489,8 @@ def test_azure_blob_image_folder_map_style_datasource(mock_azure_blob):
 
 def test_azure_blob_image_folder_map_style_datasource_verify(mock_azure_blob):
     container1, container2 = mock_azure_blob
-    ds1 = AzureBlobDataSource(container1["connection_string"], container1["container_name"])
-    ds2 = AzureBlobDataSource(container2["connection_string"], container2["container_name"])
+    ds1 = AzureBlobDataSource("abds", container1["connection_string"], container1["container_name"])
+    ds2 = AzureBlobDataSource("abds", container2["connection_string"], container2["container_name"])
     datasources = [ds1, ds2]
     verifiable_dataset_info = VerifiableDatasetInfo(
         data_sources=datasources,
@@ -515,8 +515,8 @@ def test_azure_blob_image_folder_map_style_datasource_verify(mock_azure_blob):
 def test_azure_blob_image_folder_map_style_datasource_labels(mock_azure_blob):
     """Test that LabelMapper correctly maps labels across multiple datasets."""
     container1, container2 = mock_azure_blob
-    ds1 = AzureBlobDataSource(container1["connection_string"], container1["container_name"])
-    ds2 = AzureBlobDataSource(container2["connection_string"], container2["container_name"])
+    ds1 = AzureBlobDataSource("abds", container1["connection_string"], container1["container_name"])
+    ds2 = AzureBlobDataSource("abds", container2["connection_string"], container2["container_name"])
     datasources = [ds1, ds2]
 
     verifiable_dataset_info = VerifiableDatasetInfo(
@@ -555,11 +555,11 @@ def test_mixed_ds_image_folder_map_style_datasource_labels(fake_image_datasource
     """Test that LabelMapper correctly maps labels across multiple datasets."""
     local_ds1, local_ds2, _ = fake_image_datasources
     base_path, relative_paths = split_to_base_and_relative_paths([local_ds1, local_ds2])
-    datasources = [LocalDataSource(source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
+    datasources = [LocalDataSource(name="lds", source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
 
     container1, container2 = mock_azure_blob
-    azure_ds1 = AzureBlobDataSource(container1["connection_string"], container1["container_name"])
-    azure_ds2 = AzureBlobDataSource(container2["connection_string"], container2["container_name"])
+    azure_ds1 = AzureBlobDataSource("abds", container1["connection_string"], container1["container_name"])
+    azure_ds2 = AzureBlobDataSource("abds", container2["connection_string"], container2["container_name"])
 
     datasources.append(azure_ds1)
     datasources.append(azure_ds2)

--- a/tests/openfl/federated/data/test_verifiable_map_style.py
+++ b/tests/openfl/federated/data/test_verifiable_map_style.py
@@ -85,7 +85,7 @@ class MockVerifiableMapStyle(VerifiableMapStyleDataset):
 def test_local_map_style_datasource(data_sources):
     ds1, ds2 = data_sources
     base_path, relative_paths = split_to_base_and_relative_paths([ds1, ds2])
-    datasources = [LocalDataSource(source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
+    datasources = [LocalDataSource(name="lds", source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
     verifiable_dataset_info = VerifiableDatasetInfo(
         data_sources=datasources,
         label="Test VerifiableMapStyleDataset",
@@ -102,7 +102,7 @@ def test_local_map_style_datasource(data_sources):
 def test_local_map_style_datasource_verify(data_sources):
     ds1, ds2 = data_sources
     base_path, relative_paths = split_to_base_and_relative_paths([ds1, ds2])
-    datasources = [LocalDataSource(source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
+    datasources = [LocalDataSource(name="lds", source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
     verifiable_dataset_info = VerifiableDatasetInfo(
         data_sources=datasources,
         label="Test VerifiableMapStyleDataset",
@@ -152,7 +152,7 @@ def fake_image_datasources(fs):
 def test_local_image_folder_map_style_datasource(fake_image_datasources):
     ds1, ds2, _ = fake_image_datasources
     base_path, relative_paths = split_to_base_and_relative_paths([ds1, ds2])
-    datasources = [LocalDataSource(source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
+    datasources = [LocalDataSource(name="lds", source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
     verifiable_dataset_info = VerifiableDatasetInfo(
         data_sources=datasources,
         label="Test VerifiableMapStyleDataset",
@@ -173,7 +173,7 @@ def test_local_image_folder_map_style_datasource(fake_image_datasources):
 def test_local_image_folder_map_style_datasource_verify(fake_image_datasources):
     ds1, ds2, _ = fake_image_datasources
     base_path, relative_paths = split_to_base_and_relative_paths([ds1, ds2])
-    datasources = [LocalDataSource(source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
+    datasources = [LocalDataSource(name="lds", source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
     verifiable_dataset_info = VerifiableDatasetInfo(
         data_sources=datasources,
         label="Test VerifiableMapStyleDataset",
@@ -198,7 +198,7 @@ def test_local_image_folder_map_style_datasource_labels(fake_image_datasources):
     """Test that LabelMapper correctly maps labels across multiple datasets."""
     ds1, ds2, ds3 = fake_image_datasources
     base_path, relative_paths = split_to_base_and_relative_paths([ds1, ds2, ds3])
-    datasources = [LocalDataSource(source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
+    datasources = [LocalDataSource(name="lds", source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
     verifiable_dataset_info = VerifiableDatasetInfo(
         data_sources=datasources,
         label="Test VerifiableMapStyleDataset",
@@ -282,7 +282,7 @@ def mock_s3_image_buckets():
 
 def test_s3_image_folder_map_style_datasource(mock_s3_image_buckets):
     ds1, ds2 = mock_s3_image_buckets
-    datasources = [S3DataSource(uri=ds1), S3DataSource(uri=ds2)]
+    datasources = [S3DataSource(name="s3ds", uri=ds1), S3DataSource(name="s3ds", uri=ds2)]
     verifiable_dataset_info = VerifiableDatasetInfo(
         data_sources=datasources,
         label="Test VerifiableMapStyleDataset",
@@ -302,7 +302,7 @@ def test_s3_image_folder_map_style_datasource(mock_s3_image_buckets):
 
 def test_s3_image_folder_map_style_datasource_verify(mock_s3_image_buckets):
     ds1, ds2 = mock_s3_image_buckets
-    datasources = [S3DataSource(uri=ds1), S3DataSource(uri=ds2)]
+    datasources = [S3DataSource(name="s3ds", uri=ds1), S3DataSource(name="s3ds", uri=ds2)]
     verifiable_dataset_info = VerifiableDatasetInfo(
         data_sources=datasources,
         label="Test VerifiableMapStyleDataset",
@@ -324,7 +324,7 @@ def test_s3_image_folder_map_style_datasource_verify(mock_s3_image_buckets):
 
 def test_s3_image_folder_map_style_datasource_verify_w_transform(mock_s3_image_buckets):
     ds1, ds2 = mock_s3_image_buckets
-    datasources = [S3DataSource(uri=ds1), S3DataSource(uri=ds2)]
+    datasources = [S3DataSource(name="s3ds", uri=ds1), S3DataSource(name="s3ds", uri=ds2)]
     verifiable_dataset_info = VerifiableDatasetInfo(
         data_sources=datasources,
         label="Test VerifiableMapStyleDataset",
@@ -347,7 +347,7 @@ def test_s3_image_folder_map_style_datasource_verify_w_transform(mock_s3_image_b
 def test_s3_image_folder_map_style_datasource_labels(mock_s3_image_buckets):
     """Test that LabelMapper correctly maps labels across multiple datasets."""
     s3_ds1, s3_ds2 = mock_s3_image_buckets
-    datasources =[S3DataSource(uri=s3_ds1), S3DataSource(uri=s3_ds2)]
+    datasources =[S3DataSource(name="s3ds", uri=s3_ds1), S3DataSource(name="s3ds", uri=s3_ds2)]
 
     verifiable_dataset_info = VerifiableDatasetInfo(
         data_sources=datasources,


### PR DESCRIPTION
## Summary
Support using verifiable datasets in experiment, includes
* Multiple data sources
* S3 data sources
* Verifiability

Add histology S3 workspace example.

## Type of Change (Mandatory)
- Feature enhancement  

## Description (Mandatory)
* Allow multiple data sources, including S3
* S3 workspace example
* CLI command for calculating root hash of a given dataset
* Add 'name' to data sources classes
* Keep backward compatibility

## Testing
Pass verifiable existing unittests
Run full experiments using JSON definition of the data sources (new method)
and  full experiments using data_path (the tradtional method)

**Run instructions:**
1. Run MINIO or S3 server.
2. Set: 
`export YOUR_ACCESS_KEY=<your_access_key>`
`export YOUR_SECRET_KEY=<your_secret_key>`
example:
`export MINIO_ROOT_PASSWORD=minioadmin`
`export MINIO_ROOT_USER=minioadmin`

3. Setup workspace and aggregator:
`fx workspace create --prefix ./hist_s3 --template torch/histology_s3`
`cd hist_s3/`
`pip install -r requirements.txt > /dev/null`
`fx workspace certify`
`fx aggregator generate-cert-request --fqdn localhost`
`fx aggregator certify --fqdn localhost --silent`

4. Create client: `--data_path` should point a directory that contains a file `datasources.json`, foe example:
`fx collaborator create --data_path plan/collaborator1  -n bob --silent`

5. Optional: Calculate the root hash of the collaborator's dataset.
The hash will be saved at `<data_path>/hash.txt`. In dataloader, if this file is found, dataset integrity verification will be performed.
`fx collaborator calchash --data_path plan/collaborator1`

6. Complete client certification:
`fx collaborator generate-cert-request -n bob --silent`
`fx collaborator certify --request-pkg col_bob_to_agg_cert_request.zip --silent`
`fx collaborator certify --import agg_to_col_bob_signed_cert.zip`

7. Repeat steps 4,5,6 for each client

8. Initialize plan:
`fx plan initialize -a localhost`

9. Start experiment (for example, collaborators bob and charlie):
`fx aggregator start & fx collaborator start -n bob & fx collaborator start -n charlie`

<!-- ## Additional Information


-->