### PR TITLE
[Task Runner API] Collaborators should only send optimizer information after training when `self.opt_treatment== "CONTINUE_GLOBAL"`

### DIFF
--- a/openfl/federated/task/runner_gandlf.py
+++ b/openfl/federated/task/runner_gandlf.py
@@ -223,7 +223,7 @@ class GaNDLFTaskRunner(TaskRunner):
             )
 
         # output model tensors (Doesn't include TensorKey)
-        tensor_dict = self.get_tensor_dict(with_opt_vars=True)
+        tensor_dict = self.get_tensor_dict(with_opt_vars=(self.opt_treatment == "CONTINUE_GLOBAL"))
 
         metric_dict = {"loss": epoch_train_loss}
         for k, v in epoch_train_metric.items():

--- a/openfl/federated/task/runner_keras.py
+++ b/openfl/federated/task/runner_keras.py
@@ -120,7 +120,9 @@ class KerasTaskRunner(TaskRunner):
         }
 
         # output model tensors (Doesn't include TensorKey)
-        output_model_dict = self.get_tensor_dict(with_opt_vars=(self.opt_treatment == "CONTINUE_GLOBAL"))
+        output_model_dict = self.get_tensor_dict(
+            with_opt_vars=(self.opt_treatment == "CONTINUE_GLOBAL")
+        )
         global_model_dict, local_model_dict = split_tensor_dict_for_holdouts(
             output_model_dict, **self.tensor_dict_split_fn_kwargs
         )
@@ -405,7 +407,6 @@ class KerasTaskRunner(TaskRunner):
             return self.required_tensorkeys_for_function[func_name][local_model]
         else:
             return self.required_tensorkeys_for_function[func_name]
-
 
     def initialize_tensorkeys_for_functions(self, with_opt_vars=False):
         """Set the required tensors for all publicly accessible methods that

--- a/openfl/federated/task/runner_keras.py
+++ b/openfl/federated/task/runner_keras.py
@@ -120,7 +120,7 @@ class KerasTaskRunner(TaskRunner):
         }
 
         # output model tensors (Doesn't include TensorKey)
-        output_model_dict = self.get_tensor_dict(with_opt_vars=True)
+        output_model_dict = self.get_tensor_dict(with_opt_vars=(self.opt_treatment == "CONTINUE_GLOBAL"))
         global_model_dict, local_model_dict = split_tensor_dict_for_holdouts(
             output_model_dict, **self.tensor_dict_split_fn_kwargs
         )
@@ -165,7 +165,6 @@ class KerasTaskRunner(TaskRunner):
         if self.opt_treatment == "CONTINUE_GLOBAL":
             self.initialize_tensorkeys_for_functions(with_opt_vars=True)
 
-        self.update_tensorkeys_for_functions()
         return global_tensor_dict, local_tensor_dict
 
     def train_(self, batch_generator, metrics: list = None, **kwargs):
@@ -407,34 +406,6 @@ class KerasTaskRunner(TaskRunner):
         else:
             return self.required_tensorkeys_for_function[func_name]
 
-    def update_tensorkeys_for_functions(self):
-        """Update the required tensors for all publicly accessible methods that
-        could be called as part of a task.
-
-        By default, this is just all of the layers and optimizer of the model.
-        Custom tensors should be added to this function
-        """
-        # TODO complete this function. It is only needed for opt_treatment,
-        #  and making the model stateless
-
-        # Minimal required tensors for train function
-        model_layer_names = self._get_weights_names(self.model)
-        opt_names = self._get_weights_names(self.model.optimizer)
-        tensor_names = model_layer_names + opt_names
-        logger.debug("Updating model tensor names: %s", tensor_names)
-        self.required_tensorkeys_for_function["train_task"] = [
-            TensorKey(tensor_name, "GLOBAL", 0, False, ("model",)) for tensor_name in tensor_names
-        ]
-
-        # Validation may be performed on local or aggregated (global) model,
-        # so there is an extra lookup dimension for kwargs
-        self.required_tensorkeys_for_function["validate_task"] = {}
-        self.required_tensorkeys_for_function["validate_task"]["apply=local"] = [
-            TensorKey(tensor_name, "LOCAL", 0, False, ("trained",)) for tensor_name in tensor_names
-        ]
-        self.required_tensorkeys_for_function["validate_task"]["apply=global"] = [
-            TensorKey(tensor_name, "GLOBAL", 0, False, ("model",)) for tensor_name in tensor_names
-        ]
 
     def initialize_tensorkeys_for_functions(self, with_opt_vars=False):
         """Set the required tensors for all publicly accessible methods that

--- a/openfl/federated/task/runner_pt.py
+++ b/openfl/federated/task/runner_pt.py
@@ -178,7 +178,7 @@ class PyTorchTaskRunner(nn.Module, TaskRunner):
         }
 
         # output model tensors (Doesn't include TensorKey)
-        output_model_dict = self.get_tensor_dict(with_opt_vars=True)
+        output_model_dict = self.get_tensor_dict(with_opt_vars=(self.opt_treatment == "CONTINUE_GLOBAL"))
         global_model_dict, local_model_dict = split_tensor_dict_for_holdouts(
             output_model_dict, **self.tensor_dict_split_fn_kwargs
         )

--- a/openfl/federated/task/runner_pt.py
+++ b/openfl/federated/task/runner_pt.py
@@ -178,7 +178,9 @@ class PyTorchTaskRunner(nn.Module, TaskRunner):
         }
 
         # output model tensors (Doesn't include TensorKey)
-        output_model_dict = self.get_tensor_dict(with_opt_vars=(self.opt_treatment == "CONTINUE_GLOBAL"))
+        output_model_dict = self.get_tensor_dict(
+            with_opt_vars=(self.opt_treatment == "CONTINUE_GLOBAL")
+        )
         global_model_dict, local_model_dict = split_tensor_dict_for_holdouts(
             output_model_dict, **self.tensor_dict_split_fn_kwargs
         )


### PR DESCRIPTION
## Summary
The expected behavior is to send only model updates between the agg and col unless `self.opt_treatment== "CONTINUE_GLOBAL"` (which can configured in the `plan.yaml`). The Task Runners were sending optimizer states keys by default after training. Not only is this extra information that doesn't need to be sent, if a user wants to run model integrity check by hashing the values sent and received, they would have to filter out the opt values. Furthermore, keras workspaces have an additional `update_tensorkeys_for_functions()` method that will automatically update the tensorkeys to include optimizer state keys, which seems to be a less conditioned version of: 
```
if self.opt_treatment == "CONTINUE_GLOBAL":
            self.initialize_tensorkeys_for_functions(with_opt_vars=True)
```

## Type of Change (Mandatory)
Specify the type of change being made. 
- Bug fix  

## Description (Mandatory)
This PR:
- Sets `self.get_tensor_dict(with_opt_vars=(self.opt_treatment == "CONTINUE_GLOBAL"))` for all `runner_*.py` during the train task so that optimizer key states are only send if explicitly set to
-  Removes `update_tensorkeys_for_functions()` method from `runner_keras.py` as this method is redundant when compared against `self.initialize_tensorkeys_for_functions(with_opt_vars=True)` and is also adding optimizer key states to the list of tensor keys without a check.

## Testing
Manually

## Additional Information
- 