### PR TITLE
Add `on_task_*` callbacks

### DIFF
--- a/openfl/callbacks/callback.py
+++ b/openfl/callbacks/callback.py
@@ -13,8 +13,12 @@ class Callback:
     for the following events:
         * At the beginning of an experiment
         * At the beginning of a round
+        * At the beginning of a task^
+        * At the end of a task^
         * At the end of a round
         * At the end of an experiment
+
+    ^ These events are only triggered for the collaborator.
 
     Attributes:
         params: Additional parameters saved for use within the callback.

--- a/openfl/callbacks/callback.py
+++ b/openfl/callbacks/callback.py
@@ -55,17 +55,13 @@ class Callback:
         Subclasses need to implement actions to be taken here.
         """
 
-    def on_task_begin(
-        self,
-        round_num: int,
-        logs=None,
-    ):
+    def on_task_begin(self, task_name: str, round_num: int, logs=None):
         """Callback function to be executed at the beginning of a task.
 
         Subclasses need to implement actions to be taken here.
         """
 
-    def on_task_end(self, round_num: int, logs=None):
+    def on_task_end(self, task_name: str, round_num: int, logs=None):
         """Callback function to be executed at the end of a task.
 
         Subclasses need to implement actions to be taken here.

--- a/openfl/callbacks/callback_list.py
+++ b/openfl/callbacks/callback_list.py
@@ -83,17 +83,13 @@ class CallbackList(Callback):
         for callback in self.callbacks:
             callback.on_experiment_end(logs)
 
-    def on_task_begin(
-        self,
-        round_num: int,
-        logs=None,
-    ):
+    def on_task_begin(self, task_name: str, round_num: int, logs=None):
         for callback in self.callbacks:
-            callback.on_task_begin(round_num, logs)
+            callback.on_task_begin(task_name, round_num, logs)
 
-    def on_task_end(self, round_num: int, logs=None):
+    def on_task_end(self, task_name: str, round_num: int, logs=None):
         for callback in self.callbacks:
-            callback.on_task_end(round_num, logs)
+            callback.on_task_end(task_name, round_num, logs)
 
 
 def _flatten(l):

--- a/openfl/callbacks/lambda_callback.py
+++ b/openfl/callbacks/lambda_callback.py
@@ -12,10 +12,14 @@ class LambdaCallback(Callback):
 
     * on_round_begin: expects `round_num` as a positional argument.
     * on_round_end: expects `round_num` as a positional argument.
+    * on_task_begin: expects `task_name` and `round_num` as a positional argument.
+    * on_task_end: expects `task_name` and `round_num` as a positional argument.
 
     Args:
         on_round_begin: called at the beginning of every round.
         on_round_end: called at the end of every round.
+        on_task_begin: called at the beginning of a task.
+        on_task_end: called at the end of a task.
         on_experiment_begin: called at the beginning of an experiment.
         on_experiment_end: called at the end of an experiment.
     """
@@ -24,6 +28,8 @@ class LambdaCallback(Callback):
         self,
         on_round_begin=None,
         on_round_end=None,
+        on_task_begin=None,
+        on_task_end=None,
         on_experiment_begin=None,
         on_experiment_end=None,
     ):
@@ -32,6 +38,10 @@ class LambdaCallback(Callback):
             self.on_round_begin = on_round_begin
         if on_round_end is not None:
             self.on_round_end = on_round_end
+        if on_task_begin is not None:
+            self.on_task_begin = on_task_begin
+        if on_task_end is not None:
+            self.on_task_end = on_task_end
         if on_experiment_begin is not None:
             self.on_experiment_begin = on_experiment_begin
         if on_experiment_end is not None:

--- a/openfl/component/collaborator/collaborator.py
+++ b/openfl/component/collaborator/collaborator.py
@@ -240,7 +240,7 @@ class Collaborator:
         input_tensor_dict = {
             k.tensor_name: self.get_data_for_tensorkey(k) for k in required_tensorkeys
         }
-        self.callbacks.on_task_begin(round_number)
+        self.callbacks.on_task_begin(task_name, round_number)
         # now we have whatever the model needs to do the task
         # Tasks are defined as methods of TaskRunner
         func = getattr(self.task_runner, func_name)
@@ -253,7 +253,7 @@ class Collaborator:
             **kwargs,
         )
 
-        self.callbacks.on_task_end(round_number)
+        self.callbacks.on_task_end(task_name, round_number)
 
         # If secure aggregation is enabled, add masks to the dict to be shared
         # with the aggregator.


### PR DESCRIPTION
This PR generalizes existing support for callbacks at the beginning and end of a task. Task callbacks now take `task_name` as a positional argument, allowing downstream implementations to trigger functions based on the task.