### PR TITLE
Datasets: support Azure Blob data sources

### DIFF
--- a/openfl/federated/data/sources/azure_blob_data_source.py
+++ b/openfl/federated/data/sources/azure_blob_data_source.py
@@ -1,0 +1,60 @@
+# Copyright 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import hashlib
+from typing import Callable
+
+from azure.storage.blob import BlobServiceClient
+
+from openfl.federated.data.sources.data_source import DataSource, DataSourceType
+
+
+class AzureBlobDataSource(DataSource):
+    """Class for Azure Blob data"""
+
+    def __init__(
+        self,
+        connection_string: str,
+        container_name: str,
+        folder_prefix="",
+        hash_func: Callable[..., "hashlib._Hash"] = hashlib.sha384,
+    ):
+        super().__init__(DataSourceType.AZURE_BLOB)
+        self.connection_string = connection_string
+        self.container_name = container_name
+        self.folder_prefix = folder_prefix
+        if not super().is_valid_hash_function(hash_func):
+            raise ValueError(
+                f"Data source {self.name}: Invalid hash function: {hash_func.__name__}."
+                " Must be a hashlib function."
+            )
+        self.hash_func = hash_func
+        self._service_client = BlobServiceClient.from_connection_string(connection_string)
+        self._container_client = self._service_client.get_container_client(container_name)
+
+    def enumerate_files(self):
+        """List all blobs in the container (full recursive listing)"""
+        return [
+            blob.name
+            for blob in self._container_client.list_blobs(name_starts_with=self.folder_prefix)
+        ]
+
+    def compute_file_hash(self, blob_path: str):
+        """Compute the hash of a blob's binary content."""
+        content = self.read_blob(blob_path)
+        return self.hash_func(content).hexdigest()
+
+    def read_blob(self, blob_path: str):
+        """Read blob content as binary data."""
+        blob_client = self._container_client.get_blob_client(blob_path)
+        downloader = blob_client.download_blob()
+        return downloader.readall()
+
+    @classmethod
+    def from_dict(cls, ds_dict: dict):
+        hash_func = getattr(hashlib, ds_dict.get("hash_func", "sha384"), None)
+        return cls(
+            connection_string=ds_dict["connection_string"],
+            container_name=ds_dict["container_name"],
+            hash_func=hash_func,
+        )

--- a/openfl/federated/data/sources/data_source.py
+++ b/openfl/federated/data/sources/data_source.py
@@ -15,6 +15,7 @@ class DataSourceType(Enum):
 
     LOCAL = auto()
     S3 = auto()
+    AZURE_BLOB = auto()
 
 
 class DataSource(ABC):

--- a/openfl/federated/data/sources/verifiable_dataset_info.py
+++ b/openfl/federated/data/sources/verifiable_dataset_info.py
@@ -7,6 +7,7 @@ import json
 from hashlib import sha384
 from typing import List
 
+from openfl.federated.data.sources.azure_blob_data_source import AzureBlobDataSource
 from openfl.federated.data.sources.data_source import DataSource, DataSourceType
 from openfl.federated.data.sources.local_data_source import LocalDataSource
 from openfl.federated.data.sources.s3_data_source import S3DataSource
@@ -95,6 +96,8 @@ class VerifiableDatasetInfo:
             path = str(self.data_sources[0].get_source_full_path())
         elif self.data_sources[0].type == DataSourceType.S3:
             path = self.data_sources[0].uri
+        elif self.data_sources[0].type == DataSourceType.AZURE_BLOB:
+            path = self.data_sources[0].connection_string
         else:
             raise ValueError(f"Unknown storage type: {self.data_sources[0].type}")
 
@@ -109,6 +112,10 @@ class VerifiableDatasetInfo:
             s3_dict = self.data_sources[0].to_dict()
             s3_dict.pop("uri")
             dataset_dict.update(s3_dict)
+        elif self.data_sources[0].type == DataSourceType.AZURE_BLOB:
+            azure_dict = self.data_sources[0].to_dict()
+            azure_dict.pop("connection_string")
+            dataset_dict.update(azure_dict)
 
         return json.dumps(dataset_dict, sort_keys=True, indent=4)
 
@@ -132,6 +139,15 @@ class VerifiableDatasetInfo:
                 metadata=data_dict["metadata"],
                 root_hash=data_dict["dataset_id"],
             )
+        elif "container_name" in data_dict:
+            azure_dict = data_dict
+            azure_dict["connection_string"] = data_dict["mount_absolute_path"]
+            return VerifiableDatasetInfo(
+                [AzureBlobDataSource.from_dict(ds_dict=azure_dict)],
+                label=data_dict["label"],
+                metadata=data_dict["metadata"],
+                root_hash=data_dict["dataset_id"],
+            )
         else:
             return VerifiableDatasetInfo(
                 [LocalDataSource(source_path=".", base_path=base_path)],
@@ -151,6 +167,8 @@ class VerifiableDatasetInfo:
                 data_source = LocalDataSource.from_dict(ds_dict=datasource, base_path=base_path)
             elif datasource["type"] == DataSourceType.S3.value:
                 data_source = S3DataSource.from_dict(ds_dict=datasource)
+            elif datasource["type"] == DataSourceType.AZURE_BLOB.value:
+                data_source = AzureBlobDataSource.from_dict(ds_dict=datasource)
             else:
                 raise ValueError(f"Unknown storage type: {datasource['type']}")
             data_sources.append(data_source)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -13,3 +13,4 @@ torch==2.7.0
 boto3==1.37.19
 moto==5.1.1
 torchvision==0.22.0
+azure-storage-blob==12.25.1

--- a/tests/openfl/federated/data/test_azure_blob_data_source.py
+++ b/tests/openfl/federated/data/test_azure_blob_data_source.py
@@ -1,0 +1,116 @@
+# Copyright 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import hashlib
+import pytest
+from unittest.mock import MagicMock, patch
+from openfl.federated.data.sources.azure_blob_data_source import AzureBlobDataSource
+
+@pytest.fixture
+def mocked_azure_blob_ds():
+    connection_string = "DefaultEndpointsProtocol=https;AccountName=fake;AccountKey=fakekey;"
+    container_name = "test-container"
+
+    # File paths and their binary content
+    files = [
+        "folder1/file1.txt",
+        "folder1/file2.txt",
+        "folder2/subfolder/file3.txt",
+        "folder2/subfolder/file4.txt",
+        "folder3/file5.txt",
+        "folder3/subfolder/file6.txt",
+    ]
+    file_contents = {f: f"file content of file #{i}".encode() for i, f in enumerate(files)}
+
+    with patch("openfl.federated.data.sources.azure_blob_data_source.BlobServiceClient") as mock_service_cls:
+        # Mock container and blob service
+        mock_service = MagicMock()
+        mock_container = MagicMock()
+
+        # Mock list_blobs to return blob-like objects with a `name` attribute
+        blob_mocks = []
+        for f in files:
+            mock_blob = MagicMock()
+            type(mock_blob).name = property(lambda self, name=f: name)  # ensures blob.name == f
+            blob_mocks.append(mock_blob)
+
+        mock_container.list_blobs.return_value = blob_mocks
+
+        # Mock get_blob_client to return blob clients with readall data
+        def get_blob_client(blob_path):
+            mock_blob_client = MagicMock()
+            downloader = MagicMock()
+            downloader.readall.return_value = file_contents[blob_path]
+            mock_blob_client.download_blob.return_value = downloader
+            return mock_blob_client
+
+        mock_container.get_blob_client.side_effect = get_blob_client
+
+        def list_blobs(name_starts_with=None):
+            if name_starts_with is None:
+                return blob_mocks
+            return [b for b in blob_mocks if b.name.startswith(name_starts_with)]
+
+        mock_container.list_blobs.side_effect = list_blobs
+
+        mock_service.get_container_client.return_value = mock_container
+        mock_service_cls.from_connection_string.return_value = mock_service
+
+        yield connection_string, container_name, files, file_contents
+
+def test_enumerate_files(mocked_azure_blob_ds):
+    connection_string, container_name, expected_files, _ = mocked_azure_blob_ds
+    datasource = AzureBlobDataSource(
+            connection_string=connection_string,
+            container_name=container_name,
+        )
+    listed_files = datasource.enumerate_files()
+    assert listed_files == expected_files
+
+def test_compute_file_hash(mocked_azure_blob_ds):
+    connection_string, container_name, files, file_contents = mocked_azure_blob_ds
+    datasource = AzureBlobDataSource(
+            connection_string=connection_string,
+            container_name=container_name,
+        )
+    for f in files:
+        expected_hash = hashlib.sha384(file_contents[f]).hexdigest()
+        actual_hash = datasource.compute_file_hash(f)
+        assert actual_hash == expected_hash, f"Hash mismatch for file: {f}"
+
+def test_from_dict(mocked_azure_blob_ds):
+    connection_string, container_name, _, _ = mocked_azure_blob_ds
+
+    ds_dict = {
+        "connection_string": connection_string,
+        "container_name": container_name,
+        "hash_func": "sha384"
+    }
+
+    new_ds = AzureBlobDataSource.from_dict(ds_dict)
+    assert new_ds.connection_string == connection_string
+    assert new_ds.container_name == container_name
+    assert callable(new_ds.hash_func)
+    assert new_ds.hash_func == hashlib.sha384
+
+def test_files_content(mocked_azure_blob_ds):
+    connection_string, container_name, files, file_contents = mocked_azure_blob_ds
+    datasource = AzureBlobDataSource(
+            connection_string=connection_string,
+            container_name=container_name,
+        )
+    for f in files:
+        content = datasource.read_blob(f)
+        assert content == file_contents[f], f"Content mismatch for file: {f}"
+
+def test_folder_prefix(mocked_azure_blob_ds):
+    connection_string, container_name, files, _ = mocked_azure_blob_ds
+    folder_prefix = "folder1/"
+    datasource = AzureBlobDataSource(
+            connection_string=connection_string,
+            container_name=container_name,
+            folder_prefix=folder_prefix,
+        )
+    expected_files = [f for f in files if f.startswith(folder_prefix)]
+    listed_files = datasource.enumerate_files()
+    assert listed_files == expected_files

--- a/tests/openfl/federated/data/test_verifiable_dataset.py
+++ b/tests/openfl/federated/data/test_verifiable_dataset.py
@@ -3,6 +3,8 @@
 
 from hashlib import sha256, sha384
 import json
+from unittest.mock import MagicMock, patch
+from openfl.federated.data.sources.azure_blob_data_source import AzureBlobDataSource
 from openfl.federated.data.sources.local_data_source import LocalDataSource
 from openfl.federated.data.sources.s3_data_source import S3DataSource
 from openfl.federated.data.sources.verifiable_dataset_info import VerifiableDatasetInfo
@@ -70,6 +72,81 @@ def mock_s3_buckets():
             s3_client.put_object(Bucket=bucket2, Key=file, Body=f"Content of {file}")
 
         yield bucket1, bucket2  # Return both bucket names
+
+@pytest.fixture
+def mock_azure_blob():
+    # Define two containers
+    containers = [
+        {
+            "connection_string": "DefaultEndpointsProtocol=https;AccountName=fake1;AccountKey=fakekey1;",
+            "container_name": "test-container-1",
+        },
+        {
+            "connection_string": "DefaultEndpointsProtocol=https;AccountName=fake2;AccountKey=fakekey2;",
+            "container_name": "test-container-2",
+        }
+    ]
+
+    files1 = [
+        "folder1/file1.txt",
+        "folder1/file2.txt",
+        "folder1/subfolder/file3.txt",
+        "folder2/file4.txt",
+        "folder2/file5.txt",
+        "folder2/subfolder/file6.txt"
+    ]
+    files2 = [
+        "dir1/fileA.txt",
+        "dir1/fileB.txt",
+        "dir1/subdir/fileC.txt",
+        "dir2/fileD.txt",
+        "dir2/fileE.txt",
+        "dir2/subdir/fileF.txt"
+    ]
+    files_per_container = [files1, files2]
+
+    file_contents_list = []
+    for c_idx, files in enumerate(files_per_container):
+        file_contents = {f: f"file content of file #{i} in container {c_idx + 1}, path: {f}".encode() for i, f in enumerate(files)}
+        file_contents_list.append(file_contents)
+
+    with patch("openfl.federated.data.sources.azure_blob_data_source.BlobServiceClient") as mock_service_cls:
+        service_mocks = []
+
+        for files, file_contents in zip(files_per_container, file_contents_list):
+            mock_service = MagicMock()
+            mock_container = MagicMock()
+
+            # Create blob mocks with correct names
+            blob_mocks = []
+            for f in files:
+                mock_blob = MagicMock()
+                type(mock_blob).name = property(lambda self, name=f: name)
+                blob_mocks.append(mock_blob)
+            mock_container.list_blobs.return_value = blob_mocks
+
+            def get_blob_client(blob_path, file_contents=file_contents):
+                mock_blob_client = MagicMock()
+                downloader = MagicMock()
+                downloader.readall.return_value = file_contents[blob_path]
+                mock_blob_client.download_blob.return_value = downloader
+                return mock_blob_client
+
+            mock_container.get_blob_client.side_effect = get_blob_client
+            mock_service.get_container_client.return_value = mock_container
+            service_mocks.append(mock_service)
+
+        def from_connection_string_mock(conn_str):
+            if conn_str == containers[0]["connection_string"]:
+                return service_mocks[0]
+            elif conn_str == containers[1]["connection_string"]:
+                return service_mocks[1]
+            else:
+                raise ValueError(f"Unknown connection string: {conn_str}")
+
+        mock_service_cls.from_connection_string.side_effect = from_connection_string_mock
+
+        yield containers[0], containers[1]
 
 def split_to_base_and_relative_paths(data_sources_paths: List[str]) -> Tuple[str, List[str]]:
     """Split a list of paths into a base directory and relative paths."""
@@ -355,3 +432,87 @@ def test_one_s3_datasource_verify_single_file(mock_s3_buckets):
     verifiable.verify_dataset(dataset_info_dict["dataset_id"])
     for file_path, hash in verifiable.all_hashes.items():
         assert verifiable_from_json.verify_single_file(file_path, hash)
+
+def test_one_azure_blob_data_source(mock_azure_blob):
+    container1, _ = mock_azure_blob
+    ds1 = AzureBlobDataSource(container1["connection_string"], container1["container_name"])
+    verifiable = VerifiableDatasetInfo(data_sources=[ds1], label="my_dataset", metadata="md")
+    hash = verifiable.create_dataset_hash()
+    assert isinstance(hash, str), f"Expected str, got {type(hash)}"
+    verifiable_json = verifiable.to_json()
+    verifiable_from_json = VerifiableDatasetInfo.from_json(verifiable_json)
+    assert verifiable_from_json.verify_dataset()
+
+def test_two_azure_blob_datasource(mock_azure_blob):
+    container1, container2 = mock_azure_blob
+    ds1 = AzureBlobDataSource(container1["connection_string"], container1["container_name"])
+    ds2 = AzureBlobDataSource(container2["connection_string"], container2["container_name"])
+    verifiable = VerifiableDatasetInfo(data_sources=[ds1, ds2], label="my_dataset", metadata="md")
+    hash = verifiable.create_dataset_hash()
+    assert isinstance(hash, str), f"Expected str, got {type(hash)}"
+    verifiable_json = verifiable.to_json()
+    verifiable_from_json = VerifiableDatasetInfo.from_json(verifiable_json)
+    assert verifiable_from_json.verify_dataset()
+
+def test_two_azure_blob_datasource_use_saved_hash(mock_azure_blob):
+    container1, container2 = mock_azure_blob
+    ds1 = AzureBlobDataSource(container1["connection_string"], container1["container_name"])
+    ds2 = AzureBlobDataSource(container2["connection_string"], container2["container_name"])
+    verifiable = VerifiableDatasetInfo(data_sources=[ds1, ds2], label="my_dataset", metadata="md")
+    hash = verifiable.create_dataset_hash()
+    assert isinstance(hash, str), f"Expected str, got {type(hash)}"
+    verifiable_json = verifiable.to_json()
+    dataset_info = json.loads(verifiable_json)
+    assert verifiable.verify_dataset(dataset_info["root_hash"])
+    assert verifiable.verify_dataset()
+
+def test_one_azure_blob_datasource_one_file_hash_func(mock_azure_blob):
+    container1, _ = mock_azure_blob
+    ds1 = AzureBlobDataSource(container1["connection_string"], container1["container_name"], sha256)
+    verifiable = VerifiableDatasetInfo(data_sources=[ds1], label="my_dataset", metadata="md")
+    hash = verifiable.create_dataset_hash()
+    assert isinstance(hash, str), f"Expected str, got {type(hash)}"
+    verifiable_json = verifiable.to_json()
+    verifiable_from_json = VerifiableDatasetInfo.from_json(verifiable_json)
+    assert verifiable_from_json.verify_dataset()
+
+def test_two_azure_blob_datasource_hash_func_use_saved_hash(mock_azure_blob):
+    container1, container2 = mock_azure_blob
+    ds1 = AzureBlobDataSource(container1["connection_string"], container1["container_name"], sha256)
+    ds2 = AzureBlobDataSource(container2["connection_string"], container2["container_name"], sha256)
+    verifiable = VerifiableDatasetInfo(data_sources=[ds1, ds2], label="my_dataset", metadata="md")
+    hash = verifiable.create_dataset_hash()
+    assert isinstance(hash, str), f"Expected str, got {type(hash)}"
+    verifiable_json = verifiable.to_json()
+    dataset_info = json.loads(verifiable_json)
+    assert verifiable.verify_dataset(dataset_info["root_hash"])
+    assert verifiable.verify_dataset()
+
+def test_one_azure_blob_datasource_verify_single_file(mock_azure_blob):
+    container1, _ = mock_azure_blob
+    ds1 = AzureBlobDataSource(container1["connection_string"], container1["container_name"])
+    verifiable = VerifiableDatasetInfo(data_sources=[ds1], label="my_dataset", metadata="md")
+    hash = verifiable.create_dataset_hash()
+    assert isinstance(hash, str), f"Expected str, got {type(hash)}"
+    verifiable_json = verifiable.to_json()
+    dataset_info_dict = json.loads(verifiable_json)
+    verifiable_from_json = VerifiableDatasetInfo.from_json(verifiable_json)
+    # Create & save in memory the hashes for all files
+    verifiable.verify_dataset(dataset_info_dict["dataset_id"])
+    for file_path, hash in verifiable.all_hashes.items():
+        assert verifiable_from_json.verify_single_file(file_path, hash)
+
+def test_azure_blob_and_local_datasources(local_data_sources, mock_azure_blob):
+    local_path1, local_path2 = local_data_sources
+    base_path, relative_paths = split_to_base_and_relative_paths([local_path1, local_path2])
+    local_ds1 = LocalDataSource(source_path=relative_paths[0], base_path=base_path)
+    local_ds2 = LocalDataSource(source_path=relative_paths[1], base_path=base_path)
+    container1, container2 = mock_azure_blob
+    azure_ds1 = AzureBlobDataSource(container1["connection_string"], container1["container_name"])
+    azure_ds2 = AzureBlobDataSource(container2["connection_string"], container2["container_name"])
+    verifiable = VerifiableDatasetInfo(data_sources=[local_ds1, azure_ds1, local_ds2, azure_ds2], label="my_dataset", metadata="md")
+    hash = verifiable.create_dataset_hash()
+    assert isinstance(hash, str), f"Expected str, got {type(hash)}"
+    verifiable_json = verifiable.to_json()
+    verifiable_from_json = VerifiableDatasetInfo.from_json(verifiable_json, base_path)
+    assert verifiable_from_json.verify_dataset()

--- a/tests/openfl/federated/data/test_verifiable_map_style.py
+++ b/tests/openfl/federated/data/test_verifiable_map_style.py
@@ -6,6 +6,7 @@ import os
 
 from pathlib import Path
 from typing import List, Tuple
+from unittest.mock import MagicMock, patch
 import pytest
 import boto3
 from moto import mock_aws
@@ -13,6 +14,7 @@ import torch
 from torchvision.transforms import ToTensor
 
 import io
+from openfl.federated.data.sources.azure_blob_data_source import AzureBlobDataSource
 from openfl.federated.data.sources.data_source import DataSource
 from openfl.federated.data.sources.local_data_source import LocalDataSource
 from openfl.federated.data.sources.torch.folder_dataset import FolderDataset, LabelMapper
@@ -373,6 +375,220 @@ def test_s3_image_folder_map_style_datasource_labels(mock_s3_image_buckets):
 
     # Ensure that index also maps back correctly in idx_to_label
     assert label_mapper.idx_to_label[elephant_label_id] == "elephant", "Reverse mapping is incorrect"
+
+    # Esure that "dog" is mapped to a single label index
+    dog_occurrences = sum(1 for label in label_mapper.idx_to_label.values() if label == "dog")
+    assert dog_occurrences == 1, f"Label 'dog' should have only one unique index, but found {dog_occurrences}"
+
+
+
+
+
+@pytest.fixture
+def mock_azure_blob():
+    # Define two containers
+    containers = [
+        {
+            "connection_string": "DefaultEndpointsProtocol=https;AccountName=fake1;AccountKey=fakekey1;",
+            "container_name": "test-container-1",
+        },
+        {
+            "connection_string": "DefaultEndpointsProtocol=https;AccountName=fake2;AccountKey=fakekey2;",
+            "container_name": "test-container-2",
+        }
+    ]
+
+    files1 = [
+        "train/cat/cat1.png",
+        "train/cat/cat2.png",
+        "train/dog/dog1.png",
+        "train/dog/dog2.png",
+        "train/rabbit/rabbit1.png",
+        "train/rabbit/rabbit2.png"
+    ]
+    files2 = [
+        "rabbit/rabbit3.png",
+        "rabbit/rabbit4.png",
+        "elephant/elephant1.png",
+        "elephant/elephant2.png",
+        "snake/snake1.png",
+        "snake/snake2.png"
+    ]
+    files_per_container = [files1, files2]
+
+    img = Image.new("RGB", (10, 10), color="red")
+    img_bytes_io = io.BytesIO()
+    img.save(img_bytes_io, format="PNG")
+    img_data = img_bytes_io.getvalue()
+
+    file_contents_list = [
+        {f: img_data for f in files}
+        for files in files_per_container
+    ]
+    with patch("openfl.federated.data.sources.azure_blob_data_source.BlobServiceClient") as mock_service_cls:
+        service_mocks = []
+
+        for files, file_contents in zip(files_per_container, file_contents_list):
+            mock_service = MagicMock()
+            mock_container = MagicMock()
+
+            # Create blob mocks with correct names
+            blob_mocks = []
+            for f in files:
+                mock_blob = MagicMock()
+                type(mock_blob).name = property(lambda self, name=f: name)
+                blob_mocks.append(mock_blob)
+            mock_container.list_blobs.return_value = blob_mocks
+
+            def get_blob_client(blob_path, file_contents=file_contents):
+                mock_blob_client = MagicMock()
+                downloader = MagicMock()
+                downloader.readall.return_value = file_contents[blob_path]
+                mock_blob_client.download_blob.return_value = downloader
+                return mock_blob_client
+
+            mock_container.get_blob_client.side_effect = get_blob_client
+            mock_service.get_container_client.return_value = mock_container
+            service_mocks.append(mock_service)
+
+        def from_connection_string_mock(conn_str):
+            if conn_str == containers[0]["connection_string"]:
+                return service_mocks[0]
+            elif conn_str == containers[1]["connection_string"]:
+                return service_mocks[1]
+            else:
+                raise ValueError(f"Unknown connection string: {conn_str}")
+
+        mock_service_cls.from_connection_string.side_effect = from_connection_string_mock
+
+        yield containers[0], containers[1]
+
+
+
+def test_azure_blob_image_folder_map_style_datasource(mock_azure_blob):
+    container1, container2 = mock_azure_blob
+    ds1 = AzureBlobDataSource(container1["connection_string"], container1["container_name"])
+    ds2 = AzureBlobDataSource(container2["connection_string"], container2["container_name"])
+    datasources = [ds1, ds2]
+    verifiable_dataset_info = VerifiableDatasetInfo(
+        data_sources=datasources,
+        label="Test VerifiableMapStyleDataset",
+        metadata={"test": "test"}
+    )
+    verifiable_map_style = VerifiableImageFolder(verifiable_dataset_info, verify_dataset_items=False)
+    assert len(verifiable_map_style) == 12
+    assert len(verifiable_map_style.datasets) == len(datasources)
+
+    for i in range(len(verifiable_map_style)):
+        if i < 6:
+            assert verifiable_map_style[i][0] == verifiable_map_style.datasets[0][i]["data"]
+            assert verifiable_map_style[i][1] == verifiable_map_style.datasets[0][i]["label"]
+        else:
+            assert verifiable_map_style[i][0] == verifiable_map_style.datasets[1][i - 6]["data"]
+            assert verifiable_map_style[i][1] == verifiable_map_style.datasets[1][i - 6]["label"]
+
+def test_azure_blob_image_folder_map_style_datasource_verify(mock_azure_blob):
+    container1, container2 = mock_azure_blob
+    ds1 = AzureBlobDataSource(container1["connection_string"], container1["container_name"])
+    ds2 = AzureBlobDataSource(container2["connection_string"], container2["container_name"])
+    datasources = [ds1, ds2]
+    verifiable_dataset_info = VerifiableDatasetInfo(
+        data_sources=datasources,
+        label="Test VerifiableMapStyleDataset",
+        metadata={"test": "test"}
+    )
+    dataset_info_json = verifiable_dataset_info.to_json()
+    verifiable_dataset_info.verify_dataset(json.loads(dataset_info_json)["root_hash"])
+    verifiable_map_style = VerifiableImageFolder(verifiable_dataset_info, verify_dataset_items=True)
+    assert len(verifiable_map_style) == 12
+    assert len(verifiable_map_style.datasets) == len(datasources)
+
+    for i in range(len(verifiable_map_style)):
+        if i < 6:
+            assert verifiable_map_style[i][0] == verifiable_map_style.datasets[0][i]["data"]
+            assert verifiable_map_style[i][1] == verifiable_map_style.datasets[0][i]["label"]
+        else:
+            assert verifiable_map_style[i][0] == verifiable_map_style.datasets[1][i - 6]["data"]
+            assert verifiable_map_style[i][1] == verifiable_map_style.datasets[1][i - 6]["label"]
+
+
+def test_azure_blob_image_folder_map_style_datasource_labels(mock_azure_blob):
+    """Test that LabelMapper correctly maps labels across multiple datasets."""
+    container1, container2 = mock_azure_blob
+    ds1 = AzureBlobDataSource(container1["connection_string"], container1["container_name"])
+    ds2 = AzureBlobDataSource(container2["connection_string"], container2["container_name"])
+    datasources = [ds1, ds2]
+
+    verifiable_dataset_info = VerifiableDatasetInfo(
+        data_sources=datasources,
+        label="Test VerifiableMapStyleDataset",
+        metadata={"test": "test"}
+    )
+    verifiable_map_style = VerifiableImageFolder(verifiable_dataset_info, verify_dataset_items=True)
+
+    # Check the label mapping
+    label_mapper = verifiable_map_style.label_mapper
+    assert label_mapper is not None, "LabelMapper should be initialized"
+
+    # Expected label mappings (combining all dataset labels)
+    expected_labels = {"cat", "dog", "rabbit", "elephant", "snake"}
+    mapped_labels = set(label_mapper.label_to_idx.keys())
+
+    assert mapped_labels == expected_labels, f"Expected labels {expected_labels}, but got {mapped_labels}"
+
+    # Ensure all mapped values are unique integers
+    mapped_values = set(label_mapper.label_to_idx.values())
+    assert len(mapped_values) == len(expected_labels), "LabelMapper should assign unique integers to each label"
+
+    # Ensure "elephant" has the same integer mapping across all datasets
+    elephant_label_id = label_mapper.get_label_index("elephant")
+
+    # Ensure that index also maps back correctly in idx_to_label
+    assert label_mapper.idx_to_label[elephant_label_id] == "elephant", "Reverse mapping is incorrect"
+
+    # Esure that "dog" is mapped to a single label index
+    dog_occurrences = sum(1 for label in label_mapper.idx_to_label.values() if label == "dog")
+    assert dog_occurrences == 1, f"Label 'dog' should have only one unique index, but found {dog_occurrences}"
+
+
+def test_mixed_ds_image_folder_map_style_datasource_labels(fake_image_datasources, mock_azure_blob):
+    """Test that LabelMapper correctly maps labels across multiple datasets."""
+    local_ds1, local_ds2, _ = fake_image_datasources
+    base_path, relative_paths = split_to_base_and_relative_paths([local_ds1, local_ds2])
+    datasources = [LocalDataSource(source_path=rel_path, base_path=base_path) for rel_path in relative_paths]
+
+    container1, container2 = mock_azure_blob
+    azure_ds1 = AzureBlobDataSource(container1["connection_string"], container1["container_name"])
+    azure_ds2 = AzureBlobDataSource(container2["connection_string"], container2["container_name"])
+
+    datasources.append(azure_ds1)
+    datasources.append(azure_ds2)
+    verifiable_dataset_info = VerifiableDatasetInfo(
+        data_sources=datasources,
+        label="Test VerifiableMapStyleDataset",
+        metadata={"test": "test"}
+    )
+    verifiable_map_style = VerifiableImageFolder(verifiable_dataset_info, verify_dataset_items=True)
+
+    # Check the label mapping
+    label_mapper = verifiable_map_style.label_mapper
+    assert label_mapper is not None, "LabelMapper should be initialized"
+
+    # Expected label mappings (combining all dataset labels)
+    expected_labels = {"cat", "dog", "rabbit", "elephant", "snake"}
+    mapped_labels = set(label_mapper.label_to_idx.keys())
+
+    assert mapped_labels == expected_labels, f"Expected labels {expected_labels}, but got {mapped_labels}"
+
+    # Ensure all mapped values are unique integers
+    mapped_values = set(label_mapper.label_to_idx.values())
+    assert len(mapped_values) == len(expected_labels), "LabelMapper should assign unique integers to each label"
+
+    # Ensure "dog" has the same integer mapping across all datasets
+    dog_label_id = label_mapper.get_label_index("dog")
+
+    # Ensure that index also maps back correctly in idx_to_label
+    assert label_mapper.idx_to_label[dog_label_id] == "dog", "Reverse mapping is incorrect"
 
     # Esure that "dog" is mapped to a single label index
     dog_occurrences = sum(1 for label in label_mapper.idx_to_label.values() if label == "dog")


### PR DESCRIPTION
## Summary
Support Azure blob data sources.

## Type of Change (Mandatory)
- Feature enhancement  

## Description (Mandatory)
Support Azure blob data sources, including needed changes in `verifiableDatasetInfo`, serializing and deserializing to JSON (v1 and v2).

## Testing
Add unittests for the new class, with `verifiableDatasetInfo` and with `VerifiableMapStyleDataset`/`VerifiableImageFolder`.
Test with OpenFl-Security using Azurite.

<!-- ## Additional Information
[Any additional information that reviewers should be aware of.] -->