### PR TITLE
Add function to deserialize the flower message for further introspection

### DIFF
--- a/openfl/transport/grpc/interop/flower/message_conversion.py
+++ b/openfl/transport/grpc/interop/flower/message_conversion.py
@@ -1,11 +1,13 @@
 # Copyright 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from flwr.proto import grpcadapter_pb2
-from openfl.protocols import aggregator_pb2
 import importlib
-from google.protobuf.message import DecodeError
 import logging
+
+from flwr.proto import grpcadapter_pb2
+from google.protobuf.message import DecodeError
+
+from openfl.protocols import aggregator_pb2
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +82,7 @@ def openfl_to_flower_message(openfl_message):
         flower_message.ParseFromString(openfl_message.message.npbytes)
         return flower_message
 
+
 def deserialize_flower_message(flower_message):
     """
     Deserialize the grpc_message_content of a Flower message using the module and class name
@@ -93,8 +96,8 @@ def deserialize_flower_message(flower_message):
     """
     # Access metadata directly
     metadata = flower_message.metadata
-    module_name = metadata.get('grpc-message-module')
-    qualname = metadata.get('grpc-message-qualname')
+    module_name = metadata.get("grpc-message-module")
+    qualname = metadata.get("grpc-message-qualname")
 
     # Import the module
     try:

--- a/openfl/transport/grpc/interop/flower/message_conversion.py
+++ b/openfl/transport/grpc/interop/flower/message_conversion.py
@@ -2,8 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from flwr.proto import grpcadapter_pb2
-
 from openfl.protocols import aggregator_pb2
+import importlib
+from google.protobuf.message import DecodeError
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def flower_to_openfl_message(flower_message, header=None, end_experiment=False):
@@ -28,6 +32,14 @@ def flower_to_openfl_message(flower_message, header=None, end_experiment=False):
         # If the input is already an OpenFL message, return it as-is
         return flower_message
     else:
+        # Check if the Flower message can be deserialized, log a warning if not
+        try:
+            deserialized_message = deserialize_flower_message(flower_message)
+            if deserialized_message is None:
+                logger.warning("Failed to introspect Flower message.")
+        except Exception as e:
+            logger.warning(f"Exception during Flower message introspection: {e}")
+
         # Create the OpenFL message
         openfl_message = aggregator_pb2.InteropMessage()
         # Set the MessageHeader fields based on the provided sender and receiver
@@ -67,3 +79,42 @@ def openfl_to_flower_message(openfl_message):
         flower_message = grpcadapter_pb2.MessageContainer()
         flower_message.ParseFromString(openfl_message.message.npbytes)
         return flower_message
+
+def deserialize_flower_message(flower_message):
+    """
+    Deserialize the grpc_message_content of a Flower message using the module and class name
+    specified in the metadata.
+
+    Args:
+        flower_message: The Flower message containing the metadata and binary content.
+
+    Returns:
+        The deserialized message object, or None if deserialization fails.
+    """
+    # Access metadata directly
+    metadata = flower_message.metadata
+    module_name = metadata.get('grpc-message-module')
+    qualname = metadata.get('grpc-message-qualname')
+
+    # Import the module
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError as e:
+        print(f"Failed to import module: {module_name}. Error: {e}")
+        return None
+
+    # Get the message class
+    try:
+        message_class = getattr(module, qualname)
+    except AttributeError as e:
+        print(f"Failed to get message class '{qualname}' from module '{module_name}'. Error: {e}")
+        return None
+
+    # Deserialize the content
+    try:
+        message = message_class.FromString(flower_message.grpc_message_content)
+    except DecodeError as e:
+        print(f"Failed to deserialize message content. Error: {e}")
+        return None
+
+    return message


### PR DESCRIPTION
## Summary

In the long term, we will want a mechanism that provides some control over the type of information that Flower is allowed to send across the network for security purposes.

In the short term, we introduce a mechanism to deserialize the flower message. If the flower message cannot be deserialized successfully, we will log a warning

## Type of Change (Mandatory)
Specify the type of change being made. 
- Feature enhancement  

## Description (Mandatory)
- introduce `deserialize_flower_message` function in `openfl/transport/grpc/interop/flower/message_conversion.py` to dynamically import the specified module and class from Flower message metadata, deserialize the message content, and return the deserialized object, logging errors if any step fails.
- when converting between a flower message to an openfl message (i.e. when the openfl interop component receives a message from the flower compoennt), first check if the Flower message can be deserialized and log a warning if not -> can potentially escalate into an error as we tighten the security (long term)

## Testing
Manual testing