### PR TITLE
Revert "Torch version 2.7.0 update -Flower App"

### DIFF
--- a/openfl-workspace/flower-app-pytorch/src/app-pytorch/pyproject.toml
+++ b/openfl-workspace/flower-app-pytorch/src/app-pytorch/pyproject.toml
@@ -10,8 +10,8 @@ license = "Apache-2.0"
 dependencies = [
     "flwr>=1.15.0,<1.17.0",
     "flwr-datasets[vision]>=0.5.0",
-    "torch==2.7.0",
-    "torchvision==0.22.0",
+    "torch==2.5.1",
+    "torchvision==0.20.1",
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
Reverts securefederatedai/openfl#1588

It is not clear to me what is happening, but it seems that `torch==2.7.0` when run through `Flower` will break in SGX:
<img width="625" alt="image" src="https://github.com/user-attachments/assets/16fc70fa-f127-44cf-8e7c-87a49a554345" />


This issue is not present in `torch==2.5.1`. Also, since the dependencies in [pyproject.toml](https://github.com/securefederatedai/openfl/compare/develop...revert-1588-FTU?expand=1#diff-51b39a499c304e7fa00929d54b0e1aa975dda313c26427016bd969a767ab0275) are generally dictated by Flower, we might want to consider holding off on version bumps until Flower bumps them

@tanwarsh @rahulga1 If this PR is required for security checks, I can just document the issue and resolution instead. Let me know