### PR TITLE
Fix FedEval Workflow API notebook with correct dependencies

### DIFF
--- a/openfl-tutorials/experimental/workflow/FederatedEvaluation/workspace/MNIST_FederatedEvaluation.ipynb
+++ b/openfl-tutorials/experimental/workflow/FederatedEvaluation/workspace/MNIST_FederatedEvaluation.ipynb
@@ -50,8 +50,9 @@
    "outputs": [],
    "source": [
     "!pip install -r ../../workflow_interface_requirements.txt\n",
-    "!pip install torch==2.7.0\n",
-    "!pip install torchvision==0.22.0"
+    "# Uncomment this section if running in Google Colab\n",
+    "#!pip install -r https://raw.githubusercontent.com/securefederatedai/openfl/refs/heads/develop/openfl-tutorials/experimental/workflow/workflow_interface_requirements.txt\n",
+    "!pip install torch==2.7.0 torchvision==0.22.0"
    ]
   },
   {


### PR DESCRIPTION
## Summary
Fixes failing FeEval workflow notebook for Local runtime (simulation run)

## Type of Change (Mandatory)
Install required deps in the notebook first step
## Description (Mandatory)
Notebook fails to run erring missing deps like - ray, metaflow, nbdev