### PR TITLE
Fix histology image shape

### DIFF
--- a/openfl-workspace/torch/histology/src/dataloader.py
+++ b/openfl-workspace/torch/histology/src/dataloader.py
@@ -187,7 +187,7 @@ def load_histology_shard(shard_num, collaborator_count, feature_shape=None, num_
         numpy.ndarray: The validation data
         numpy.ndarray: The validation labels
     """
-    img_rows, img_cols = feature_shape[0], feature_shape[1]
+    img_rows, img_cols = feature_shape[1], feature_shape[2]
 
     (X_train, y_train), (X_valid, y_valid) = _load_raw_datashards(
         shard_num, collaborator_count)

--- a/openfl-workspace/torch/histology_fedcurv/src/dataloader.py
+++ b/openfl-workspace/torch/histology_fedcurv/src/dataloader.py
@@ -174,7 +174,7 @@ def load_histology_shard(shard_num, collaborator_count, feature_shape=None, num_
         numpy.ndarray: The validation data
         numpy.ndarray: The validation labels
     """
-    img_rows, img_cols = feature_shape[0], feature_shape[1]
+    img_rows, img_cols = feature_shape[1], feature_shape[2]
 
     (X_train, y_train), (X_valid, y_valid) = _load_raw_datashards(
         shard_num, collaborator_count)


### PR DESCRIPTION
**Summary**

#1590 replaced hardcoded values `150, 150` to those of `feature shape[0], feature_shape[1]`, which translate to `3, 150` when `feature_shape = [3, 150, 150]`.

This PR corrects it to be `feature_shape[1], feature_shape[2]`. Issue went unnoticed because no CI test covers histology workspace