### PR TITLE
add more robust device handling in torch Task Runner

### DIFF
--- a/openfl/federated/task/runner_pt.py
+++ b/openfl/federated/task/runner_pt.py
@@ -46,10 +46,14 @@ class PyTorchTaskRunner(nn.Module, TaskRunner):
         """
         super().__init__()
         TaskRunner.__init__(self, **kwargs)
-        if device:
+        if device is None:
+            self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        elif isinstance(device, str):
+            self.device = torch.device(device)
+        elif isinstance(device, torch.device):
             self.device = device
         else:
-            self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+            raise ValueError("Device must be None, a string, or a torch.device object.")
 
         # This is a map of all the required tensors for each of the public
         # functions in PyTorchTaskRunner


### PR DESCRIPTION
## Summary
Currently, a user can either specify the device type explicitly or let the torch Task Runner handle setting the device. Typically, a user will specify the device as a string (i.e. 'cuda' or 'cpu') whereas the automatic handling will set it as a `torch.device()` object. This is a minor discrepancy overall, but can lead to unexpected consequences. For example, if a user checks `if self.device == 'cpu'`. The condition will only be true if self.device is a string, not if it was set as a `torch.device()`. It is better practice to ensure that `self.device` is consistent, at least as it pertains to the base torch Task Runner.

## Type of Change (Mandatory)
- Feature enhancement  

## Description (Mandatory)
This PR adds/modifies three conditionals:
 - If the input is a string, it will be converted to a `torch.device` object for consistency before setting `self.device`
 - If it is already a `torch.device` object, it will set `self.device` to this directly
 - Added error handling for unexpected device types to prevent runtime errors.

## Testing
Manual testing