### PR TITLE
Retry download of `openfl-nightly` package after its publish

### DIFF
--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -64,16 +64,16 @@ jobs:
         echo "OPENFL_NIGHTLY_WHL_FILE=$(ls dist/*.whl)" >> $GITHUB_ENV
         echo "Package built successfully!"
 
-    # - name: Verify package installation before pushing to PyPI
-    #   run: |
-    #     echo "OpenFL version is $(pip list | grep openfl)" 
-    #     python3 -m pip uninstall -y openfl openfl-nightly
-    #     python3 -m pip install ${{ env.OPENFL_NIGHTLY_WHL_FILE }}
-    #     python3 -m pip install -r test-requirements.txt
-    #     python3 -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
-    #     -m task_runner_basic --model_name "keras/mnist" \
-    #     --num_rounds 1 --num_collaborators 1
-    #     echo "Verified the package installation successfully!"
+    - name: Verify package installation before pushing to PyPI
+      run: |
+        echo "OpenFL version is $(pip list | grep openfl)" 
+        python3 -m pip uninstall -y openfl openfl-nightly
+        python3 -m pip install ${{ env.OPENFL_NIGHTLY_WHL_FILE }}
+        python3 -m pip install -r test-requirements.txt
+        python3 -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+        -m task_runner_basic --model_name "keras/mnist" \
+        --num_rounds 1 --num_collaborators 1
+        echo "Verified the package installation successfully!"
 
     - name: Upload package to PyPI
       run: |
@@ -89,16 +89,15 @@ jobs:
       id: install_package_using_wheel
       run: |
         python3 -m pip uninstall -y openfl openfl-nightly
-        # Install the package from the pypi repository
-        for i in {1..3}; do
+        # Install the package with retry logic
+        for i in {1..5}; do
           if [ "${{ env.TEST_PYPI }}" == "true" ]; then
             PIP_CMD="python3 -m pip install -i https://test.pypi.org/simple/ openfl-nightly==${{ env.NEW_VERSION }}"
           else
             PIP_CMD="python3 -m pip install openfl-nightly==${{ env.NEW_VERSION }}"
           fi
-
           if $PIP_CMD; then
-            echo "Successfully installed openfl-nightly."
+            echo "Successfully installed openfl-nightly using command '$PIP_CMD'"
             break
           else
             echo "Attempt $i failed. Retrying in 20 seconds..."
@@ -107,21 +106,21 @@ jobs:
         done
         # Check if the package was installed successfully
         if ! python3 -m pip show openfl-nightly > /dev/null; then
-          echo "Failed to install openfl-nightly after 3 attempts."
+          echo "Failed to install openfl-nightly after 5 attempts."
           exit 1
         fi
         python3 -m pip install -r test-requirements.txt
 
-    # - name: Verify package installation after pushing to PyPI
-    #   run: |
-    #     echo "OpenFL version is $(pip list | grep openfl)" 
-    #     python3 -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
-    #     -m task_runner_basic --model_name "keras/mnist" \
-    #     --num_rounds 1 --num_collaborators 1
-    #     echo "Verified the package installation successfully!"
+    - name: Verify package installation after pushing to PyPI
+      run: |
+        echo "OpenFL version is $(pip list | grep openfl)" 
+        python3 -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+        -m task_runner_basic --model_name "keras/mnist" \
+        --num_rounds 1 --num_collaborators 1
+        echo "Verified the package installation successfully!"
 
-    # - name: Print package information
-    #   run: |
-    #     echo "**Version:** $(pip list | grep openfl)" >> $GITHUB_STEP_SUMMARY
-    #     echo "**Commit ID:** ${{ env.COMMIT_ID }}" >> $GITHUB_STEP_SUMMARY
-    #     echo "Package information printed successfully!"
+    - name: Print package information
+      run: |
+        echo "**Version:** $(pip list | grep openfl)" >> $GITHUB_STEP_SUMMARY
+        echo "**Commit ID:** ${{ env.COMMIT_ID }}" >> $GITHUB_STEP_SUMMARY
+        echo "Package information printed successfully!"

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -64,16 +64,16 @@ jobs:
         echo "OPENFL_NIGHTLY_WHL_FILE=$(ls dist/*.whl)" >> $GITHUB_ENV
         echo "Package built successfully!"
 
-    - name: Verify package installation before pushing to PyPI
-      run: |
-        echo "OpenFL version is $(pip list | grep openfl)" 
-        python3 -m pip uninstall -y openfl openfl-nightly
-        python3 -m pip install ${{ env.OPENFL_NIGHTLY_WHL_FILE }}
-        python3 -m pip install -r test-requirements.txt
-        python3 -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
-        -m task_runner_basic --model_name "keras/mnist" \
-        --num_rounds 1 --num_collaborators 1
-        echo "Verified the package installation successfully!"
+    # - name: Verify package installation before pushing to PyPI
+    #   run: |
+    #     echo "OpenFL version is $(pip list | grep openfl)" 
+    #     python3 -m pip uninstall -y openfl openfl-nightly
+    #     python3 -m pip install ${{ env.OPENFL_NIGHTLY_WHL_FILE }}
+    #     python3 -m pip install -r test-requirements.txt
+    #     python3 -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+    #     -m task_runner_basic --model_name "keras/mnist" \
+    #     --num_rounds 1 --num_collaborators 1
+    #     echo "Verified the package installation successfully!"
 
     - name: Upload package to PyPI
       run: |
@@ -89,23 +89,39 @@ jobs:
       id: install_package_using_wheel
       run: |
         python3 -m pip uninstall -y openfl openfl-nightly
-        if [ "${{ env.TEST_PYPI }}" == "true" ]; then
-          python3 -m pip install -i https://test.pypi.org/simple/ openfl-nightly==${{ env.NEW_VERSION }}
-        else
-          python3 -m pip install openfl-nightly==${{ env.NEW_VERSION }}
+        # Install the package from the pypi repository
+        for i in {1..3}; do
+          if [ "${{ env.TEST_PYPI }}" == "true" ]; then
+            PIP_CMD="python3 -m pip install -i https://test.pypi.org/simple/ openfl-nightly==${{ env.NEW_VERSION }}"
+          else
+            PIP_CMD="python3 -m pip install openfl-nightly==${{ env.NEW_VERSION }}"
+          fi
+
+          if $PIP_CMD; then
+            echo "Successfully installed openfl-nightly."
+            break
+          else
+            echo "Attempt $i failed. Retrying in 20 seconds..."
+            sleep 20
+          fi
+        done
+        # Check if the package was installed successfully
+        if ! python3 -m pip show openfl-nightly > /dev/null; then
+          echo "Failed to install openfl-nightly after 3 attempts."
+          exit 1
         fi
         python3 -m pip install -r test-requirements.txt
 
-    - name: Verify package installation after pushing to PyPI
-      run: |
-        echo "OpenFL version is $(pip list | grep openfl)" 
-        python3 -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
-        -m task_runner_basic --model_name "keras/mnist" \
-        --num_rounds 1 --num_collaborators 1
-        echo "Verified the package installation successfully!"
+    # - name: Verify package installation after pushing to PyPI
+    #   run: |
+    #     echo "OpenFL version is $(pip list | grep openfl)" 
+    #     python3 -m pytest -s tests/end_to_end/test_suites/task_runner_tests.py \
+    #     -m task_runner_basic --model_name "keras/mnist" \
+    #     --num_rounds 1 --num_collaborators 1
+    #     echo "Verified the package installation successfully!"
 
-    - name: Print package information
-      run: |
-        echo "**Version:** $(pip list | grep openfl)" >> $GITHUB_STEP_SUMMARY
-        echo "**Commit ID:** ${{ env.COMMIT_ID }}" >> $GITHUB_STEP_SUMMARY
-        echo "Package information printed successfully!"
+    # - name: Print package information
+    #   run: |
+    #     echo "**Version:** $(pip list | grep openfl)" >> $GITHUB_STEP_SUMMARY
+    #     echo "**Commit ID:** ${{ env.COMMIT_ID }}" >> $GITHUB_STEP_SUMMARY
+    #     echo "Package information printed successfully!"

--- a/.github/workflows/publish_nightly_package.yml
+++ b/.github/workflows/publish_nightly_package.yml
@@ -90,23 +90,25 @@ jobs:
       run: |
         python3 -m pip uninstall -y openfl openfl-nightly
         # Install the package with retry logic
-        for i in {1..5}; do
-          if [ "${{ env.TEST_PYPI }}" == "true" ]; then
-            PIP_CMD="python3 -m pip install -i https://test.pypi.org/simple/ openfl-nightly==${{ env.NEW_VERSION }}"
-          else
-            PIP_CMD="python3 -m pip install openfl-nightly==${{ env.NEW_VERSION }}"
-          fi
+        MAX_ATTEMPTS=5
+        WAIT_TIME_IN_SEC=20
+        if [ "${{ env.TEST_PYPI }}" == "true" ]; then
+          PIP_CMD="python3 -m pip install -i https://test.pypi.org/simple/ openfl-nightly==${{ env.NEW_VERSION }}"
+        else
+          PIP_CMD="python3 -m pip install openfl-nightly==${{ env.NEW_VERSION }}"
+        fi
+        for i in $(seq 1 $MAX_ATTEMPTS); do
           if $PIP_CMD; then
             echo "Successfully installed openfl-nightly using command '$PIP_CMD'"
             break
           else
-            echo "Attempt $i failed. Retrying in 20 seconds..."
-            sleep 20
+            echo "Attempt $i/$MAX_ATTEMPTS failed. Retrying in $WAIT_TIME_IN_SEC seconds..."
+            sleep $WAIT_TIME_IN_SEC
           fi
         done
         # Check if the package was installed successfully
         if ! python3 -m pip show openfl-nightly > /dev/null; then
-          echo "Failed to install openfl-nightly after 5 attempts."
+          echo "Failed to install openfl-nightly after $MAX_ATTEMPTS attempts."
           exit 1
         fi
         python3 -m pip install -r test-requirements.txt


### PR DESCRIPTION
## Summary
Retry download of `openfl-nightly` package after its publish.

## Type of Change (Mandatory)
Specify the type of change being made. 
- Feature enhancement

## Description (Mandatory)
As part of Product Quality Pipeline run, after the `openfl-nightly` package is pushed to pypi, we are downloading the same and running a basic E2E test.

Somehow it takes time for the package to be available for download as we get error like

`ERROR: No matching distribution found for openfl-nightly==1.9.0.dev202505012`

Although, if we try the same after a few minutes, it works fine.

In this PR, I have added the retry mechanism with 5 attempts and 20s sleep time to help give sometime between publish and download of the package.

## Testing
Triggered workflow from my branch - https://github.com/noopurintel/openfl/actions/runs/14791388068/job/41529117596#step:8:45

*IMP - if it still doesn't work, will need to further increase the attempt/sleep time.*