### PR TITLE
E2E - Print summary even if the test fails or best score not found

### DIFF
--- a/.github/actions/tr_post_test_run/action.yml
+++ b/.github/actions/tr_post_test_run/action.yml
@@ -13,7 +13,7 @@ runs:
   steps:
     - name: Print test summary
       id: print_test_summary
-      if: ${{ always() }}
+      if: success() || failure()  # Run only on success or failure
       run: |
         export PYTHONPATH="$PYTHONPATH:."
         python tests/end_to_end/utils/summary_helper.py --func_name "print_task_runner_score"

--- a/.github/actions/tr_post_test_run/action.yml
+++ b/.github/actions/tr_post_test_run/action.yml
@@ -13,7 +13,7 @@ runs:
   steps:
     - name: Print test summary
       id: print_test_summary
-      if: success() || failure()  # Run only on success or failure
+      if: success() || failure()  # Run only on success or failure (i.e. not for skipped and cancelled jobs)
       run: |
         export PYTHONPATH="$PYTHONPATH:."
         python tests/end_to_end/utils/summary_helper.py --func_name "print_task_runner_score"

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -132,7 +132,7 @@ jobs:
     needs: input_selection
     if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_with_tls'
     runs-on: ubuntu-22.04
-    timeout-minutes: 30
+    timeout-minutes: 10
     strategy:
       matrix:
         model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_tls) }}

--- a/.github/workflows/task_runner_basic_e2e.yml
+++ b/.github/workflows/task_runner_basic_e2e.yml
@@ -132,7 +132,7 @@ jobs:
     needs: input_selection
     if: needs.input_selection.outputs.selected_jobs == 'all' || needs.input_selection.outputs.selected_jobs == 'test_with_tls'
     runs-on: ubuntu-22.04
-    timeout-minutes: 10
+    timeout-minutes: 30
     strategy:
       matrix:
         model_name: ${{ fromJson(needs.input_selection.outputs.selected_models_for_tls) }}

--- a/tests/end_to_end/utils/db_helper.py
+++ b/tests/end_to_end/utils/db_helper.py
@@ -71,8 +71,8 @@ def get_key_value_from_db(key, database_file, max_retries=10, sleep_interval=5):
         if os.path.exists(database_file):
             db_obj = DBHelper(database_file)
             val = db_obj.read_key_value_store().get(key)
-            # if val:
-            #     return val
+            if val:
+                return val
             log.info(f"Value not found in the database. Retrying in {sleep_interval} seconds...")
         else:
             log.info(f"Database file not found. Retrying in {sleep_interval} seconds...")

--- a/tests/end_to_end/utils/db_helper.py
+++ b/tests/end_to_end/utils/db_helper.py
@@ -4,6 +4,7 @@
 import os
 import sqlite3
 import time
+import logging
 
 import tests.end_to_end.utils.exceptions as ex
 
@@ -14,7 +15,7 @@ import tests.end_to_end.utils.exceptions as ex
 # Columns: id, tensor_name, origin, round, report, tags, nparray
 # Table: tensors
 # Columns: id, tensor_name, origin, round, report, tags, nparray
-
+log = logging.getLogger(__name__)
 
 class DBHelper:
     def __init__(self, db_name):
@@ -70,11 +71,11 @@ def get_key_value_from_db(key, database_file, max_retries=10, sleep_interval=5):
         if os.path.exists(database_file):
             db_obj = DBHelper(database_file)
             val = db_obj.read_key_value_store().get(key)
-            if val:
-                return val
-            print(f"Value not found in the database. Retrying in {sleep_interval} seconds...")
+            # if val:
+            #     return val
+            log.info(f"Value not found in the database. Retrying in {sleep_interval} seconds...")
         else:
-            print(f"Database file not found. Retrying in {sleep_interval} seconds...")
+            log.info(f"Database file not found. Retrying in {sleep_interval} seconds...")
 
         time.sleep(sleep_interval)
         retries += 1

--- a/tests/end_to_end/utils/federation_helper.py
+++ b/tests/end_to_end/utils/federation_helper.py
@@ -239,7 +239,7 @@ def run_federation(fed_obj):
         executor.submit(
             participant.start
         )
-        for participant in [fed_obj.aggregator] + fed_obj.collaborators[:-1]  # TODO - remove this intentional failure after testing
+        for participant in [fed_obj.aggregator] + fed_obj.collaborators
     ]
 
     # Result will contain response files for all the participants.

--- a/tests/end_to_end/utils/federation_helper.py
+++ b/tests/end_to_end/utils/federation_helper.py
@@ -239,7 +239,7 @@ def run_federation(fed_obj):
         executor.submit(
             participant.start
         )
-        for participant in [fed_obj.aggregator] + fed_obj.collaborators
+        for participant in [fed_obj.aggregator] + fed_obj.collaborators[:-1]  # TODO - remove this intentional failure after testing
     ]
 
     # Result will contain response files for all the participants.
@@ -1025,12 +1025,14 @@ def get_current_round(database_file: str) -> int:
     return int(db_helper.get_key_value_from_db("round_number", database_file))
 
 
-def get_best_agg_score(database_file=None, agg_metric_file=None):
+def get_best_agg_score(database_file=None, agg_metric_file=None, max_retries=10, sleep_interval=5):
     """
     Get the best aggregated score from the database file or aggregator metrics file
     Args:
         database_file (str): Database file. Optional.
         agg_metric_file (str): Aggregator metrics file. Optional.
+        max_retries (int): Maximum number of retries to get the best score in case of database_file. Default is 10.
+        sleep_interval (int): Sleep interval between retries in seconds in case of database_file. Default is 5 seconds.
     Returns:
         float: Best aggregated score
     """
@@ -1039,7 +1041,7 @@ def get_best_agg_score(database_file=None, agg_metric_file=None):
         raise ValueError("Either database_file or agg_metric_file should be provided")
 
     if database_file:
-        return db_helper.get_key_value_from_db("best_score", database_file)
+        return db_helper.get_key_value_from_db("best_score", database_file, max_retries=max_retries, sleep_interval=sleep_interval)
     else:
         json_file = convert_to_json(agg_metric_file)
         best_score = json_file[-1].get(constants.AGG_METRIC_MODEL_ACCURACY_KEY)

--- a/tests/end_to_end/utils/summary_helper.py
+++ b/tests/end_to_end/utils/summary_helper.py
@@ -9,6 +9,7 @@ import re
 from pathlib import Path
 
 import tests.end_to_end.utils.constants as constants
+import tests.end_to_end.utils.exceptions as ex
 from tests.end_to_end.utils import federation_helper as fed_helper
 
 result_path = os.path.join(Path().home(), "results")
@@ -148,7 +149,16 @@ def print_task_runner_score():
         "tensor.db",
     )
     # If the federation run fails in between, tensor.db file won't be present
-    best_score = fed_helper.get_best_agg_score(tensor_db_file) if os.path.exists(tensor_db_file) else "Not Found"
+    best_score = "Not Found"
+    try:
+        # Pass max retries=1 as we are printing the summary after completion itself
+        best_score = fed_helper.get_best_agg_score(tensor_db_file, max_retries=1) if os.path.exists(tensor_db_file) else "Not Found"
+    except ex.TensorDBException as e:
+        # Do not fail the test in any scenario
+        print(f"Error reading tensor.db file: {e}")
+    except Exception as e:
+        # Do not fail the test in any scenario
+        print(f"Unexpected error: {e}")
 
     # Write the results to GitHub step summary file
     # This file is created at runtime by the GitHub action, thus we cannot verify its existence beforehand

--- a/tests/end_to_end/utils/summary_helper.py
+++ b/tests/end_to_end/utils/summary_helper.py
@@ -146,7 +146,7 @@ def print_task_runner_score():
         "aggregator",
         "workspace",
         "local_state",
-        "tensor.db",
+        "tensor.db1",
     )
     # If the federation run fails in between, tensor.db file won't be present
     best_score = "Not Found"

--- a/tests/end_to_end/utils/summary_helper.py
+++ b/tests/end_to_end/utils/summary_helper.py
@@ -155,7 +155,7 @@ def print_task_runner_score():
         best_score = fed_helper.get_best_agg_score(tensor_db_file, max_retries=1) if os.path.exists(tensor_db_file) else "Not Found"
     except ex.TensorDBException as e:
         # Do not fail the test in any scenario
-        print(f"Error reading tensor.db file: {e}")
+        print(f"Error reading tensor.db file: {e}. Best score will be reported as {best_score}.")
     except Exception as e:
         # Do not fail the test in any scenario
         print(f"Unexpected error: {e}")

--- a/tests/end_to_end/utils/summary_helper.py
+++ b/tests/end_to_end/utils/summary_helper.py
@@ -146,7 +146,7 @@ def print_task_runner_score():
         "aggregator",
         "workspace",
         "local_state",
-        "tensor.db1",
+        "tensor.db",
     )
     # If the federation run fails in between, tensor.db file won't be present
     best_score = "Not Found"

--- a/tests/end_to_end/utils/summary_helper.py
+++ b/tests/end_to_end/utils/summary_helper.py
@@ -139,7 +139,7 @@ def print_task_runner_score():
         print("No directory starting with 'test_' found in the result path.")
         return
 
-    # Assumption - result directory is present in the home directory
+    best_score = "Not Found"
     tensor_db_file = os.path.join(
         test_specific_result_path,
         model_name,
@@ -149,16 +149,17 @@ def print_task_runner_score():
         "tensor.db",
     )
     # If the federation run fails in between, tensor.db file won't be present
-    best_score = "Not Found"
-    try:
-        # Pass max retries=1 as we are printing the summary after completion itself
-        best_score = fed_helper.get_best_agg_score(tensor_db_file, max_retries=1) if os.path.exists(tensor_db_file) else "Not Found"
-    except ex.TensorDBException as e:
-        # Do not fail the test in any scenario
-        print(f"Error reading tensor.db file: {e}. Best score will be reported as {best_score}.")
-    except Exception as e:
-        # Do not fail the test in any scenario
-        print(f"Unexpected error: {e}")
+    # In any scenario, we should not fail the script
+    if not os.path.exists(tensor_db_file):
+        print(f"File tensor.db not found at {tensor_db_file}.")
+    else:
+        try:
+            # Pass max retries=1 as we are printing the summary after completion itself
+            best_score = fed_helper.get_best_agg_score(tensor_db_file, max_retries=1)
+        except ex.TensorDBException as e:
+            print(f"Error reading tensor.db file: {e}.")
+        except Exception as e:
+            print(f"Unexpected error: {e}")
 
     # Write the results to GitHub step summary file
     # This file is created at runtime by the GitHub action, thus we cannot verify its existence beforehand


### PR DESCRIPTION
## Summary
TaskRunner E2E workflow post test action - Print summary even if the test fails or best score is not found.

## Type of Change (Mandatory)
Specify the type of change being made. 
- E2E framework enhancement  

## Description (Mandatory)
In the "Print Summary" step of post-test-run action of TaskRunner E2E workflows, we fetch the best score from `tensor.db`.
If for some reason, the value is not available, this step was failing for e.g. - https://github.com/securefederatedai/openfl/actions/runs/14993710726/job/42122886444#step:6:37

Expectation is that summary should still get printed with score as `Not Found`, this is because it contains other useful information as well apart from the score.

## Testing
PR pipeline contains the jobs impacted by the changes.

Also, the job where I explicitly induced an error to fail the test - https://github.com/noopurintel/openfl/actions/runs/14997840042

<img width="1355" alt="image" src="https://github.com/user-attachments/assets/3a957efc-9351-4557-b057-d113b0f9cd41" />
