### PR TITLE
Documentation for verifiable datasets and data sources

### DIFF
--- a/docs/developer_guide/utilities.rst
+++ b/docs/developer_guide/utilities.rst
@@ -9,6 +9,9 @@ The following are utilities available in Open Federated Learning (OpenFL).
 :doc:`utilities/splitters_data`
     Split your data to run your federation from a single dataset.
 
+:doc:`utilities/verifiable_datasets`
+    Build and verify datasets composed of multiple data sources.
+
 :doc:`utilities/timeouts`
     Decorate methods to enforce timeout on it's execution.
 
@@ -18,4 +21,6 @@ The following are utilities available in Open Federated Learning (OpenFL).
 
    utilities/pki
    utilities/splitters_data
+   utilities/verifiable_datasets
    utilities/timeouts
+   

--- a/docs/developer_guide/utilities.rst
+++ b/docs/developer_guide/utilities.rst
@@ -6,11 +6,11 @@ The following are utilities available in Open Federated Learning (OpenFL).
 :doc:`utilities/pki`
     Use the Public Key Infrastructure (PKI) solution workflows to certify the nodes in your federation.
     
-:doc:`utilities/splitters_data`
-    Split your data to run your federation from a single dataset.
-
 :doc:`utilities/verifiable_datasets`
     Build and verify datasets composed of multiple data sources.
+
+:doc:`utilities/splitters_data`
+    Split your data to run your federation from a single dataset.
 
 :doc:`utilities/timeouts`
     Decorate methods to enforce timeout on it's execution.
@@ -20,7 +20,7 @@ The following are utilities available in Open Federated Learning (OpenFL).
    :hidden:
 
    utilities/pki
-   utilities/splitters_data
    utilities/verifiable_datasets
+   utilities/splitters_data
    utilities/timeouts
    

--- a/docs/developer_guide/utilities/verifiable_datasets.rst
+++ b/docs/developer_guide/utilities/verifiable_datasets.rst
@@ -7,8 +7,6 @@ Verifiable Datasets and Data Sources
 
 .. _verifiable_datasets_overview:
 
-Overview
-
 To accommodate for the proliferation of data sources and the need for trusted datasets, OpenFL provides a hierarchy of utility classes to build and verify datasets. 
 This includes an extensible class hierarchy that enables the creation of datasets from various data sources, such as local file system, object storage and others.
 

--- a/docs/developer_guide/utilities/verifiable_datasets.rst
+++ b/docs/developer_guide/utilities/verifiable_datasets.rst
@@ -1,0 +1,38 @@
+.. # Copyright (C) 2025 Intel Corporation
+.. # SPDX-License-Identifier: Apache-2.0
+
+*************************************
+Verifiable Datasets and Data Sources
+*************************************
+
+.. _verifiable_datasets_overview:
+
+Overview
+
+To accommodate for the proliferation of data sources and the need for trusted datasets, OpenFL provides a hierarchy of utility classes to build and verify datasets. 
+This includes an extensible class hierarchy that enables the creation of datasets from various data sources, such as local file system, object storage and others.
+
+The central abstraction is the :code:`VerifiableDatasetInfo` class that encapsulates the dataset's metadata and provides a method for verifying the integrity of the dataset.
+A dataset can be built from multiple data sources (not necessarily from the same type):
+
+.. mermaid:: ../../mermaid/verifiable_dataset_info.mmd
+    :caption: Verifiable Dataset with Multiple Data Sources
+    :align: center
+
+The :code:`VerifiableDatasetInfo` class can then be used to create higher-order dataset classes that enable iterating through multiple data sources, while verifying integrity if required.
+The :code:`root_hash` is used as a reference for integrity when loading items from the the data sources in the :code:`VerifiableDatasetInfo` object.
+
+OpenFL comes with a toolbox of dataset layout classes per ML framework. For PyTorch's :code:`torch.utils.data.Dataset` OpenFL curently provides: 
+- :code:`FolderDataset` - represents an iterable folder-layout dataset from a single data source, by implementing the :code:`__getitem__` method.
+- :code:`ImageFolder` - a specialization of the :code:`FolderDataset` that is able to load binary images from a foler-like structure
+- :code:`VerifiableMapStyleDataset` - a base class for map-style datasets that can be built from multiple data sources (as specified by a :code:`VerifiableDatasetInfo` object), including integrity checks.
+- :code:`VerifiableImageFolder` - a specialization of the :code:`VerifiableMapStyleDataset` encapsulating a collection of :code:`ImageFolder` datasets
+
+Note that the all those classes (directly or indirectly) extend :code:`torch.utils.data.DataLoader`, and are therefore compatible with all PyTorch utilities for pre-processing data sets.
+A similar class hierarchy can be created for other ML frameworks that offer dataset utilities, such as TensorFlow.
+
+.. mermaid:: ../../mermaid/verifiable_image_folder.mmd
+    :caption: Dataset hierarchy
+    :align: center
+
+A practical example for the :code:`VerifiableImageFolder` backed by a mix of :code:`LocalDataSource` and :code:`S3DataSource` objects is provided in the `s3_histology <https://github.com/securefederatedai/openfl/tree/develop/openfl-workspace/torch/histology_s3>`_ workspace template.

--- a/docs/mermaid/verifiable_dataset_info.mmd
+++ b/docs/mermaid/verifiable_dataset_info.mmd
@@ -1,0 +1,47 @@
+classDiagram
+    class VerifiableDatasetInfo {
+        +str label
+        +DataSource[] data_sources
+        +dict[str, str] metadata
+        +HASH root_hash
+
+        +verify_dataset(root_hash: HASH)
+        +verify_single_file(file_path: str, file_hash: HASH)
+        +to_json() str
+        +from_json(json_str: str) VerifiableDatasetInfo
+    }
+
+    class DataSource {
+        <<abstract>>
+        +str name
+        +DataSourceType type
+        +compute_file_hash(path: str) str
+        +enumerate_files() Generator~str~
+        +read_blob(path: str) bytes
+        +from_dict(ds_dict: dict) DataSource
+        +is_valid_hash_function(func) bool
+        +to_dict() dict
+    }
+
+    class LocalDataSource {
+        +str base_path
+        ...
+    }
+
+    class S3DataSource {
+        +str uri
+        +str endpoint
+        ...
+    }
+
+    class AzureBlobDataSource {
+        +str name
+        +str container_string
+        +str folder_prefix
+        ...
+    }
+
+    VerifiableDatasetInfo "1" o-- "*" DataSource
+    DataSource <|-- LocalDataSource
+    DataSource <|-- S3DataSource
+    DataSource <|-- AzureBlobDataSource

--- a/docs/mermaid/verifiable_dataset_info.mmd
+++ b/docs/mermaid/verifiable_dataset_info.mmd
@@ -48,3 +48,9 @@ classDiagram
     DataSource <|-- LocalDataSource
     DataSource <|-- S3DataSource
     DataSource <|-- AzureBlobDataSource
+
+    style VerifiableDatasetInfo fill:#FFFFE0,stroke:#000,stroke-width:1px
+    style DataSource fill:#FFFFE0,stroke:#000,stroke-width:1px
+    style LocalDataSource fill:#FFFFE0,stroke:#000,stroke-width:1px
+    style S3DataSource fill:#FFFFE0,stroke:#000,stroke-width:1px
+    style AzureBlobDataSource fill:#FFFFE0,stroke:#000,stroke-width:1px

--- a/docs/mermaid/verifiable_dataset_info.mmd
+++ b/docs/mermaid/verifiable_dataset_info.mmd
@@ -3,10 +3,10 @@
 
 classDiagram
     class VerifiableDatasetInfo {
-        +str label
-        +DataSource[] data_sources
-        +dict[str, str] metadata
-        +HASH root_hash
+        +label: str
+        +data_sources: DataSource[] 
+        +metadata: dict[str, str] 
+        +root_hash: HASH 
 
         +verify_dataset(root_hash: HASH)
         +verify_single_file(file_path: str, file_hash: HASH)
@@ -16,8 +16,8 @@ classDiagram
 
     class DataSource {
         <<abstract>>
-        +str name
-        +DataSourceType type
+        +name: str 
+        +type: DataSourceType 
         +compute_file_hash(path: str) str
         +enumerate_files() Generator~str~
         +read_blob(path: str) bytes
@@ -27,20 +27,20 @@ classDiagram
     }
 
     class LocalDataSource {
-        +str base_path
+        +base_path: str
         ...
     }
 
     class S3DataSource {
-        +str uri
-        +str endpoint
+        +uri: str 
+        +endpoint: str
         ...
     }
 
     class AzureBlobDataSource {
-        +str name
-        +str container_string
-        +str folder_prefix
+        +name: str 
+        +container_string: str 
+        +folder_prefix: str
         ...
     }
 

--- a/docs/mermaid/verifiable_dataset_info.mmd
+++ b/docs/mermaid/verifiable_dataset_info.mmd
@@ -1,3 +1,6 @@
+%% Copyright 2025 Intel Corporation
+%% SPDX-License-Identifier: Apache-2.0
+
 classDiagram
     class VerifiableDatasetInfo {
         +str label

--- a/docs/mermaid/verifiable_image_folder.mmd
+++ b/docs/mermaid/verifiable_image_folder.mmd
@@ -45,3 +45,6 @@ classDiagram
     VerifiableMapStyleDataset <|-- VerifiableImageFolder
     VerifiableMapStyleDataset o-- FolderDataset
     FolderDataset <|-- ImageFolder
+
+    style torch_utils_data_Dataset fill:#D3D3D3,stroke:#000,stroke-width:1px
+    style VerifiableDatasetInfo fill:#FFFFE0,stroke:#000,stroke-width:1px

--- a/docs/mermaid/verifiable_image_folder.mmd
+++ b/docs/mermaid/verifiable_image_folder.mmd
@@ -2,7 +2,7 @@
 %% SPDX-License-Identifier: Apache-2.0
 
 classDiagram
-    class torch.utils.data.Dataset {
+    class torch_utils_data_Dataset {
         +__len__() int
         +__getitem__(index: int) Any
     }
@@ -14,9 +14,10 @@ classDiagram
     }
 
     class VerifiableMapStyleDataset {
+        <<abstract>>
         +__len__() int
         +__getitem__(index: int) Any
-        +create_datasets() void <<abstract>>
+        +create_datasets() void*
     }
 
     class VerifiableImageFolder {
@@ -26,9 +27,10 @@ classDiagram
     }
 
     class FolderDataset {
+        <<abstract>>
         +__len__() int
         +__getitem__(index: int) Any
-        +load_file(file_path: str) void <<abstract>>
+        +load_file(file_path: str) void*
     }
 
     class ImageFolder {
@@ -37,8 +39,8 @@ classDiagram
         +load_file(file_path: str) void
     }
 
-    torch.utils.data.Dataset <|.. VerifiableMapStyleDataset
-    torch.utils.data.Dataset <|.. FolderDataset
+    torch_utils_data_Dataset <|.. VerifiableMapStyleDataset
+    torch_utils_data_Dataset <|.. FolderDataset
     VerifiableMapStyleDataset o-- VerifiableDatasetInfo
     VerifiableMapStyleDataset <|-- VerifiableImageFolder
     VerifiableMapStyleDataset o-- FolderDataset

--- a/docs/mermaid/verifiable_image_folder.mmd
+++ b/docs/mermaid/verifiable_image_folder.mmd
@@ -1,3 +1,6 @@
+%% Copyright 2025 Intel Corporation
+%% SPDX-License-Identifier: Apache-2.0
+
 classDiagram
     class torch.utils.data.Dataset {
         +__len__() int
@@ -40,4 +43,3 @@ classDiagram
     VerifiableMapStyleDataset <|-- VerifiableImageFolder
     VerifiableMapStyleDataset o-- FolderDataset
     FolderDataset <|-- ImageFolder
-    

--- a/docs/mermaid/verifiable_image_folder.mmd
+++ b/docs/mermaid/verifiable_image_folder.mmd
@@ -1,0 +1,43 @@
+classDiagram
+    class torch.utils.data.Dataset {
+        +__len__() int
+        +__getitem__(index: int) Any
+    }
+
+    class VerifiableDatasetInfo {
+        +verify_dataset(root_hash: HASH)
+        +verify_single_file(file_path: str, file_hash: HASH)
+        +from_json(json_str: str) VerifiableDatasetInfo
+    }
+
+    class VerifiableMapStyleDataset {
+        +__len__() int
+        +__getitem__(index: int) Any
+        +create_datasets() void <<abstract>>
+    }
+
+    class VerifiableImageFolder {
+        +__len__() int
+        +__getitem__(index: int) Any
+        +create_datasets() void
+    }
+
+    class FolderDataset {
+        +__len__() int
+        +__getitem__(index: int) Any
+        +load_file(file_path: str) void <<abstract>>
+    }
+
+    class ImageFolder {
+        +__len__() int
+        +__getitem__(index: int) Any
+        +load_file(file_path: str) void
+    }
+
+    torch.utils.data.Dataset <|.. VerifiableMapStyleDataset
+    torch.utils.data.Dataset <|.. FolderDataset
+    VerifiableMapStyleDataset o-- VerifiableDatasetInfo
+    VerifiableMapStyleDataset <|-- VerifiableImageFolder
+    VerifiableMapStyleDataset o-- FolderDataset
+    FolderDataset <|-- ImageFolder
+    

--- a/openfl-workspace/torch/histology_s3/README.md
+++ b/openfl-workspace/torch/histology_s3/README.md
@@ -6,25 +6,26 @@ It is important to note that the integrity verification is done based on a hash 
 ## Steps to run the experiment
 1. Set up a MinIO server which hosts the S3 data sources from the JSON descriptors
 2. Configure the credentials
-```shell
-export YOUR_ACCESS_KEY=<your_access_key>
-export YOUR_SECRET_KEY=<your_secret_key>
-```
-for example:
-```shell
-export MINIO_ROOT_PASSWORD=minioadmin
-export MINIO_ROOT_USER=minioadmin
-```
+    ```shell
+    export YOUR_ACCESS_KEY=<your_access_key>
+    export YOUR_SECRET_KEY=<your_secret_key>
+    ```
+
+    For example:
+    ```shell
+    export MINIO_ROOT_PASSWORD=minioadmin
+    export MINIO_ROOT_USER=minioadmin
+    ```
 3. Create a workspace folder from the `histology_s3` template
-```shell
-fx workspace create --prefix ~/hist_s3 --template torch/histology_s3
-cd ~/hist_s3/
-pip install -r requirements.txt
-```
+    ```shell
+    fx workspace create --prefix ~/hist_s3 --template torch/histology_s3
+    cd ~/hist_s3/
+    pip install -r requirements.txt
+    ```
 4. Optional: Calculate the dataset hashes for both collaborators.
 The hash will be saved at `<data_path>/hash.txt`. Later on, when the Federated Learning process starts, the data loader will check for this file and verify the dataset's integrity against the hash stored inside:
-```shell
-fx collaborator calchash --data_path plan/collaborator1
-fx collaborator calchash --data_path plan/collaborator2
-```
+    ```shell
+    fx collaborator calchash --data_path plan/collaborator1
+    fx collaborator calchash --data_path plan/collaborator2
+    ```
 5. For the rest of the steps, follow the [quickstart guide](https://openfl.readthedocs.io/en/latest/tutorials/taskrunner.html)

--- a/openfl-workspace/torch/histology_s3/README.md
+++ b/openfl-workspace/torch/histology_s3/README.md
@@ -1,0 +1,30 @@
+## Overview
+This workspace template showcases the use of `VerifiableImageFolder` among a federation of two collaborators with a diverse mix of data sources (`LocalDataSource` and `S3DataSource`). The data source JSON descriptors are located under `./data/collaborator1` and `./data/collaborator2`. In a distributed setup, those would be located on separate machines at each collaborator's premises, to make the entire experiment executable locally.
+
+It is important to note that the integrity verification is done based on a hash of each dataset that is calculated _prior_ to the experiment via the `fx collaborator calchash` command. Doing so provides protection against various data integrity attacks that could occur between the dataset preparation and the actual federated learning process.
+
+## Steps to run the experiment
+1. Set up a MinIO server which hosts the S3 data sources from the JSON descriptors
+2. Configure the credentials
+```shell
+export YOUR_ACCESS_KEY=<your_access_key>
+export YOUR_SECRET_KEY=<your_secret_key>
+```
+for example:
+```shell
+export MINIO_ROOT_PASSWORD=minioadmin
+export MINIO_ROOT_USER=minioadmin
+```
+3. Create a workspace folder from the `histology_s3` template
+```shell
+fx workspace create --prefix ~/hist_s3 --template torch/histology_s3
+cd ~/hist_s3/
+pip install -r requirements.txt
+```
+4. Optional: Calculate the dataset hashes for both collaborators.
+The hash will be saved at `<data_path>/hash.txt`. Later on, when the Federated Learning process starts, the data loader will check for this file and verify the dataset's integrity against the hash stored inside:
+```shell
+fx collaborator calchash --data_path plan/collaborator1
+fx collaborator calchash --data_path plan/collaborator2
+```
+5. For the rest of the steps, follow the [quickstart guide](https://openfl.readthedocs.io/en/latest/tutorials/taskrunner.html)


### PR DESCRIPTION
## Summary
Added user manual documentation and a README.md for the `histology_s3` workspace template.

## Type of Change (Mandatory)
- Documentation update  

## Description (Mandatory)
The goal of this PR is to provide OpenFL users with sufficient information to build and extend the newly introduced verifiable datasets and data sources framework of classes and utilities. This also includes UML class diagrams and explanations.

## Testing
Locally rendered the documentation website:

![image](https://github.com/user-attachments/assets/f65057af-b6b3-4e30-a8df-b78cab644456)
![image](https://github.com/user-attachments/assets/9e56b9e8-808d-4df3-87f0-ed23fce4e439)
![image](https://github.com/user-attachments/assets/e12e6aec-df20-45fe-a393-149f47d2b2c3)
