### PR TITLE
Do not install torch along with the basic workflow interface requirements

### DIFF
--- a/openfl-tutorials/experimental/workflow/FederatedEvaluation/workspace/MNIST_FederatedEvaluation.ipynb
+++ b/openfl-tutorials/experimental/workflow/FederatedEvaluation/workspace/MNIST_FederatedEvaluation.ipynb
@@ -37,7 +37,21 @@
    "id": "94d98490",
    "metadata": {},
    "source": [
-    "First we start by installing the necessary dependencies for the workflow interface as per [installation guide](https://openfl.readthedocs.io/en/latest/installation.html)"
+    "First we start by installing OpenFL as per [installation guide](https://openfl.readthedocs.io/en/latest/installation.html).\n",
+    "\n",
+    "The next step is to install the Workflow API dependencies, and PyTorch for the ML part."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "47734ca5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -r ../../workflow_interface_requirements.txt\n",
+    "!pip install torch==2.7.0\n",
+    "!pip install torchvision==0.22.0"
    ]
   },
   {

--- a/openfl-tutorials/experimental/workflow/workflow_interface_requirements.txt
+++ b/openfl-tutorials/experimental/workflow/workflow_interface_requirements.txt
@@ -7,5 +7,3 @@ nbdev==2.3.37
 nbformat==5.10.4
 ray==2.43.0
 tabulate==0.9.0
-torch==2.7.0
-torchvision==0.22.0


### PR DESCRIPTION
## Summary
Removing torch dependency from `workflow_interface_requirements.txt`.

## Type of Change (Mandatory)
- Bug fix  

## Description (Mandatory)
Only core framework requirements should be installed with `workflow_interface_requirements.txt`. Specific ML framework packages should be managed on a per-notebook/example level.

I additionally inserted a code block in the `MNIST_FederatedEvaluation` notebook to install PyTorch (modernized to the latest 2.7.0).

## Testing
- [x] Tested `MNIST_FederatedEvaluation` with LocalRuntime
- [x] Checked that all other PyTorch-based notebooks install `torch` themselves.
- [x] CI (incl. `workflow_interface` label to trigger all available Workflow API tests)