### PR TITLE
Indentation and other minor fixes in verifiable_datasets.rst

### DIFF
--- a/docs/developer_guide/utilities/verifiable_datasets.rst
+++ b/docs/developer_guide/utilities/verifiable_datasets.rst
@@ -11,7 +11,7 @@ To accommodate for the proliferation of data sources and the need for trusted da
 This includes an extensible class hierarchy that enables the creation of datasets from various data sources, such as local file system, object storage and others.
 
 The central abstraction is the :code:`VerifiableDatasetInfo` class that encapsulates the dataset's metadata and provides a method for verifying the integrity of the dataset.
-A dataset can be built from multiple data sources (not necessarily from the same type):
+A dataset can be built from multiple data sources (not necessarily of the same type):
 
 .. mermaid:: ../../mermaid/verifiable_dataset_info.mmd
     :caption: Verifiable Dataset with Multiple Data Sources
@@ -21,6 +21,7 @@ The :code:`VerifiableDatasetInfo` class can then be used to create higher-order 
 The :code:`root_hash` is used as a reference for integrity when loading items from the the data sources in the :code:`VerifiableDatasetInfo` object.
 
 OpenFL comes with a toolbox of dataset layout classes per ML framework. For PyTorch's :code:`torch.utils.data.Dataset` OpenFL curently provides: 
+
 - :code:`FolderDataset` - represents an iterable folder-layout dataset from a single data source, by implementing the :code:`__getitem__` method.
 - :code:`ImageFolder` - a specialization of the :code:`FolderDataset` that is able to load binary images from a foler-like structure
 - :code:`VerifiableMapStyleDataset` - a base class for map-style datasets that can be built from multiple data sources (as specified by a :code:`VerifiableDatasetInfo` object), including integrity checks.
@@ -33,4 +34,4 @@ A similar class hierarchy can be created for other ML frameworks that offer data
     :caption: Dataset hierarchy
     :align: center
 
-A practical example for the :code:`VerifiableImageFolder` backed by a mix of :code:`LocalDataSource` and :code:`S3DataSource` objects is provided in the `s3_histology <https://github.com/securefederatedai/openfl/tree/develop/openfl-workspace/torch/histology_s3>`_ workspace template.
+A practical example for the :code:`VerifiableImageFolder` backed by :code:`S3DataSource` is provided in the `s3_histology <https://github.com/securefederatedai/openfl/tree/develop/openfl-workspace/torch/histology_s3>`_ workspace template.


### PR DESCRIPTION
## Summary
Minor fixes in the verifiable datasets documentation.

## Type of Change (Mandatory)
- Documentation update  

## Description (Mandatory)
The dataset class list didn't properly render as bullets. I've also fixed a couple of minor imprecisions in the text.

## Testing
Rendered the documentation website locally, and double-checked indentation:
![image](https://github.com/user-attachments/assets/5ea7c021-5c79-4efc-a27a-49ecad747ff8)
